### PR TITLE
refactor(swift): rename `expiresAt` to `expirationTime`

### DIFF
--- a/sdk/swift/Sources/Hedera/FileCreateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/FileCreateTransaction.swift
@@ -66,12 +66,12 @@ public final class FileCreateTransaction: Transaction {
     }
 
     /// The time at which this file should expire.
-    public var expiresAt: Date?
+    public var expirationTime: Date?
 
     /// Sets the time at which this file should expire.
     @discardableResult
-    public func expiresAt(_ expiresAt: Date) -> Self {
-        self.expiresAt = expiresAt
+    public func expirationTime(_ expirationTime: Date) -> Self {
+        self.expirationTime = expirationTime
 
         return self
     }
@@ -80,7 +80,7 @@ public final class FileCreateTransaction: Transaction {
         case fileMemo
         case keys
         case contents
-        case expiresAt
+        case expirationTime
     }
 
     public override func encode(to encoder: Encoder) throws {
@@ -89,7 +89,7 @@ public final class FileCreateTransaction: Transaction {
         try container.encode(fileMemo, forKey: .fileMemo)
         try container.encode(keys, forKey: .keys)
         try container.encode(contents.base64EncodedString(), forKey: .contents)
-        try container.encodeIfPresent(expiresAt?.unixTimestampNanos, forKey: .expiresAt)
+        try container.encodeIfPresent(expirationTime?.unixTimestampNanos, forKey: .expirationTime)
 
         try super.encode(to: encoder)
     }

--- a/sdk/swift/Sources/Hedera/FileUpdateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/FileUpdateTransaction.swift
@@ -81,12 +81,12 @@ public final class FileUpdateTransaction: Transaction {
     }
 
     /// The time at which this file should expire.
-    public var expiresAt: Date?
+    private var expirationTime: Date?
 
     /// Sets the time at which this file should expire.
     @discardableResult
-    public func expiresAt(_ expiresAt: Date) -> Self {
-        self.expiresAt = expiresAt
+    public func expirationTime(_ expirationTime: Date) -> Self {
+        self.expirationTime = expirationTime
 
         return self
     }
@@ -96,7 +96,7 @@ public final class FileUpdateTransaction: Transaction {
         case fileMemo
         case keys
         case contents
-        case expiresAt
+        case expirationTime
     }
 
     public override func encode(to encoder: Encoder) throws {
@@ -106,7 +106,7 @@ public final class FileUpdateTransaction: Transaction {
         try container.encode(fileMemo, forKey: .fileMemo)
         try container.encode(keys, forKey: .keys)
         try container.encode(contents.base64EncodedString(), forKey: .contents)
-        try container.encodeIfPresent(expiresAt?.unixTimestampNanos, forKey: .expiresAt)
+        try container.encodeIfPresent(expirationTime?.unixTimestampNanos, forKey: .expirationTime)
 
         try super.encode(to: encoder)
     }

--- a/sdk/swift/Sources/Hedera/TokenCreateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/TokenCreateTransaction.swift
@@ -24,27 +24,27 @@ import Foundation
 public final class TokenCreateTransaction: Transaction {
     /// Create a new `TokenCreateTransaction`.
     public init(
-        name: String = "",
-        symbol: String = "",
-        decimals: UInt32 = 0,
-        initialSupply: UInt64 = 0,
-        treasuryAccountId: AccountId? = nil,
-        adminKey: Key? = nil,
-        kycKey: Key? = nil,
-        freezeKey: Key? = nil,
-        wipeKey: Key? = nil,
-        supplyKey: Key? = nil,
-        freezeDefault: Bool = false,
-        expiresAt: Date? = nil,
-        autoRenewAccountId: AccountId? = nil,
-        autoRenewPeriod: TimeInterval? = nil,
-        tokenMemo: String = "",
-        tokenType: TokenType = .fungibleCommon,
-        tokenSupplyType: TokenSupplyType = .infinite,
-        maxSupply: UInt64 = 0,
-        feeScheduleKey: Key? = nil,
-        customFees: [CustomFee] = [],
-        pauseKey: Key? = nil
+            name: String = "",
+            symbol: String = "",
+            decimals: UInt32 = 0,
+            initialSupply: UInt64 = 0,
+            treasuryAccountId: AccountId? = nil,
+            adminKey: Key? = nil,
+            kycKey: Key? = nil,
+            freezeKey: Key? = nil,
+            wipeKey: Key? = nil,
+            supplyKey: Key? = nil,
+            freezeDefault: Bool = false,
+            expirationTime: Date? = nil,
+            autoRenewAccountId: AccountId? = nil,
+            autoRenewPeriod: TimeInterval? = nil,
+            tokenMemo: String = "",
+            tokenType: TokenType = .fungibleCommon,
+            tokenSupplyType: TokenSupplyType = .infinite,
+            maxSupply: UInt64 = 0,
+            feeScheduleKey: Key? = nil,
+            customFees: [CustomFee] = [],
+            pauseKey: Key? = nil
     ) {
         self.name = name
         self.symbol = symbol
@@ -57,7 +57,7 @@ public final class TokenCreateTransaction: Transaction {
         self.wipeKey = wipeKey
         self.supplyKey = supplyKey
         self.freezeDefault = freezeDefault
-        self.expiresAt = expiresAt
+        self.expirationTime = expirationTime
         self.autoRenewAccountId = autoRenewAccountId
         self.autoRenewPeriod = autoRenewPeriod
         self.tokenMemo = tokenMemo
@@ -192,12 +192,12 @@ public final class TokenCreateTransaction: Transaction {
     }
 
     /// The time at which the token should expire.
-    public var expiresAt: Date?
+    public var expirationTime: Date?
 
     /// Sets the time at which the token should expire.
     @discardableResult
-    public func expiresAt(_ expiresAt: Date) -> Self {
-        self.expiresAt = expiresAt
+    public func expirationTime(_ expirationTime: Date) -> Self {
+        self.expirationTime = expirationTime
 
         return self
     }
@@ -315,7 +315,7 @@ public final class TokenCreateTransaction: Transaction {
         case wipeKey
         case supplyKey
         case freezeDefault
-        case expiresAt
+        case expirationTime
         case autoRenewAccountId
         case autoRenewPeriod
         case tokenMemo
@@ -341,7 +341,7 @@ public final class TokenCreateTransaction: Transaction {
         try container.encodeIfPresent(wipeKey, forKey: .wipeKey)
         try container.encodeIfPresent(supplyKey, forKey: .supplyKey)
         try container.encode(freezeDefault, forKey: .freezeDefault)
-        try container.encodeIfPresent(expiresAt?.unixTimestampNanos, forKey: .expiresAt)
+        try container.encodeIfPresent(expirationTime?.unixTimestampNanos, forKey: .expirationTime)
         try container.encodeIfPresent(autoRenewAccountId, forKey: .autoRenewAccountId)
         try container.encodeIfPresent(autoRenewPeriod?.wholeSeconds, forKey: .autoRenewPeriod)
         try container.encode(tokenMemo, forKey: .tokenMemo)

--- a/sdk/swift/Sources/Hedera/TokenUpdateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/TokenUpdateTransaction.swift
@@ -24,21 +24,21 @@ import Foundation
 public final class TokenUpdateTransaction: Transaction {
     /// Create a new `TokenUpdateTransaction`.
     public init(
-        tokenId: TokenId? = nil,
-        name: String = "",
-        symbol: String = "",
-        treasuryAccountId: AccountId? = nil,
-        adminKey: Key? = nil,
-        kycKey: Key? = nil,
-        freezeKey: Key? = nil,
-        wipeKey: Key? = nil,
-        supplyKey: Key? = nil,
-        autoRenewAccountId: AccountId? = nil,
-        autoRenewPeriod: TimeInterval? = nil,
-        expiresAt: Date? = nil,
-        tokenMemo: String = "",
-        feeScheduleKey: Key? = nil,
-        pauseKey: Key? = nil
+            tokenId: TokenId? = nil,
+            name: String = "",
+            symbol: String = "",
+            treasuryAccountId: AccountId? = nil,
+            adminKey: Key? = nil,
+            kycKey: Key? = nil,
+            freezeKey: Key? = nil,
+            wipeKey: Key? = nil,
+            supplyKey: Key? = nil,
+            autoRenewAccountId: AccountId? = nil,
+            autoRenewPeriod: TimeInterval? = nil,
+            expirationTime: Date? = nil,
+            tokenMemo: String = "",
+            feeScheduleKey: Key? = nil,
+            pauseKey: Key? = nil
     ) {
         self.tokenId = tokenId
         self.name = name
@@ -51,7 +51,7 @@ public final class TokenUpdateTransaction: Transaction {
         self.supplyKey = supplyKey
         self.autoRenewAccountId = autoRenewAccountId
         self.autoRenewPeriod = autoRenewPeriod
-        self.expiresAt = expiresAt
+        self.expirationTime = expirationTime
         self.tokenMemo = tokenMemo
         self.feeScheduleKey = feeScheduleKey
         self.pauseKey = pauseKey
@@ -181,12 +181,12 @@ public final class TokenUpdateTransaction: Transaction {
     }
 
     /// The new time at which the token should expire.
-    public var expiresAt: Date?
+    public var expirationTime: Date?
 
     /// Sets the new time at which the token should expire.
     @discardableResult
-    public func expiresAt(_ expiresAt: Date) -> Self {
-        self.expiresAt = expiresAt
+    public func expirationTime(_ expirationTime: Date) -> Self {
+        self.expirationTime = expirationTime
 
         return self
     }
@@ -236,7 +236,7 @@ public final class TokenUpdateTransaction: Transaction {
         case supplyKey
         case autoRenewAccountId
         case autoRenewPeriod
-        case expiresAt
+        case expirationTime
         case tokenMemo
         case feeScheduleKey
         case pauseKey
@@ -256,7 +256,7 @@ public final class TokenUpdateTransaction: Transaction {
         try container.encodeIfPresent(supplyKey, forKey: .supplyKey)
         try container.encodeIfPresent(autoRenewAccountId, forKey: .autoRenewAccountId)
         try container.encodeIfPresent(autoRenewPeriod?.wholeSeconds, forKey: .autoRenewPeriod)
-        try container.encodeIfPresent(expiresAt?.unixTimestampNanos, forKey: .expiresAt)
+        try container.encodeIfPresent(expirationTime?.unixTimestampNanos, forKey: .expirationTime)
         try container.encode(tokenMemo, forKey: .tokenMemo)
         try container.encodeIfPresent(feeScheduleKey, forKey: .feeScheduleKey)
         try container.encodeIfPresent(pauseKey, forKey: .pauseKey)


### PR DESCRIPTION
This is to match the other hedera sdks (java, js, rust)

**Description**:
-  Change: `FileCreateTransaction.expiresAt` -> `expirationTime`
-  Change: `FileUpdateTransaction.expiresAt` -> `expirationTime`
-  Change: `TokenCreateTransaction.expiresAt` -> `expirationTime`
-  Change: `TokenUpdateTransaction.expiresAt` -> `expirationTime`
**Related issue(s)**:

Fixes #
- Fixes #239  
- #236 
- #255 
- #258



**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
