### PR TITLE
feat(swift): NftId `{to,from}_bytes`

### DIFF
--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -731,6 +731,25 @@ enum HederaError hedera_nft_id_from_string(const char *s,
                                            uint64_t *serial);
 
 /**
+ * Parse a Hedera `NftId` from the passed bytes.
+ */
+enum HederaError hedera_nft_id_from_bytes(const uint8_t *bytes,
+                                          size_t bytes_size,
+                                          uint64_t *token_id_shard,
+                                          uint64_t *token_id_realm,
+                                          uint64_t *token_id_num,
+                                          uint64_t *serial);
+
+/**
+ * Serialize the passed NftId as bytes
+ */
+size_t hedera_nft_id_to_bytes(uint64_t token_id_shard,
+                              uint64_t token_id_realm,
+                              uint64_t token_id_num,
+                              uint64_t serial,
+                              uint8_t **buf);
+
+/**
  * Subscribe with this request against the provided client of the Hedera network.
  * On successful completion, calls `callback` with `ERROR_OK` and a `NULL` `message`.
  */

--- a/sdk/rust/src/ffi/nft_id.rs
+++ b/sdk/rust/src/ffi/nft_id.rs
@@ -20,14 +20,23 @@
 
 use std::os::raw::c_char;
 use std::str::FromStr;
+use std::{
+    ptr,
+    slice,
+};
+
+use libc::size_t;
 
 use crate::ffi::error::Error;
 use crate::ffi::util::cstr_from_ptr;
-use crate::NftId;
+use crate::{
+    FromProtobuf,
+    NftId, TokenId, ToProtobuf,
+};
 
 /// Parse a Hedera `NftId` from the passed string.
 #[no_mangle]
-pub extern "C" fn hedera_nft_id_from_string(
+pub unsafe extern "C" fn hedera_nft_id_from_string(
     s: *const c_char,
     token_id_shard: *mut u64,
     token_id_realm: *mut u64,
@@ -43,11 +52,77 @@ pub extern "C" fn hedera_nft_id_from_string(
     let parsed = ffi_try!(NftId::from_str(&s));
 
     unsafe {
-        *token_id_shard = parsed.token_id.shard;
-        *token_id_realm = parsed.token_id.shard;
-        *token_id_num = parsed.token_id.num;
-        *serial = parsed.serial;
+        ptr::write(token_id_shard, parsed.token_id.shard);
+        ptr::write(token_id_realm, parsed.token_id.realm);
+        ptr::write(token_id_num, parsed.token_id.num);
+        ptr::write(serial, parsed.serial);
     }
 
     Error::Ok
+}
+
+/// Parse a Hedera `NftId` from the passed bytes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_nft_id_from_bytes(
+    bytes: *const u8,
+    bytes_size: size_t,
+    token_id_shard: *mut u64,
+    token_id_realm: *mut u64,
+    token_id_num: *mut u64,
+    serial: *mut u64,
+) -> Error {
+    assert!(!bytes.is_null());
+    assert!(!token_id_shard.is_null());
+    assert!(!token_id_realm.is_null());
+    assert!(!token_id_num.is_null());
+    assert!(!serial.is_null());
+
+    // safety: caller promises that `bytes` is valid for r/w of up to `bytes_size`, which is exactly what `slice::from_raw_parts` wants.
+    let bytes = unsafe { slice::from_raw_parts(bytes, bytes_size) };
+
+    let parsed = ffi_try!(NftId::from_bytes(bytes));
+
+    unsafe {
+        ptr::write(token_id_shard, parsed.token_id.shard);
+        ptr::write(token_id_realm, parsed.token_id.realm);
+        ptr::write(token_id_num, parsed.token_id.num);
+        ptr::write(serial, parsed.serial);
+    }
+
+    Error::Ok
+}
+
+/// Serialize the passed NftId as bytes
+#[no_mangle]
+pub unsafe extern "C" fn hedera_nft_id_to_bytes(
+    token_id_shard:  u64,
+    token_id_realm:  u64,
+    token_id_num:  u64,
+    serial: u64,
+    buf: *mut *mut u8
+) -> size_t {
+    // todo: use `as_maybe_uninit_ref` once that's stable.
+    assert!(!buf.is_null());
+
+    let nft_id = NftId {
+        token_id: TokenId {
+            shard: token_id_shard,
+            realm: token_id_realm,
+            num: token_id_num,
+        },
+        serial,
+    };
+
+    let bytes = nft_id.to_bytes().into_boxed_slice();
+
+    let bytes = Box::leak(bytes);
+    let len = bytes.len();
+    let bytes = bytes.as_mut_ptr();
+
+    // safety: invariants promise that `buf` must be valid for writes.
+    unsafe {
+        ptr::write(buf, bytes);
+    }
+
+    len
 }

--- a/sdk/rust/src/token/nft_id.rs
+++ b/sdk/rust/src/token/nft_id.rs
@@ -148,7 +148,7 @@ mod tests {
     }
 
     #[test]
-    fn it_can_parse_from_str() -> anyhow::Result<()> {
+    fn from_str() -> anyhow::Result<()> {
         // Test '/' format parsing
         let nft_id_slash_str = "0.0.123/456";
 

--- a/sdk/swift/Tests/HederaTests/NftIdTests.swift
+++ b/sdk/swift/Tests/HederaTests/NftIdTests.swift
@@ -1,0 +1,39 @@
+/*
+ * ‌
+ * Hedera Swift SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import XCTest
+@testable import Hedera
+
+private let parsedNftId = NftId(tokenId: TokenId(shard: 1415, realm: 314, num: 123), serial: 456)
+
+final class NftIdTests: XCTestCase {
+    func testParseSlashFormat() {
+
+        let actualNftId: NftId = "1415.314.123/456"
+
+        XCTAssertEqual(parsedNftId, actualNftId)
+    }
+
+    func testParseAtFormat() {
+        let actualNftId: NftId = "1415.314.123@456"
+
+        XCTAssertEqual(parsedNftId, actualNftId)
+    }
+}


### PR DESCRIPTION
**Description**:

- Add: `NftId.fromBytes(byte[] bytes)` as `static func NftId.fromBytes(_ bytes: Data) -> Self`
- Add: `byte[] NftId.toBytes()` as `static func NftId.toBytes() -> Data`
- Fix: Parsing an `NftId` from a string no longer duplicates the `token`'s `shard` into the `token`'s `realm`

**Related issue(s)**:
Closes #245 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
