### PR TITLE
feat(swift): add Mnemonic support

### DIFF
--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -42,6 +42,11 @@ typedef enum HederaError {
 typedef struct HederaClient HederaClient;
 
 /**
+ *  `BIP-39` 24-word mnemonic phrase compatible with the Android and iOS mobile wallets.
+ */
+typedef struct HederaMnemonic HederaMnemonic;
+
+/**
  * A private key on the Hedera network.
  */
 typedef struct HederaPrivateKey HederaPrivateKey;
@@ -471,6 +476,17 @@ enum HederaError hedera_private_key_legacy_derive(struct HederaPrivateKey *key,
                                                   struct HederaPrivateKey **derived);
 
 /**
+ * Recover a `PrivateKey` from a mnemonic phrase and a passphrase.
+ *
+ * # Safety
+ * - `mnemonic` must be valid for reads according to the [*Rust* pointer rules].
+ * - `passphrase` must be valid for reads up until and including the first NUL (`'\0'`) byte.
+ * - the retured `PrivateKey` must only be freed via [`hedera_private_key_free`], notably, this means that it *must not* be freed with `free`.
+ */
+struct HederaPrivateKey *hedera_private_key_from_mnemonic(struct HederaMnemonic *mnemonic,
+                                                          const char *passphrase);
+
+/**
  * Releases memory associated with the private key.
  */
 void hedera_private_key_free(struct HederaPrivateKey *key);
@@ -720,6 +736,122 @@ bool hedera_public_key_is_ecdsa(struct HederaPublicKey *key);
  * Releases memory associated with the public key.
  */
 void hedera_public_key_free(struct HederaPublicKey *key);
+
+/**
+ * Parse a `Mnemonic` from a string.
+ *
+ * # Safety
+ * - `s` must be valid for reads up until and including the first NUL (`'\0'`) byte.
+ * - `mnemonic` must be valid for writes according to the [*Rust* pointer rules]
+ * - if this method returns anything other than [`Error::Ok`],
+ *   then the contents of `mnemonic` are undefined and must not be used or inspected.
+ * - `mnemonic` must only be freed via [`hedera_mnemonic_free`].
+ *   Notably this means that it *must not* be freed with `free`.
+ *
+ * # Errors
+ * - [`Error::MnemonicParse`] if the mnemonic has an invalid length.
+ * - [`Error::MnemonicParse`] if the mnemonic uses invalid words.
+ * - [`Error::MnemonicParse`] if the mnemonic has an invalid checksum.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_mnemonic_from_string(const char *s, struct HederaMnemonic **mnemonic);
+
+/**
+ * Generate a new 24 word mnemonic.
+ *
+ * # Safety
+ * This function is safe. However, there are invariants that must be upheld on the result.
+ *
+ * - The returned mnemonic must only be freed via [`hedera_mnemonic_free`].
+ *   Notably this means that it *must not* be freed with `free`.
+ */
+struct HederaMnemonic *hedera_mnemonic_generate_24(void);
+
+/**
+ * Generate a new 12 word mnemonic.
+ *
+ * # Safety
+ * This function is safe. However, there are invariants that must be upheld on the result.
+ *
+ * - The returned mnemonic must only be freed via [`hedera_mnemonic_free`].
+ *   Notably this means that it *must not* be freed with `free`.
+ */
+struct HederaMnemonic *hedera_mnemonic_generate_12(void);
+
+/**
+ * Returns `true` if `mnemonic` is a legacy mnemonic.
+ *
+ * # Safety
+ * - `mnemonic` must be valid for reads according to the [*Rust* pointer rules].
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+bool hedera_mnemonic_is_legacy(struct HederaMnemonic *mnemonic);
+
+/**
+ * Recover a [`PrivateKey`] from `mnemonic`.
+ *
+ * # Safety
+ * - `mnemonic` must be valid for reads according to the [*Rust* pointer rules].
+ * - `passphrase` must be valid for reads up until and including the first NUL (`'\0'`) byte.
+ * - `private_key` must be valid for writes according to the [*Rust* pointer rules].
+ * - if this method returns anything other than [`Error::Ok`],
+ *   then the contents of `private_key` are undefined and must not be used or inspected.
+ * - `private_key` must only be freed via `hedera_private_key_free`.
+ *   Notably, this means that it *must not* be freed with `free`.
+ *
+ * # Errors
+ * - [`Error::MnemonicEntropy`] if this is a legacy private key, and the passphrase isn't empty.
+ * - [`Error::MnemonicEntropy`] if this is a legacy private key,
+ *   and the `Mnemonic`'s checksum doesn't match up with the computed one.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_mnemonic_to_private_key(struct HederaMnemonic *mnemonic,
+                                                const char *passphrase,
+                                                struct HederaPrivateKey **private_key);
+
+/**
+ * Recover a [`PrivateKey`] from `mnemonic`.
+ *
+ * # Safety
+ * - `mnemonic` must be valid for reads according to the [*Rust* pointer rules].
+ * - `private_key` must be valid for writes according to the [*Rust* pointer rules].
+ * - if this method returns anything other than [`Error::Ok`],
+ *   then the contents of `private_key` are undefined and must not be used or inspected.
+ * - `private_key` must only be freed via `hedera_private_key_free`.
+ *   Notably, this means that it *must not* be freed with `free`.
+ *
+ * # Errors
+ * - [`Error::MnemonicEntropy`] if the computed checksum doesn't match the actual checksum.
+ * - [`Error::MnemonicEntropy`] if this is a v2 legacy mnemonic and doesn't have `24` words.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_mnemonic_to_legacy_private_key(struct HederaMnemonic *mnemonic,
+                                                       struct HederaPrivateKey **private_key);
+
+/**
+ * Format `mnemonic` as a string.
+ *
+ * # Safety
+ * - `mnemonic` must be valid for reads according to the [*Rust* pointer rules].
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+char *hedera_mnemonic_to_string(struct HederaMnemonic *mnemonic);
+
+/**
+ * Free `mnemonic` and release all resources associated with it.
+ *
+ * # Safety
+ * - `mnemonic` must be valid for reads and writes according to the [*Rust* pointer rules].
+ * - `mnemonic` must not be used at all after this function is called.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+void hedera_mnemonic_free(struct HederaMnemonic *mnemonic);
 
 /**
  * Parse a Hedera `NftId` from the passed string.

--- a/sdk/rust/src/ffi/key/private/mod.rs
+++ b/sdk/rust/src/ffi/key/private/mod.rs
@@ -34,7 +34,9 @@ use super::{
 };
 use crate::ffi::error::Error;
 use crate::ffi::key::to_bytes;
+use crate::ffi::util;
 use crate::{
+    Mnemonic,
     PrivateKey,
     PublicKey,
 };
@@ -490,6 +492,25 @@ pub unsafe extern "C" fn hedera_private_key_legacy_derive(
     }
 
     Error::Ok
+}
+
+/// Recover a `PrivateKey` from a mnemonic phrase and a passphrase.
+///
+/// # Safety
+/// - `mnemonic` must be valid for reads according to the [*Rust* pointer rules].
+/// - `passphrase` must be valid for reads up until and including the first NUL (`'\0'`) byte.
+/// - the retured `PrivateKey` must only be freed via [`hedera_private_key_free`], notably, this means that it *must not* be freed with `free`.
+
+#[no_mangle]
+pub unsafe extern "C" fn hedera_private_key_from_mnemonic(
+    mnemonic: *mut Mnemonic,
+    passphrase: *const c_char,
+) -> *mut PrivateKey {
+    let mnemonic = unsafe { mnemonic.as_ref() }.unwrap();
+    let passphrase = unsafe { util::cstr_from_ptr(passphrase) };
+
+    let sk = PrivateKey::from_mnemonic(mnemonic, &passphrase);
+    Box::into_raw(Box::new(sk))
 }
 
 /// Releases memory associated with the private key.

--- a/sdk/rust/src/ffi/key/public/tests.rs
+++ b/sdk/rust/src/ffi/key/public/tests.rs
@@ -26,10 +26,6 @@ use std::ptr::{
     self,
     addr_of_mut,
 };
-use std::str::FromStr;
-
-use assert_matches::assert_matches;
-use expect_test::expect;
 
 use crate::ffi::c_util::hedera_string_free;
 use crate::ffi::error::Error;
@@ -37,10 +33,6 @@ use crate::ffi::key::public::{
     hedera_public_key_free,
     hedera_public_key_from_string,
     hedera_public_key_to_string,
-};
-use crate::{
-    PublicKey,
-    Signature,
 };
 
 #[test]

--- a/sdk/rust/src/ffi/mnemonic.rs
+++ b/sdk/rust/src/ffi/mnemonic.rs
@@ -1,0 +1,176 @@
+use std::ffi::{
+    c_char,
+    CString,
+};
+
+use super::error::Error;
+use super::util;
+use crate::{
+    Mnemonic,
+    PrivateKey,
+};
+
+/// Parse a `Mnemonic` from a string.
+///
+/// # Safety
+/// - `s` must be valid for reads up until and including the first NUL (`'\0'`) byte.
+/// - `mnemonic` must be valid for writes according to the [*Rust* pointer rules]
+/// - if this method returns anything other than [`Error::Ok`],
+///   then the contents of `mnemonic` are undefined and must not be used or inspected.
+/// - `mnemonic` must only be freed via [`hedera_mnemonic_free`].
+///   Notably this means that it *must not* be freed with `free`.
+///
+/// # Errors
+/// - [`Error::MnemonicParse`] if the mnemonic has an invalid length.
+/// - [`Error::MnemonicParse`] if the mnemonic uses invalid words.
+/// - [`Error::MnemonicParse`] if the mnemonic has an invalid checksum.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_mnemonic_from_string(
+    s: *const c_char,
+    mnemonic: *mut *mut Mnemonic,
+) -> Error {
+    let s = unsafe { util::cstr_from_ptr(s) };
+
+    let parsed: Mnemonic = ffi_try!(s.parse());
+    let parsed = Box::into_raw(Box::new(parsed));
+    unsafe {
+        mnemonic.write(parsed);
+    }
+
+    Error::Ok
+}
+
+/// Generate a new 24 word mnemonic.
+///
+/// # Safety
+/// This function is safe. However, there are invariants that must be upheld on the result.
+///
+/// - The returned mnemonic must only be freed via [`hedera_mnemonic_free`].
+///   Notably this means that it *must not* be freed with `free`.
+#[no_mangle]
+pub extern "C" fn hedera_mnemonic_generate_24() -> *mut Mnemonic {
+    let mnemonic = Mnemonic::generate_24();
+
+    Box::into_raw(Box::new(mnemonic))
+}
+
+/// Generate a new 12 word mnemonic.
+///
+/// # Safety
+/// This function is safe. However, there are invariants that must be upheld on the result.
+///
+/// - The returned mnemonic must only be freed via [`hedera_mnemonic_free`].
+///   Notably this means that it *must not* be freed with `free`.
+#[no_mangle]
+pub extern "C" fn hedera_mnemonic_generate_12() -> *mut Mnemonic {
+    let mnemonic = Mnemonic::generate_12();
+
+    Box::into_raw(Box::new(mnemonic))
+}
+
+/// Returns `true` if `mnemonic` is a legacy mnemonic.
+///
+/// # Safety
+/// - `mnemonic` must be valid for reads according to the [*Rust* pointer rules].
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_mnemonic_is_legacy(mnemonic: *mut Mnemonic) -> bool {
+    let mnemonic = unsafe { mnemonic.as_ref() }.unwrap();
+    mnemonic.is_legacy()
+}
+
+/// Recover a [`PrivateKey`] from `mnemonic`.
+///
+/// # Safety
+/// - `mnemonic` must be valid for reads according to the [*Rust* pointer rules].
+/// - `passphrase` must be valid for reads up until and including the first NUL (`'\0'`) byte.
+/// - `private_key` must be valid for writes according to the [*Rust* pointer rules].
+/// - if this method returns anything other than [`Error::Ok`],
+///   then the contents of `private_key` are undefined and must not be used or inspected.
+/// - `private_key` must only be freed via `hedera_private_key_free`.
+///   Notably, this means that it *must not* be freed with `free`.
+///
+/// # Errors
+/// - [`Error::MnemonicEntropy`] if this is a legacy private key, and the passphrase isn't empty.
+/// - [`Error::MnemonicEntropy`] if this is a legacy private key,
+///   and the `Mnemonic`'s checksum doesn't match up with the computed one.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_mnemonic_to_private_key(
+    mnemonic: *mut Mnemonic,
+    passphrase: *const c_char,
+    private_key: *mut *mut PrivateKey,
+) -> Error {
+    let mnemonic = unsafe { mnemonic.as_ref() }.unwrap();
+    let passphrase = unsafe { util::cstr_from_ptr(passphrase) };
+
+    let sk = ffi_try!(mnemonic.to_private_key(&passphrase));
+    let sk = Box::into_raw(Box::new(sk));
+
+    unsafe {
+        private_key.write(sk);
+    }
+
+    Error::Ok
+}
+
+/// Recover a [`PrivateKey`] from `mnemonic`.
+///
+/// # Safety
+/// - `mnemonic` must be valid for reads according to the [*Rust* pointer rules].
+/// - `private_key` must be valid for writes according to the [*Rust* pointer rules].
+/// - if this method returns anything other than [`Error::Ok`],
+///   then the contents of `private_key` are undefined and must not be used or inspected.
+/// - `private_key` must only be freed via `hedera_private_key_free`.
+///   Notably, this means that it *must not* be freed with `free`.
+///
+/// # Errors
+/// - [`Error::MnemonicEntropy`] if the computed checksum doesn't match the actual checksum.
+/// - [`Error::MnemonicEntropy`] if this is a v2 legacy mnemonic and doesn't have `24` words.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_mnemonic_to_legacy_private_key(
+    mnemonic: *mut Mnemonic,
+    private_key: *mut *mut PrivateKey,
+) -> Error {
+    let mnemonic = unsafe { mnemonic.as_ref() }.unwrap();
+
+    let sk = ffi_try!(mnemonic.to_legacy_private_key());
+    let sk = Box::into_raw(Box::new(sk));
+
+    unsafe {
+        private_key.write(sk);
+    }
+
+    Error::Ok
+}
+
+/// Format `mnemonic` as a string.
+///
+/// # Safety
+/// - `mnemonic` must be valid for reads according to the [*Rust* pointer rules].
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_mnemonic_to_string(mnemonic: *mut Mnemonic) -> *mut c_char {
+    let mnemonic = unsafe { mnemonic.as_ref() }.unwrap();
+
+    CString::new(mnemonic.to_string()).unwrap().into_raw()
+}
+
+/// Free `mnemonic` and release all resources associated with it.
+///
+/// # Safety
+/// - `mnemonic` must be valid for reads and writes according to the [*Rust* pointer rules].
+/// - `mnemonic` must not be used at all after this function is called.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_mnemonic_free(mnemonic: *mut Mnemonic) {
+    unsafe { drop(Box::from_raw(mnemonic)) }
+}

--- a/sdk/rust/src/ffi/mod.rs
+++ b/sdk/rust/src/ffi/mod.rs
@@ -28,6 +28,7 @@ mod client;
 mod entity_id;
 mod execute;
 mod key;
+mod mnemonic;
 mod nft_id;
 mod runtime;
 mod subscribe;

--- a/sdk/rust/src/key/private_key/mod.rs
+++ b/sdk/rust/src/key/private_key/mod.rs
@@ -511,7 +511,7 @@ impl PrivateKey {
         }
     }
 
-    /// Recover a `PrivateKey` from a generated mnemonic phrase and a passphrase.
+    /// Recover a `PrivateKey` from a mnemonic phrase and a passphrase.
     // this is specifically for the two `try_into`s which depend on `split_array_ref`.
     // There *is* a 3rd unwrap for a "key is not derivable" error, but we construct a key that _is_ derivable.
     // Any panic would indicate a bug in this crate or a dependency of it, not in user code.

--- a/sdk/rust/src/mnemonic/mod.rs
+++ b/sdk/rust/src/mnemonic/mod.rs
@@ -82,7 +82,7 @@ impl fmt::Debug for Mnemonic {
 impl Mnemonic {
     // todo(sr): before release, try to find a better internal representation
     // lets not expose this until we know what the final signature should be
-    fn words(&self) -> &[String] {
+    pub(crate) fn words(&self) -> &[String] {
         match &self.0 {
             MnemonicData::V1(it) => it.words(),
             MnemonicData::V2V3(it) => it.words(),

--- a/sdk/swift/Sources/Hedera/Mnemonic.swift
+++ b/sdk/swift/Sources/Hedera/Mnemonic.swift
@@ -1,0 +1,118 @@
+﻿/*
+ * ‌
+ * Hedera Swift SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import CHedera
+import Foundation
+
+public final class Mnemonic: LosslessStringConvertible, ExpressibleByStringLiteral {
+    internal let ptr: OpaquePointer;
+
+    public var words: [String] {
+        description.components(separatedBy: " ")
+    }
+
+    public var isLegacy: Bool {
+        hedera_mnemonic_is_legacy(ptr)
+    }
+
+    private init(_ ptr: OpaquePointer) {
+        self.ptr = ptr
+    }
+
+    public static func fromWords(_ words: [String]) throws -> Self {
+        // this is kinda backwards, but, it's easier than dealing with a `***char`
+        try Self.fromString(words.joined(separator: " "))
+    }
+
+    public static func fromString(_ description: String) throws -> Self {
+        var ptr = OpaquePointer.init(bitPattern: 0)
+
+        let err = hedera_mnemonic_from_string(description, &ptr)
+
+        if err != HEDERA_ERROR_OK {
+            throw HError(err)!
+        }
+
+        return Self.init(ptr!)
+    }
+
+    public init?(_ description: String) {
+        var ptr = OpaquePointer.init(bitPattern: 0)
+
+        let err = hedera_mnemonic_from_string(description, &ptr)
+
+        if err != HEDERA_ERROR_OK {
+            return nil
+        }
+
+        self.ptr = ptr!
+    }
+
+    public required convenience init(stringLiteral value: StringLiteralType) {
+        self.init(value)!
+    }
+
+    public static func generate24() -> Self {
+        let ptr = hedera_mnemonic_generate_24()
+        return Self.init(ptr!)
+    }
+
+    public static func generate12() -> Self {
+        let ptr = hedera_mnemonic_generate_24()
+        return Self.init(ptr!)
+    }
+
+    public func toPrivateKey(passphrase: String = "") throws -> PrivateKey {
+        var ptr = OpaquePointer.init(bitPattern: 0)
+
+        let err = hedera_mnemonic_to_private_key(self.ptr, passphrase, &ptr)
+
+        if err != HEDERA_ERROR_OK {
+            throw HError(err)!
+        }
+
+        return PrivateKey.unsafeFromPtr(ptr!)
+    }
+
+    public func toLegacyPrivateKey() throws -> PrivateKey {
+        var ptr = OpaquePointer.init(bitPattern: 0)
+
+        let err = hedera_mnemonic_to_legacy_private_key(self.ptr, &ptr)
+
+        if err != HEDERA_ERROR_OK {
+            throw HError(err)!
+        }
+
+        return PrivateKey.unsafeFromPtr(ptr!)
+    }
+
+    public func toString() -> String {
+        description
+    }
+
+    public var description: String {
+        let descriptionBytes = hedera_mnemonic_to_string(ptr)
+        return String(hString: descriptionBytes!)!
+    }
+
+    deinit {
+        hedera_mnemonic_free(ptr)
+    }
+}

--- a/sdk/swift/Sources/Hedera/PrivateKey.swift
+++ b/sdk/swift/Sources/Hedera/PrivateKey.swift
@@ -33,6 +33,11 @@ private let unsafeCHederaBytesFree: Data.Deallocator = .custom { (buf, size) in
 public final class PrivateKey: LosslessStringConvertible, ExpressibleByStringLiteral {
     internal let ptr: OpaquePointer
 
+    internal static func unsafeFromPtr(_ ptr: OpaquePointer) -> Self {
+        Self.init(ptr)
+    }
+
+    // sadly, we can't avoid a leaky abstraction here.
     private init(_ ptr: OpaquePointer) {
         self.ptr = ptr
     }
@@ -226,6 +231,10 @@ public final class PrivateKey: LosslessStringConvertible, ExpressibleByStringLit
         }
 
         return Self(derived!)
+    }
+
+    public func fromMnemonic(_ mnemonic: Mnemonic, _ passphrase: String) -> Self {
+        Self.init(hedera_private_key_from_mnemonic(mnemonic.ptr, passphrase))
     }
 
     deinit {

--- a/sdk/swift/Tests/HederaTests/MnemonicTests.swift
+++ b/sdk/swift/Tests/HederaTests/MnemonicTests.swift
@@ -1,0 +1,88 @@
+/*
+ * ‌
+ * Hedera Swift SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import XCTest
+@testable import Hedera
+
+let knownGoodMnemonics: [String] = [
+    "inmate flip alley wear offer often piece magnet surge toddler submit right radio absent pear floor belt raven " +
+            "price stove replace reduce plate home",
+    "tiny denial casual grass skull spare awkward indoor ethics dash enough flavor good daughter early " +
+            "hard rug staff capable swallow raise flavor empty angle",
+    "ramp april job flavor surround pyramid fish sea good know blame gate village viable include mixed term " +
+            "draft among monitor swear swing novel track",
+    "evoke rich bicycle fire promote climb zero squeeze little spoil slight damage"
+]
+
+final class MnemonicTests: XCTestCase {
+    func testParse() throws {
+        for s in knownGoodMnemonics {
+            XCTAssertEqual(try Mnemonic.fromString(s).description, s)
+        }
+    }
+
+    func testMnemonic3() throws {
+        let str = "obvious favorite remain caution " +
+                "remove laptop base vacant " +
+                "increase video erase pass " +
+                "sniff sausage knock grid " +
+                "argue salt romance way " +
+                "alone fever slush dune"
+
+        let mnemonic = try Mnemonic.fromString(str)
+
+        let sk = try mnemonic.toLegacyPrivateKey()
+
+        XCTAssertEqual(
+                sk.description,
+                "302e020100300506032b65700422042098aa82d6125b5efa04bf8372be7931d05cd77f5ef3330b97d6ee7c006eaaf312"
+        )
+
+
+        func testLegacyMnemonic() throws {
+            let str = "jolly kidnap tom lawn drunk chick optic lust mutter mole bride " +
+                    "galley dense member sage neural widow decide curb aboard margin manure"
+
+            let mnemonic = try Mnemonic.fromString(str)
+            let sk = try mnemonic.toLegacyPrivateKey()
+
+            XCTAssertEqual(
+                    sk.description,
+                    "302e020100300506032b65700422042000c2f59212cb3417f0ee0d38e7bd876810d04f2dd2cb5c2d8f26ff406573f2bd"
+            )
+        }
+
+        func testToPrivateKey() throws {
+            let str = "inmate flip alley wear offer often " +
+                    "piece magnet surge toddler submit right " +
+                    "radio absent pear floor belt raven " +
+                    "price stove replace reduce plate home"
+
+            let mnemonic = try Mnemonic.fromString(str)
+
+            let key = try mnemonic.toPrivateKey()
+
+            XCTAssertEqual(
+                    key.description,
+                    "302e020100300506032b657004220420853f15aecd22706b105da1d709b4ac05b4906170c2b9c7495dff9af49e1391da"
+            )
+        }
+    }
+}


### PR DESCRIPTION
**Description**:

- Add: `PrivateKey.fromMnemonic`
- Add: `Mnemonic.generate12`
- Add: `Menmonic.generate24`
- Add: `Mnemonic.fromString`
- Add: `Mnemonic.toString`
- Add: `Mnemonic.toPrivateKey`
- Add: `Mnemonic.toLegacyPrivateKey`
- Add: `Mnemonic.fromWords`
- Add: `Mnemonic.words`
- Add: `Mnemonic.isLegacy`


**Related issue(s)**:

- #268 (there's no issue for `Mnemonic`, instead there's a checkbox, this checks the box)
- #246 (`PrivateKey.fromMnemonic`, only methods left are `isDerivable`, `sign`, and `signTransaction`)

**Checklist**

- [ ] Documented (the rust and ffi side is)
- [x] Tested (unit, integration, etc.)
