### PR TITLE
feat(swift/PublicKey): Add all the remaining PK API sans signature verification

### DIFF
--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -245,6 +245,9 @@ enum HederaError hedera_private_key_from_bytes_der(const uint8_t *bytes,
 /**
  * Parse a Hedera private key from the passed string.
  *
+ * Optionally strips a `0x` prefix.
+ * See [`hedera_private_key_from_bytes`]
+ *
  * # Safety
  * - `s` must be a valid string
  * - `key` must be a valid for writes according to [*Rust* pointer rules].
@@ -473,23 +476,245 @@ enum HederaError hedera_private_key_legacy_derive(struct HederaPrivateKey *key,
 void hedera_private_key_free(struct HederaPrivateKey *key);
 
 /**
+ * Parse a `PublicKey` from a sequence of bytes.
+ *
+ * # Safety
+ * - `bytes` must be valid for reads of up to `bytes_size` bytes.
+ * - `key` must be a valid for writes according to [*Rust* pointer rules].
+ *
+ * # Errors
+ * - [`Error::KeyParse`] if `bytes` cannot be parsed into a `PublicKey`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_public_key_from_bytes(const uint8_t *bytes,
+                                              size_t bytes_size,
+                                              struct HederaPublicKey **key);
+
+/**
+ * Parse a `PublicKey` from a sequence of bytes.
+ *
+ * # Safety
+ * - `bytes` must be valid for reads of up to `bytes_size` bytes.
+ * - `key` must be a valid for writes according to [*Rust* pointer rules].
+ *
+ * # Errors
+ * - [`Error::KeyParse`] if `bytes` cannot be parsed into a ed25519 `PublicKey`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_public_key_from_bytes_ed25519(const uint8_t *bytes,
+                                                      size_t bytes_size,
+                                                      struct HederaPublicKey **key);
+
+/**
+ * Parse a `PublicKey` from a sequence of bytes.
+ *
+ * # Safety
+ * - `bytes` must be valid for reads of up to `bytes_size` bytes.
+ * - `key` must be a valid for writes according to [*Rust* pointer rules].
+ *
+ * # Errors
+ * - [`Error::KeyParse`] if `bytes` cannot be parsed into a ECDSA(secp256k1) `PublicKey`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_public_key_from_bytes_ecdsa(const uint8_t *bytes,
+                                                    size_t bytes_size,
+                                                    struct HederaPublicKey **key);
+
+/**
+ * Parse a `PublicKey` from a sequence of bytes.
+ *
+ * # Safety
+ * - `bytes` must be valid for reads of up to `bytes_size` bytes.
+ * - `key` must be a valid for writes according to [*Rust* pointer rules].
+ *
+ * # Errors
+ * - [`Error::KeyParse`] if `bytes` cannot be parsed into a `PublicKey`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_public_key_from_bytes_der(const uint8_t *bytes,
+                                                  size_t bytes_size,
+                                                  struct HederaPublicKey **key);
+
+/**
  * Parse a Hedera public key from the passed string.
+ *
+ * Optionally strips a `0x` prefix.
+ * See [`hedera_public_key_from_bytes`]
+ *
+ * # Safety
+ * - `s` must be a valid string
+ * - `key` must be a valid for writes according to [*Rust* pointer rules].
+ *
+ * # Errors
+ * - [`Error::KeyParse`] if `s` cannot be parsed into a `PublicKey`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 enum HederaError hedera_public_key_from_string(const char *s, struct HederaPublicKey **key);
 
 /**
- * Format a Hedera `PublicKey` as a string.
+ * Parse a `PublicKey` from a der encoded string.
+ *
+ * Optionally strips a `0x` prefix.
+ * See [`hedera_public_key_from_bytes_der`].
+ *
+ * # Safety
+ * - `s` must be a valid string
+ * - `key` must be a valid for writes according to [*Rust* pointer rules].
+ *
+ * # Errors
+ * - [`Error::KeyParse`] if `s` cannot be parsed into a `PublicKey`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_public_key_from_string_der(const char *s, struct HederaPublicKey **key);
+
+/**
+ * Parse a Ed25519 `PublicKey` from a string containing the raw key material.
+ *
+ * Optionally strips a `0x` prefix.
+ * See: [`hedera_public_key_from_bytes_ed25519`]
+ *
+ * # Safety
+ * - `s` must be a valid string
+ * - `key` must be a valid for writes according to [*Rust* pointer rules].
+ *
+ * # Errors
+ * - [`Error::KeyParse`] if `s` cannot be parsed into a ed25519 `PublicKey`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_public_key_from_string_ed25519(const char *s, struct HederaPublicKey **key);
+
+/**
+ * Parse a ECDSA(secp256k1) `PublicKey` from a string containing the raw key material.
+ *
+ * Optionally strips a `0x` prefix.
+ * See: [`hedera_public_key_from_bytes_ecdsa`]
+ *
+ * # Safety
+ * - `s` must be a valid string
+ * - `key` must be a valid for writes according to [*Rust* pointer rules].
+ *
+ * # Errors
+ * - [`Error::KeyParse`] if `s` cannot be parsed into a ECDSA(secp256k1) `PublicKey`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_public_key_from_string_ecdsa(const char *s, struct HederaPublicKey **key);
+
+/**
+ * Return `key`, serialized as der encoded bytes.
+ *
+ * Note: the returned `buf` must be freed via `hedera_bytes_free` in order to prevent a memory leak.
+ *
+ * # Safety
+ * - `key` must be valid for reads according to [*Rust* pointer rules]
+ * - `buf` must be valid for writes according to [*Rust* pointer rules]
+ * - the length of the returned buffer must not be modified.
+ * - the returned pointer must NOT be freed with `free`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+size_t hedera_public_key_to_bytes_der(struct HederaPublicKey *key, uint8_t **buf);
+
+/**
+ * Return `key`, serialized as bytes.
+ *
+ * Note: `buf` must be freed via `hedera_bytes_free` in order to prevent a memory leak.
+ *
+ * If this is an ed25519 public key, this is equivalent to [`hedera_public_key_to_bytes_raw`]
+ * If this is an ecdsa public key, this is equivalent to [`hedera_public_key_to_bytes_der`]
+ * # Safety
+ * - `key` must be valid for reads according to [*Rust* pointer rules]
+ * - `buf` must be valid for writes according to [*Rust* pointer rules]
+ * - the length of the returned buffer must not be modified.
+ * - the returned pointer must NOT be freed with `free`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+size_t hedera_public_key_to_bytes(struct HederaPublicKey *key, uint8_t **buf);
+
+/**
+ * Return `key`, serialized as bytes.
+ *
+ * Note: `buf` must be freed via `hedera_bytes_free` in order to prevent a memory leak.
+ *
+ * # Safety
+ * - `key` must be valid for reads according to [*Rust* pointer rules]
+ * - `buf` must be valid for writes according to [*Rust* pointer rules]
+ * - the length of the returned buffer must not be modified.
+ * - the returned pointer must NOT be freed with `free`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+size_t hedera_public_key_to_bytes_raw(struct HederaPublicKey *key, uint8_t **buf);
+
+/**
+ * Format a Hedera public key as a string.
  *
  * Note: the returned string must be freed via `hedera_string_free` in order to prevent a memory leak.
  *
  * # Safety
  * - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
  * - the length of the returned string must not be modified.
- * - the returned string must NOT be freed with `free`.
+ * - the returned pointer must NOT be freed with `free`.
  *
  * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 char *hedera_public_key_to_string(struct HederaPublicKey *key);
+
+/**
+ * Format a Hedera public key as a der encoded string.
+ *
+ * Note: the returned string must be freed via `hedera_string_free` in order to prevent a memory leak.
+ *
+ * # Safety
+ * - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
+ * - the length of the returned string must not be modified.
+ * - the returned pointer must NOT be freed with `free`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+char *hedera_public_key_to_string_der(struct HederaPublicKey *key);
+
+/**
+ * Format a Hedera public key as a string.
+ *
+ * Note: the returned string must be freed via `hedera_string_free` in order to prevent a memory leak.
+ *
+ * # Safety
+ * - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
+ * - the length of the returned string must not be modified.
+ * - the returned pointer must NOT be freed with `free`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+char *hedera_public_key_to_string_raw(struct HederaPublicKey *key);
+
+/**
+ * Returns `true` if `key` is an Ed25519 `PublicKey`.
+ *
+ * # Safety
+ * - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+bool hedera_public_key_is_ed25519(struct HederaPublicKey *key);
+
+/**
+ * Returns `true` if `key` is an ECDSA(secp256k1) `PublicKey`.
+ *
+ * # Safety
+ * - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+bool hedera_public_key_is_ecdsa(struct HederaPublicKey *key);
 
 /**
  * Releases memory associated with the public key.

--- a/sdk/rust/rust-toolchain
+++ b/sdk/rust/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2022-07-30"
-components = ["rust-src"]
+components = ["rust-src", "miri"]

--- a/sdk/rust/src/ffi/key/mod.rs
+++ b/sdk/rust/src/ffi/key/mod.rs
@@ -12,7 +12,7 @@ use crate::ffi::util::cstr_from_ptr;
 mod private;
 mod public;
 
-/// Parse a `PrivateKey` with the given function.
+/// Parse a `key` with the given function.
 ///
 /// Internal function to reduce boilerplate.
 ///

--- a/sdk/rust/src/ffi/key/private.rs
+++ b/sdk/rust/src/ffi/key/private.rs
@@ -153,6 +153,9 @@ pub unsafe extern "C" fn hedera_private_key_from_bytes_der(
 
 /// Parse a Hedera private key from the passed string.
 ///
+/// Optionally strips a `0x` prefix.
+/// See [`hedera_private_key_from_bytes`]
+/// 
 /// # Safety
 /// - `s` must be a valid string
 /// - `key` must be a valid for writes according to [*Rust* pointer rules].

--- a/sdk/rust/src/ffi/key/private/mod.rs
+++ b/sdk/rust/src/ffi/key/private/mod.rs
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn hedera_private_key_from_bytes_der(
 ///
 /// Optionally strips a `0x` prefix.
 /// See [`hedera_private_key_from_bytes`]
-/// 
+///
 /// # Safety
 /// - `s` must be a valid string
 /// - `key` must be a valid for writes according to [*Rust* pointer rules].

--- a/sdk/rust/src/ffi/key/public.rs
+++ b/sdk/rust/src/ffi/key/public.rs
@@ -22,47 +22,337 @@ use std::ffi::CString;
 use std::os::raw::c_char;
 use std::str::FromStr;
 
+use libc::size_t;
+
+use super::{
+    parse_bytes,
+    parse_str, to_bytes,
+};
 use crate::ffi::error::Error;
-use crate::ffi::util::cstr_from_ptr;
 use crate::PublicKey;
 
-/// Parse a Hedera public key from the passed string.
+/// Parse a `PublicKey` from a sequence of bytes.
+///
+/// # Safety
+/// - `bytes` must be valid for reads of up to `bytes_size` bytes.
+/// - `key` must be a valid for writes according to [*Rust* pointer rules].
+///
+/// # Errors
+/// - [`Error::KeyParse`] if `bytes` cannot be parsed into a `PublicKey`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[no_mangle]
-pub extern "C" fn hedera_public_key_from_string(
+pub unsafe extern "C" fn hedera_public_key_from_bytes(
+    bytes: *const u8,
+    bytes_size: size_t,
+    key: *mut *mut PublicKey,
+) -> Error {
+    // safety: invariants are passed through from the caller.
+    unsafe { parse_bytes(bytes, bytes_size, key, PublicKey::from_bytes) }
+}
+
+/// Parse a `PublicKey` from a sequence of bytes.
+///
+/// # Safety
+/// - `bytes` must be valid for reads of up to `bytes_size` bytes.
+/// - `key` must be a valid for writes according to [*Rust* pointer rules].
+///
+/// # Errors
+/// - [`Error::KeyParse`] if `bytes` cannot be parsed into a ed25519 `PublicKey`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_from_bytes_ed25519(
+    bytes: *const u8,
+    bytes_size: size_t,
+    key: *mut *mut PublicKey,
+) -> Error {
+    // safety: invariants are passed through from the caller.
+    unsafe { parse_bytes(bytes, bytes_size, key, PublicKey::from_bytes_ed25519) }
+}
+
+/// Parse a `PublicKey` from a sequence of bytes.
+///
+/// # Safety
+/// - `bytes` must be valid for reads of up to `bytes_size` bytes.
+/// - `key` must be a valid for writes according to [*Rust* pointer rules].
+///
+/// # Errors
+/// - [`Error::KeyParse`] if `bytes` cannot be parsed into a ECDSA(secp256k1) `PublicKey`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_from_bytes_ecdsa(
+    bytes: *const u8,
+    bytes_size: size_t,
+    key: *mut *mut PublicKey,
+) -> Error {
+    // safety: invariants are passed through from the caller.
+    unsafe { parse_bytes(bytes, bytes_size, key, PublicKey::from_bytes_ecdsa) }
+}
+
+/// Parse a `PublicKey` from a sequence of bytes.
+///
+/// # Safety
+/// - `bytes` must be valid for reads of up to `bytes_size` bytes.
+/// - `key` must be a valid for writes according to [*Rust* pointer rules].
+///
+/// # Errors
+/// - [`Error::KeyParse`] if `bytes` cannot be parsed into a `PublicKey`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_from_bytes_der(
+    bytes: *const u8,
+    bytes_size: size_t,
+    key: *mut *mut PublicKey,
+) -> Error {
+    // safety: invariants are passed through from the caller.
+    unsafe { parse_bytes(bytes, bytes_size, key, PublicKey::from_bytes_der) }
+}
+
+/// Parse a Hedera public key from the passed string.
+/// 
+/// Optionally strips a `0x` prefix.
+/// See [`hedera_public_key_from_bytes`]
+/// 
+/// # Safety
+/// - `s` must be a valid string
+/// - `key` must be a valid for writes according to [*Rust* pointer rules].
+///
+/// # Errors
+/// - [`Error::KeyParse`] if `s` cannot be parsed into a `PublicKey`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_from_string(
     s: *const c_char,
     key: *mut *mut PublicKey,
 ) -> Error {
-    assert!(!key.is_null());
-
-    let s = unsafe { cstr_from_ptr(s) };
-    let parsed = ffi_try!(PublicKey::from_str(&s));
-
-    unsafe {
-        *key = Box::into_raw(Box::new(parsed));
-    }
-
-    Error::Ok
+    // safety: invariants are passed through from the caller.
+    unsafe { parse_str(s, key, PublicKey::from_str) }
 }
 
-/// Format a Hedera `PublicKey` as a string.
+/// Parse a `PublicKey` from a der encoded string.
+///
+/// Optionally strips a `0x` prefix.
+/// See [`hedera_public_key_from_bytes_der`].
+///
+/// # Safety
+/// - `s` must be a valid string
+/// - `key` must be a valid for writes according to [*Rust* pointer rules].
+///
+/// # Errors
+/// - [`Error::KeyParse`] if `s` cannot be parsed into a `PublicKey`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_from_string_der(
+    s: *const c_char,
+    key: *mut *mut PublicKey,
+) -> Error {
+    // safety: invariants are passed through from the caller.
+    unsafe { parse_str(s, key, PublicKey::from_str_der) }
+}
+
+/// Parse a Ed25519 `PublicKey` from a string containing the raw key material.
+///
+/// Optionally strips a `0x` prefix.
+/// See: [`hedera_public_key_from_bytes_ed25519`]
+///
+/// # Safety
+/// - `s` must be a valid string
+/// - `key` must be a valid for writes according to [*Rust* pointer rules].
+///
+/// # Errors
+/// - [`Error::KeyParse`] if `s` cannot be parsed into a ed25519 `PublicKey`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_from_string_ed25519(
+    s: *const c_char,
+    key: *mut *mut PublicKey,
+) -> Error {
+    // safety: invariants are passed through from the caller.
+    unsafe { parse_str(s, key, PublicKey::from_str_ed25519) }
+}
+
+/// Parse a ECDSA(secp256k1) `PublicKey` from a string containing the raw key material.
+///
+/// Optionally strips a `0x` prefix.
+/// See: [`hedera_public_key_from_bytes_ecdsa`]
+///
+/// # Safety
+/// - `s` must be a valid string
+/// - `key` must be a valid for writes according to [*Rust* pointer rules].
+///
+/// # Errors
+/// - [`Error::KeyParse`] if `s` cannot be parsed into a ECDSA(secp256k1) `PublicKey`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_from_string_ecdsa(
+    s: *const c_char,
+    key: *mut *mut PublicKey,
+) -> Error {
+    // safety: invariants are passed through from the caller.
+    unsafe { parse_str(s, key, PublicKey::from_str_ecdsa) }
+}
+
+/// Return `key`, serialized as der encoded bytes.
+///
+/// Note: the returned `buf` must be freed via `hedera_bytes_free` in order to prevent a memory leak.
+///
+/// # Safety
+/// - `key` must be valid for reads according to [*Rust* pointer rules]
+/// - `buf` must be valid for writes according to [*Rust* pointer rules]
+/// - the length of the returned buffer must not be modified.
+/// - the returned pointer must NOT be freed with `free`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_to_bytes_der(
+    key: *mut PublicKey,
+    buf: *mut *mut u8,
+) -> size_t {
+    // safety: invariants are passed through from the caller.
+    unsafe { to_bytes(key, buf, PublicKey::to_bytes_der) }
+}
+
+/// Return `key`, serialized as bytes.
+///
+/// Note: `buf` must be freed via `hedera_bytes_free` in order to prevent a memory leak.
+///
+/// If this is an ed25519 public key, this is equivalent to [`hedera_public_key_to_bytes_raw`]
+/// If this is an ecdsa public key, this is equivalent to [`hedera_public_key_to_bytes_der`]
+/// # Safety
+/// - `key` must be valid for reads according to [*Rust* pointer rules]
+/// - `buf` must be valid for writes according to [*Rust* pointer rules]
+/// - the length of the returned buffer must not be modified.
+/// - the returned pointer must NOT be freed with `free`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_to_bytes(
+    key: *mut PublicKey,
+    buf: *mut *mut u8,
+) -> size_t {
+    // safety: invariants are passed through from the caller.
+    unsafe { to_bytes(key, buf, PublicKey::to_bytes) }
+}
+
+/// Return `key`, serialized as bytes.
+///
+/// Note: `buf` must be freed via `hedera_bytes_free` in order to prevent a memory leak.
+///
+/// # Safety
+/// - `key` must be valid for reads according to [*Rust* pointer rules]
+/// - `buf` must be valid for writes according to [*Rust* pointer rules]
+/// - the length of the returned buffer must not be modified.
+/// - the returned pointer must NOT be freed with `free`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_to_bytes_raw(
+    key: *mut PublicKey,
+    buf: *mut *mut u8,
+) -> size_t {
+    // safety: invariants are passed through from the caller.
+    unsafe { to_bytes(key, buf, PublicKey::to_bytes_raw) }
+}
+
+/// Format a Hedera public key as a string.
 ///
 /// Note: the returned string must be freed via `hedera_string_free` in order to prevent a memory leak.
 ///
 /// # Safety
 /// - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
 /// - the length of the returned string must not be modified.
-/// - the returned string must NOT be freed with `free`.
+/// - the returned pointer must NOT be freed with `free`.
 ///
 /// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
 #[no_mangle]
-pub extern "C" fn hedera_public_key_to_string(key: *mut PublicKey) -> *mut c_char {
-    assert!(!key.is_null());
+pub unsafe extern "C" fn hedera_public_key_to_string(key: *mut PublicKey) -> *mut c_char {
+    // potential optimization: `PublicKey::to_string` just calls `PublicKey::to_string_der`,
+    // so, this function *could* just call `hedera_public_key_to_string_der`
+    // safety: caller promises that `key` must be valid for reads
+    let key = unsafe { key.as_ref().unwrap() };
 
-    let key = unsafe { &*key };
-
-    // if this unwrap fails `PublicKey`'s display impl has a bug,
+    // if this unwrap fails the called method's impl has a bug,
     // because hex-encoded anything doesn't contain `\0`.
     CString::new(key.to_string()).unwrap().into_raw()
+}
+
+/// Format a Hedera public key as a der encoded string.
+///
+/// Note: the returned string must be freed via `hedera_string_free` in order to prevent a memory leak.
+///
+/// # Safety
+/// - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
+/// - the length of the returned string must not be modified.
+/// - the returned pointer must NOT be freed with `free`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_to_string_der(key: *mut PublicKey) -> *mut c_char {
+    // safety: caller promises that `key` must be valid for reads
+    let key = unsafe { key.as_ref().unwrap() };
+
+    // if this unwrap fails the called method's impl has a bug,
+    // because hex-encoded anything doesn't contain `\0`.
+    CString::new(key.to_string_der()).unwrap().into_raw()
+}
+
+/// Format a Hedera public key as a string.
+///
+/// Note: the returned string must be freed via `hedera_string_free` in order to prevent a memory leak.
+///
+/// # Safety
+/// - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
+/// - the length of the returned string must not be modified.
+/// - the returned pointer must NOT be freed with `free`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_to_string_raw(key: *mut PublicKey) -> *mut c_char {
+    // safety: caller promises that `key` must be valid for reads
+    let key = unsafe { key.as_ref().unwrap() };
+
+    // if this unwrap fails the called method's impl has a bug,
+    // because hex-encoded anything doesn't contain `\0`.
+    CString::new(key.to_string_raw()).unwrap().into_raw()
+}
+
+// ffi note: `bool` is defined to have the same layout as c17's `_Bool`.
+// see: https://rust-lang.github.io/unsafe-code-guidelines/layout/scalars.html#bool
+// the wording is a little confusing because it says "which is implementation defined"
+// but it means that Rust `bool` == c17 `bool` == "something"
+/// Returns `true` if `key` is an Ed25519 `PublicKey`.
+///
+/// # Safety
+/// - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_is_ed25519(key: *mut PublicKey) -> bool {
+    // safety: caller promises that `key` must be valid for reads
+    let key = unsafe { key.as_ref().unwrap() };
+
+    key.is_ed25519()
+}
+
+/// Returns `true` if `key` is an ECDSA(secp256k1) `PublicKey`.
+///
+/// # Safety
+/// - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_is_ecdsa(key: *mut PublicKey) -> bool {
+    // safety: caller promises that `key` must be valid for reads
+    let key = unsafe { key.as_ref().unwrap() };
+
+    key.is_ecdsa()
 }
 
 /// Releases memory associated with the public key.

--- a/sdk/rust/src/ffi/key/public/mod.rs
+++ b/sdk/rust/src/ffi/key/public/mod.rs
@@ -26,10 +26,14 @@ use libc::size_t;
 
 use super::{
     parse_bytes,
-    parse_str, to_bytes,
+    parse_str,
+    to_bytes,
 };
 use crate::ffi::error::Error;
 use crate::PublicKey;
+
+#[cfg(test)]
+mod tests;
 
 /// Parse a `PublicKey` from a sequence of bytes.
 ///
@@ -112,10 +116,10 @@ pub unsafe extern "C" fn hedera_public_key_from_bytes_der(
 }
 
 /// Parse a Hedera public key from the passed string.
-/// 
+///
 /// Optionally strips a `0x` prefix.
 /// See [`hedera_public_key_from_bytes`]
-/// 
+///
 /// # Safety
 /// - `s` must be a valid string
 /// - `key` must be a valid for writes according to [*Rust* pointer rules].

--- a/sdk/rust/src/ffi/key/public/tests.rs
+++ b/sdk/rust/src/ffi/key/public/tests.rs
@@ -1,0 +1,90 @@
+/*
+ * ‌
+ * Hedera Rust SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+use std::ffi::{
+    CStr,
+    CString,
+};
+use std::ptr::{
+    self,
+    addr_of_mut,
+};
+use std::str::FromStr;
+
+use assert_matches::assert_matches;
+use expect_test::expect;
+
+use crate::ffi::c_util::hedera_string_free;
+use crate::ffi::error::Error;
+use crate::ffi::key::public::{
+    hedera_public_key_free,
+    hedera_public_key_from_string,
+    hedera_public_key_to_string,
+};
+use crate::{
+    PublicKey,
+    Signature,
+};
+
+#[test]
+fn ed25519_from_str() {
+    const PK: &str =
+        "302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a0dd828f94d37988a4b7";
+
+    let pk_str = CString::new(PK).unwrap();
+
+    let s = {
+        let pk = {
+            let mut pk = ptr::null_mut();
+            // safety: the passed string is valid for reads during this function,
+            // safety: the passed key is valid for writes (not reads)
+            let error = unsafe { hedera_public_key_from_string(pk_str.as_ptr(), addr_of_mut!(pk)) };
+            assert_eq!(error, Error::Ok);
+            // safety: pk is now initialized.
+            pk
+        };
+
+        // note (not a safety concern): This block *can* leak if it panics. it *won't*, because we produce utf8, but if we ever stop using utf8 in 5 decades, and we run out of memory on failing tests, this is where to look.
+        let s = {
+            // safety: PK is valid for reads (proven via)
+            let ptr = unsafe { hedera_public_key_to_string(pk) };
+            // safety: this CStr is lifetime bounded to `ptr`, so we ensure it lives shorter by putting it in a block
+            let s = {
+                // safety:
+                // `hedera_public_key_to_string` returns a C String (notice the space), and promises it has a null terminator (C Strings end with one)
+                // `hedera_public_key_to_string` promises that its ptr is valid for reads through the null terminator until `hedera_string_free` is called, and we won't call it until after this block.
+                let s = unsafe { CStr::from_ptr(ptr) };
+                s.to_str().unwrap().to_owned()
+            };
+
+            // safety: we haven't called this method on `ptr` yet, `ptr` has been initialized by `hedera_public_key_to_string` which is a method that allows this to be called on the resultb.
+            unsafe { hedera_string_free(ptr) };
+            s
+        };
+
+        // safety: we haven't called this method on `pk` yet, `pk` has been initialized `hedera_public_key_from_string`, which is a method that allows this to be called on the result.
+        unsafe { hedera_public_key_free(pk) };
+        s
+    };
+
+    assert_eq!(PK, s)
+}
+
+// todo: The rest of these tests (it's a lot of work )

--- a/sdk/rust/src/key/public_key/mod.rs
+++ b/sdk/rust/src/key/public_key/mod.rs
@@ -274,7 +274,7 @@ impl PublicKey {
 
     /// Return this `PublicKey`, serialized as bytes.
     #[must_use]
-    pub fn to_bytes_raw(self) -> Vec<u8> {
+    pub fn to_bytes_raw(&self) -> Vec<u8> {
         match &self.0 {
             PublicKeyData::Ed25519(key) => key.to_bytes().as_slice().to_vec(),
             PublicKeyData::Ecdsa(key) => key.to_bytes().as_slice().to_vec(),

--- a/sdk/rust/src/token/nft_id.rs
+++ b/sdk/rust/src/token/nft_id.rs
@@ -95,7 +95,9 @@ impl FromStr for NftId {
             return Err(Error::basic_parse("unexpected NftId format - expected [token_id]/[serial_number] or [token_id]@[serial_number]"));
         }
 
-        let serial = parts[1].parse().map_err(|_| Error::basic_parse("unexpected error - could not parse serial number"))?;
+        let serial = parts[1]
+            .parse()
+            .map_err(|_| Error::basic_parse("unexpected error - could not parse serial number"))?;
 
         Ok(Self { token_id: TokenId::from_str(parts[0])?, serial })
     }

--- a/sdk/rust/src/transfer_transaction.rs
+++ b/sdk/rust/src/transfer_transaction.rs
@@ -173,12 +173,8 @@ impl TransferTransaction {
         approved: bool,
     ) -> &mut Self {
         let NftId { token_id, serial } = nft_id;
-        let transfer = NftTransfer {
-            serial,
-            sender_account_id,
-            receiver_account_id,
-            is_approval: approved,
-        };
+        let transfer =
+            NftTransfer { serial, sender_account_id, receiver_account_id, is_approval: approved };
 
         if let Some(tt) =
             self.body.data.token_transfers.iter_mut().find(|tt| tt.token_id == token_id)

--- a/sdk/swift/Sources/Hedera/PublicKey.swift
+++ b/sdk/swift/Sources/Hedera/PublicKey.swift
@@ -19,6 +19,16 @@
  */
 
 import CHedera
+import Foundation
+
+// todo: deduplicate these with `PrivateKey.swift`
+private typealias UnsafeFromBytesFunc = @convention(c) (UnsafePointer<UInt8>?, Int, UnsafeMutablePointer<OpaquePointer?>?) -> HederaError
+
+// safety: `hedera_bytes_free` needs to be called so...
+// perf: might as well enable use of the no copy constructor.
+private let unsafeCHederaBytesFree: Data.Deallocator = .custom { (buf, size) in
+    hedera_bytes_free(buf, size)
+}
 
 /// A public key on the Hedera network.
 public final class PublicKey: LosslessStringConvertible, ExpressibleByStringLiteral, Codable {
@@ -26,6 +36,48 @@ public final class PublicKey: LosslessStringConvertible, ExpressibleByStringLite
 
     internal init(_ ptr: OpaquePointer) {
         self.ptr = ptr
+    }
+
+    private static func unsafeFromAnyBytes(_ bytes: Data, _ chederaCallback: UnsafeFromBytesFunc) throws -> Self {
+        let ptr = try bytes.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) in
+            var key = OpaquePointer(bitPattern: 0)
+            let err = chederaCallback(pointer.bindMemory(to: UInt8.self).baseAddress, pointer.count, &key)
+
+            if err != HEDERA_ERROR_OK {
+                throw HError(err)!
+            }
+
+            return key!
+        }
+
+        return Self(ptr)
+    }
+
+    public static func fromBytes(_ bytes: Data) throws -> Self {
+        try unsafeFromAnyBytes(bytes, hedera_public_key_from_bytes)
+    }
+
+    public static func fromBytesEd25519(_ bytes: Data) throws -> Self {
+        try unsafeFromAnyBytes(bytes, hedera_public_key_from_bytes_ed25519)
+    }
+
+    public static func fromBytesEcdsa(_ bytes: Data) throws -> Self {
+        try unsafeFromAnyBytes(bytes, hedera_public_key_from_bytes_ed25519)
+    }
+
+    public static func fromBytesDer(_ bytes: Data) throws -> Self {
+        try unsafeFromAnyBytes(bytes, hedera_public_key_from_bytes_ed25519)
+    }
+
+    public static func fromString(_ description: String) throws -> Self {
+        var key = OpaquePointer(bitPattern: 0)
+        let err = hedera_public_key_from_string(description, &key)
+
+        if err != HEDERA_ERROR_OK {
+            throw HError(err)!
+        }
+
+        return Self(key!)
     }
 
     public init?(_ description: String) {
@@ -43,26 +95,103 @@ public final class PublicKey: LosslessStringConvertible, ExpressibleByStringLite
         self.init(value)!
     }
 
+    public static func fromStringDer(_ description: String) throws -> Self {
+        var key = OpaquePointer(bitPattern: 0)
+        let err = hedera_public_key_from_string_der(description, &key)
+
+        if err != HEDERA_ERROR_OK {
+            throw HError(err)!
+        }
+
+        return Self(key!)
+    }
+
+    public static func fromStringEd25519(_ description: String) throws -> Self {
+        var key = OpaquePointer(bitPattern: 0)
+        let err = hedera_public_key_from_string_ed25519(description, &key)
+
+        if err != HEDERA_ERROR_OK {
+            throw HError(err)!
+        }
+
+        return Self(key!)
+    }
+
+    public static func fromStringEcdsa(_ description: String) throws -> Self {
+        var key = OpaquePointer(bitPattern: 0)
+        let err = hedera_public_key_from_string_ecdsa(description, &key)
+
+        if err != HEDERA_ERROR_OK {
+            throw HError(err)!
+        }
+
+        return Self(key!)
+    }
+
+
     public required convenience init(from decoder: Decoder) throws {
         self.init(try decoder.singleValueContainer().decode(String.self))!
     }
 
-    deinit {
-        hedera_public_key_free(ptr)
+    public func toBytesDer() -> Data {
+        var buf: UnsafeMutablePointer<UInt8>?
+        let size = hedera_public_key_to_bytes_der(ptr, &buf)
+
+        return Data(bytesNoCopy: buf!, count: size, deallocator: unsafeCHederaBytesFree)
+    }
+
+    public func toBytes() -> Data {
+        var buf: UnsafeMutablePointer<UInt8>?
+        let size = hedera_public_key_to_bytes(ptr, &buf)
+
+        return Data(bytesNoCopy: buf!, count: size, deallocator: unsafeCHederaBytesFree)
+    }
+
+    public func toBytesRaw() -> Data {
+        var buf: UnsafeMutablePointer<UInt8>?
+        let size = hedera_public_key_to_bytes_raw(ptr, &buf)
+
+        return Data(bytesNoCopy: buf!, count: size, deallocator: unsafeCHederaBytesFree)
     }
 
     public var description: String {
         let descriptionBytes = hedera_public_key_to_string(ptr)
-        return String.init(hString: descriptionBytes!)
+        return String(hString: descriptionBytes!)!
+    }
+
+    public func toString() -> String {
+        description
+    }
+
+    public func toStringDer() -> String {
+        let stringBytes = hedera_public_key_to_string_der(ptr)
+        return String(hString: stringBytes!)!
+    }
+
+    public func toStringRaw() -> String {
+        let stringBytes = hedera_public_key_to_string_raw(ptr)
+        return String(hString: stringBytes!)!
     }
 
     public func toAccountId(shard: UInt64, realm: UInt64) -> AccountId {
         AccountId.init(shard: shard, realm: realm, alias: self)
     }
 
+    public func isEd25519() -> Bool {
+        hedera_public_key_is_ed25519(ptr)
+    }
+
+    public func isEcdsa() -> Bool {
+        hedera_public_key_is_ecdsa(ptr)
+    }
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
 
         try container.encode(String(describing: self))
+    }
+
+    deinit {
+        hedera_public_key_free(ptr)
     }
 }

--- a/sdk/swift/Tests/HederaTests/PublicKeyTests.swift
+++ b/sdk/swift/Tests/HederaTests/PublicKeyTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import Hedera
+
+final class PublicKeyTests: XCTestCase {
+    func testParseEd25519() throws {
+        let pk: PublicKey = "302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a0dd828f94d37988a4b7"
+
+        XCTAssertEqual(pk.description, "302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a0dd828f94d37988a4b7")
+    }
+
+    func testParseEcdsa() throws {
+        let pk: PublicKey = "302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a0dd828f94d37988a4b7"
+
+        XCTAssertEqual(pk.description, "302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a0dd828f94d37988a4b7")
+    }
+
+    func pkParseVariants(key: String) throws {
+        for variant in 0..<4 {
+            let prefix = variant & 1 == 1;
+            let uppercase = (variant >> 1) & 1 == 1;
+            let prefixStr = prefix ? "0x" : "";
+            let keyCased = uppercase ? key.uppercased() : key.lowercased()
+            let pk = try PublicKey.fromString("\(prefixStr)\(keyCased)")
+
+            XCTAssertEqual(key, pk.description)
+        }
+    }
+
+    func testEd25519ParseVariants() throws {
+        try pkParseVariants(
+                key: "302a300506032b6570032100e0c8ec2758a5879ffac226a13c0c516b799e72e35141a0dd828f94d37988a4b7"
+        )
+    }
+
+    func testEcdsaParseVariants() throws {
+        try pkParseVariants(
+                key: "302f300906072a8648ce3d020103220002703a9370b0443be6ae7c507b0aec81a55e94e4a863b9655360bd65358caa6588"
+        )
+    }
+}


### PR DESCRIPTION
**Description**:
Still missing `verify`, `verifyTransaction`


**Related issue(s)**:
#247 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
