### PR TITLE
feat(swift): {File,Contract,Topic,Token,Schedule}Id {from,to}Bytes

### DIFF
--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -156,6 +156,126 @@ enum HederaError hedera_entity_id_from_string(const char *s,
                                               uint64_t *id_num);
 
 /**
+ * Parse a Hedera `FileId` from the passed bytes.
+ *
+ * # Safety
+ * - `file_id_shard`, `file_id_realm`, and `file_id_num` must all be valid for writes.
+ * - `bytes` must be valid for reads of up to `bytes_size` bytes.
+ */
+enum HederaError hedera_file_id_from_bytes(const uint8_t *bytes,
+                                           size_t bytes_size,
+                                           uint64_t *file_id_shard,
+                                           uint64_t *file_id_realm,
+                                           uint64_t *file_id_num);
+
+/**
+ * Serialize the passed FileId as bytes
+ *
+ * # Safety
+ * - `buf` must be valid for writes.
+ */
+size_t hedera_file_id_to_bytes(uint64_t file_id_shard,
+                               uint64_t file_id_realm,
+                               uint64_t file_id_num,
+                               uint8_t **buf);
+
+/**
+ * Parse a Hedera `ContractId` from the passed bytes.
+ *
+ * # Safety
+ * - `contract_id_shard`, `contract_id_realm`, and `contract_id_num` must all be valid for writes.
+ * - `bytes` must be valid for reads of up to `bytes_size` bytes.
+ */
+enum HederaError hedera_contract_id_from_bytes(const uint8_t *bytes,
+                                               size_t bytes_size,
+                                               uint64_t *contract_id_shard,
+                                               uint64_t *contract_id_realm,
+                                               uint64_t *contract_id_num);
+
+/**
+ * Serialize the passed ContractId as bytes
+ *
+ * # Safety
+ * - `buf` must be valid for writes.
+ */
+size_t hedera_contract_id_to_bytes(uint64_t contract_id_shard,
+                                   uint64_t contract_id_realm,
+                                   uint64_t contract_id_num,
+                                   uint8_t **buf);
+
+/**
+ * Parse a Hedera `TopicId` from the passed bytes.
+ *
+ * # Safety
+ * - `topic_id_shard`, `topic_id_realm`, and `topic_id_num` must all be valid for writes.
+ * - `bytes` must be valid for reads of up to `bytes_size` bytes.
+ */
+enum HederaError hedera_topic_id_from_bytes(const uint8_t *bytes,
+                                            size_t bytes_size,
+                                            uint64_t *topic_id_shard,
+                                            uint64_t *topic_id_realm,
+                                            uint64_t *topic_id_num);
+
+/**
+ * Serialize the passed TopicId as bytes
+ *
+ * # Safety
+ * - `buf` must be valid for writes.
+ */
+size_t hedera_topic_id_to_bytes(uint64_t topic_id_shard,
+                                uint64_t topic_id_realm,
+                                uint64_t topic_id_num,
+                                uint8_t **buf);
+
+/**
+ * Parse a Hedera `TokenId` from the passed bytes.
+ *
+ * # Safety
+ * - `token_id_shard`, `token_id_realm`, and `token_id_num` must all be valid for writes.
+ * - `bytes` must be valid for reads of up to `bytes_size` bytes.
+ */
+enum HederaError hedera_token_id_from_bytes(const uint8_t *bytes,
+                                            size_t bytes_size,
+                                            uint64_t *token_id_shard,
+                                            uint64_t *token_id_realm,
+                                            uint64_t *token_id_num);
+
+/**
+ * Serialize the passed TokenId as bytes
+ *
+ * # Safety
+ * - `buf` must be valid for writes.
+ */
+size_t hedera_token_id_to_bytes(uint64_t token_id_shard,
+                                uint64_t token_id_realm,
+                                uint64_t token_id_num,
+                                uint8_t **buf);
+
+/**
+ * Parse a Hedera `ScheduleId` from the passed bytes.
+ *
+ * # Safety
+ * - `schedule_id_shard`, `schedule_id_realm`, and `schedule_id_num` must all be valid for writes.
+ * - `bytes` must be valid for reads of up to `bytes_size` bytes.
+ */
+enum HederaError hedera_schedule_id_from_bytes(const uint8_t *bytes,
+                                               size_t bytes_size,
+                                               uint64_t *schedule_id_shard,
+                                               uint64_t *schedule_id_realm,
+                                               uint64_t *schedule_id_num);
+
+/**
+ * Serialize the passed ScheduleId as bytes
+ *
+ * # Safety
+ * - `buf` must be valid for writes.
+ */
+size_t hedera_schedule_id_to_bytes(uint64_t schedule_id_shard,
+                                   uint64_t schedule_id_realm,
+                                   uint64_t schedule_id_num,
+                                   uint8_t **buf);
+
+/**
  * Execute this request against the provided client of the Hedera network.
  *
  * # Safety

--- a/sdk/rust/src/ffi/entity_id.rs
+++ b/sdk/rust/src/ffi/entity_id.rs
@@ -20,10 +20,25 @@
 
 use std::os::raw::c_char;
 use std::str::FromStr;
+use std::{
+    ptr,
+    slice,
+};
+
+use libc::size_t;
 
 use crate::ffi::error::Error;
 use crate::ffi::util::cstr_from_ptr;
-use crate::EntityId;
+use crate::{
+    ContractId,
+    EntityId,
+    FileId,
+    FromProtobuf,
+    ScheduleId,
+    ToProtobuf,
+    TokenId,
+    TopicId,
+};
 
 /// Parse a Hedera `EntityId` from the passed string.
 #[no_mangle]
@@ -41,10 +56,316 @@ pub extern "C" fn hedera_entity_id_from_string(
     let parsed = ffi_try!(EntityId::from_str(&s));
 
     unsafe {
-        *id_shard = parsed.shard;
-        *id_realm = parsed.realm;
-        *id_num = parsed.num;
+        ptr::write(id_shard, parsed.shard);
+        ptr::write(id_realm, parsed.realm);
+        ptr::write(id_num, parsed.num);
     }
 
     Error::Ok
+}
+
+// note(sr): This abstraction is worthwhile because it reduces the amount of duplicated non-trival unsafe code.
+// generics (on `FromProtobuf`/`ToProtobuf`) make it very hard to do this without this hack.
+trait FromToBytes {
+    fn ffi_from_bytes(bytes: &[u8]) -> crate::Result<Self>
+    where
+        Self: Sized;
+    fn ffi_to_bytes(&self) -> Box<[u8]>;
+}
+
+trait FromIntoEntityId {
+    fn from_entity_id(id: EntityId) -> Self;
+    fn into_entity_id(&self) -> EntityId;
+}
+
+macro_rules! impl_ffi_convert_traits_for {
+    ($($type:ty),*$(,)?) => {
+        $(
+            impl FromToBytes for $type {
+                fn ffi_from_bytes(bytes: &[u8]) -> crate::Result<Self> {
+                    FromProtobuf::from_bytes(bytes)
+                }
+
+                fn ffi_to_bytes(&self) -> Box<[u8]> {
+                    self.to_bytes().into_boxed_slice()
+                }
+            }
+
+            impl FromIntoEntityId for $type {
+                fn from_entity_id(id: EntityId) -> Self {
+                    let EntityId { shard, realm, num } = id;
+                    Self { shard, realm, num }
+                }
+
+                fn into_entity_id(&self) -> EntityId {
+                    let Self { shard, realm, num } = *self;
+                    EntityId { shard, realm, num }
+                }
+            }
+        )*
+    };
+}
+
+impl_ffi_convert_traits_for!(FileId, TokenId, ScheduleId, TopicId);
+
+// todo: use a different mechanism & support evm_address
+impl FromToBytes for ContractId {
+    fn ffi_from_bytes(bytes: &[u8]) -> crate::Result<Self> {
+        FromProtobuf::from_bytes(bytes)
+    }
+
+    fn ffi_to_bytes(&self) -> Box<[u8]> {
+        self.to_bytes().into_boxed_slice()
+    }
+}
+
+impl FromIntoEntityId for ContractId {
+    fn from_entity_id(id: EntityId) -> Self {
+        let EntityId { shard, realm, num } = id;
+        Self { shard, realm, num, evm_address: None }
+    }
+
+    fn into_entity_id(&self) -> EntityId {
+        let Self { shard, realm, num, evm_address: _ } = *self;
+        EntityId { shard, realm, num }
+    }
+}
+
+/// # Safety
+/// - `id_shard`, `id_realm`, and `id_num` must all be valid for writes.
+/// - `bytes` must be valid for reads of up to `bytes_size` bytes.
+unsafe fn id_from_bytes<I: FromToBytes + FromIntoEntityId>(
+    bytes: *const u8,
+    bytes_size: size_t,
+    id_shard: *mut u64,
+    id_realm: *mut u64,
+    id_num: *mut u64,
+) -> Error {
+    assert!(!bytes.is_null());
+    assert!(!id_shard.is_null());
+    assert!(!id_realm.is_null());
+    assert!(!id_num.is_null());
+
+    // safety: caller promises that `bytes` is valid for r/w of up to `bytes_size`, which is exactly what `slice::from_raw_parts` wants.
+    let bytes = unsafe { slice::from_raw_parts(bytes, bytes_size) };
+
+    let id = ffi_try!(I::ffi_from_bytes(bytes));
+    let id = id.into_entity_id();
+
+    // safety: function contract states that all of these must be valid for writes.
+    unsafe {
+        ptr::write(id_shard, id.shard);
+        ptr::write(id_realm, id.realm);
+        ptr::write(id_num, id.num);
+    }
+
+    Error::Ok
+}
+
+/// # Safety
+/// - `buf` must be valid for writes.
+unsafe fn id_to_bytes<I: FromToBytes + FromIntoEntityId>(
+    id_shard: u64,
+    id_realm: u64,
+    id_num: u64,
+    buf: *mut *mut u8,
+) -> size_t {
+    // todo: use `as_maybe_uninit_ref` once that's stable.
+    assert!(!buf.is_null());
+
+    let id = EntityId { shard: id_shard, realm: id_realm, num: id_num };
+    let id = I::from_entity_id(id);
+    let bytes = id.ffi_to_bytes();
+
+    let bytes = Box::leak(bytes);
+    let len = bytes.len();
+    let bytes = bytes.as_mut_ptr();
+
+    // safety: invariants promise that `buf` must be valid for writes.
+    unsafe {
+        ptr::write(buf, bytes);
+    }
+
+    len
+}
+
+/// Parse a Hedera `FileId` from the passed bytes.
+///
+/// # Safety
+/// - `file_id_shard`, `file_id_realm`, and `file_id_num` must all be valid for writes.
+/// - `bytes` must be valid for reads of up to `bytes_size` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_file_id_from_bytes(
+    bytes: *const u8,
+    bytes_size: size_t,
+    file_id_shard: *mut u64,
+    file_id_realm: *mut u64,
+    file_id_num: *mut u64,
+) -> Error {
+    // safety: invariants pushed up to the caller.
+    unsafe { id_from_bytes::<FileId>(bytes, bytes_size, file_id_shard, file_id_realm, file_id_num) }
+}
+
+/// Serialize the passed FileId as bytes
+///
+/// # Safety
+/// - `buf` must be valid for writes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_file_id_to_bytes(
+    file_id_shard: u64,
+    file_id_realm: u64,
+    file_id_num: u64,
+    buf: *mut *mut u8,
+) -> size_t {
+    // safety: invariants pushed up to the caller.
+    unsafe { id_to_bytes::<FileId>(file_id_shard, file_id_realm, file_id_num, buf) }
+}
+
+/// Parse a Hedera `ContractId` from the passed bytes.
+// todo: contract ID needs EVM address handling.
+///
+/// # Safety
+/// - `contract_id_shard`, `contract_id_realm`, and `contract_id_num` must all be valid for writes.
+/// - `bytes` must be valid for reads of up to `bytes_size` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_contract_id_from_bytes(
+    bytes: *const u8,
+    bytes_size: size_t,
+    contract_id_shard: *mut u64,
+    contract_id_realm: *mut u64,
+    contract_id_num: *mut u64,
+) -> Error {
+    // safety: invariants pushed up to the caller.
+    unsafe {
+        id_from_bytes::<ContractId>(
+            bytes,
+            bytes_size,
+            contract_id_shard,
+            contract_id_realm,
+            contract_id_num,
+        )
+    }
+}
+
+/// Serialize the passed ContractId as bytes
+///
+/// # Safety
+/// - `buf` must be valid for writes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_contract_id_to_bytes(
+    contract_id_shard: u64,
+    contract_id_realm: u64,
+    contract_id_num: u64,
+    buf: *mut *mut u8,
+) -> size_t {
+    // safety: invariants pushed up to the caller.
+    unsafe { id_to_bytes::<ContractId>(contract_id_shard, contract_id_realm, contract_id_num, buf) }
+}
+
+/// Parse a Hedera `TopicId` from the passed bytes.
+///
+/// # Safety
+/// - `topic_id_shard`, `topic_id_realm`, and `topic_id_num` must all be valid for writes.
+/// - `bytes` must be valid for reads of up to `bytes_size` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_topic_id_from_bytes(
+    bytes: *const u8,
+    bytes_size: size_t,
+    topic_id_shard: *mut u64,
+    topic_id_realm: *mut u64,
+    topic_id_num: *mut u64,
+) -> Error {
+    // safety: invariants pushed up to the caller.
+    unsafe {
+        id_from_bytes::<TopicId>(bytes, bytes_size, topic_id_shard, topic_id_realm, topic_id_num)
+    }
+}
+
+/// Serialize the passed TopicId as bytes
+///
+/// # Safety
+/// - `buf` must be valid for writes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_topic_id_to_bytes(
+    topic_id_shard: u64,
+    topic_id_realm: u64,
+    topic_id_num: u64,
+    buf: *mut *mut u8,
+) -> size_t {
+    // safety: invariants pushed up to the caller.
+    unsafe { id_to_bytes::<TopicId>(topic_id_shard, topic_id_realm, topic_id_num, buf) }
+}
+
+/// Parse a Hedera `TokenId` from the passed bytes.
+///
+/// # Safety
+/// - `token_id_shard`, `token_id_realm`, and `token_id_num` must all be valid for writes.
+/// - `bytes` must be valid for reads of up to `bytes_size` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_token_id_from_bytes(
+    bytes: *const u8,
+    bytes_size: size_t,
+    token_id_shard: *mut u64,
+    token_id_realm: *mut u64,
+    token_id_num: *mut u64,
+) -> Error {
+    // safety: invariants pushed up to the caller.
+    unsafe {
+        id_from_bytes::<TokenId>(bytes, bytes_size, token_id_shard, token_id_realm, token_id_num)
+    }
+}
+
+/// Serialize the passed TokenId as bytes
+///
+/// # Safety
+/// - `buf` must be valid for writes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_token_id_to_bytes(
+    token_id_shard: u64,
+    token_id_realm: u64,
+    token_id_num: u64,
+    buf: *mut *mut u8,
+) -> size_t {
+    // safety: invariants pushed up to the caller.
+    unsafe { id_to_bytes::<TokenId>(token_id_shard, token_id_realm, token_id_num, buf) }
+}
+
+/// Parse a Hedera `ScheduleId` from the passed bytes.
+///
+/// # Safety
+/// - `schedule_id_shard`, `schedule_id_realm`, and `schedule_id_num` must all be valid for writes.
+/// - `bytes` must be valid for reads of up to `bytes_size` bytes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_schedule_id_from_bytes(
+    bytes: *const u8,
+    bytes_size: size_t,
+    schedule_id_shard: *mut u64,
+    schedule_id_realm: *mut u64,
+    schedule_id_num: *mut u64,
+) -> Error {
+    // safety: invariants pushed up to the caller.
+    unsafe {
+        id_from_bytes::<ScheduleId>(
+            bytes,
+            bytes_size,
+            schedule_id_shard,
+            schedule_id_realm,
+            schedule_id_num,
+        )
+    }
+}
+
+/// Serialize the passed ScheduleId as bytes
+///
+/// # Safety
+/// - `buf` must be valid for writes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_schedule_id_to_bytes(
+    schedule_id_shard: u64,
+    schedule_id_realm: u64,
+    schedule_id_num: u64,
+    buf: *mut *mut u8,
+) -> size_t {
+    // safety: invariants pushed up to the caller.
+    unsafe { id_to_bytes::<TokenId>(schedule_id_shard, schedule_id_realm, schedule_id_num, buf) }
 }

--- a/sdk/swift/Sources/Hedera/Data+Extensions.swift
+++ b/sdk/swift/Sources/Hedera/Data+Extensions.swift
@@ -19,6 +19,7 @@
  */
 
 import Foundation
+import CHedera
 
 private func hexVal(_ char: UInt8) -> UInt8? {
     // this would be a very clean function if swift had a way of doing ascii-charcter literals, but it can't.
@@ -41,6 +42,12 @@ private func hexVal(_ char: UInt8) -> UInt8? {
 }
 
 internal extension Data {
+    // safety: `hedera_bytes_free` needs to be called so...
+    // perf: might as well enable use of the no copy constructor.
+    static let unsafeCHederaBytesFree: Data.Deallocator = .custom { (buf, size) in
+        hedera_bytes_free(buf, size)
+    }
+
     private static let hexAlphabet = Array("0123456789abcdef".unicodeScalars)
 
     // (sr): swift compiler wins the "useless acl vs explicit acl debate

--- a/sdk/swift/Sources/Hedera/EntityId.swift
+++ b/sdk/swift/Sources/Hedera/EntityId.swift
@@ -19,6 +19,7 @@
  */
 
 import CHedera
+import Foundation
 
 public class EntityId: LosslessStringConvertible, ExpressibleByIntegerLiteral, Equatable, Codable,
         ExpressibleByStringLiteral {
@@ -78,22 +79,134 @@ public class EntityId: LosslessStringConvertible, ExpressibleByIntegerLiteral, E
     }
 }
 
+// fixme(sr): How do DRY?
+
 /// The unique identifier for a file on Hedera.
 public final class FileId: EntityId {
+    public static func fromBytes(_ bytes: Data) throws -> Self {
+        try bytes.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) in
+            var shard: UInt64 = 0
+            var realm: UInt64 = 0
+            var num: UInt64 = 0
+
+            let err = hedera_file_id_from_bytes(pointer.baseAddress, pointer.count, &shard, &realm, &num)
+
+            if err != HEDERA_ERROR_OK {
+                throw HError(err)!
+            }
+
+            return Self(shard: shard, realm: realm, num: num)
+        }
+    }
+
+    public func toBytes() -> Data {
+        var buf: UnsafeMutablePointer<UInt8>?
+        let size = hedera_file_id_to_bytes(shard, realm, num, &buf)
+
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+    }
 }
 
 /// The unique identifier for a smart contract on Hedera.
 public final class ContractId: EntityId {
+    public static func fromBytes(_ bytes: Data) throws -> Self {
+        try bytes.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) in
+            var shard: UInt64 = 0
+            var realm: UInt64 = 0
+            var num: UInt64 = 0
+
+            let err = hedera_contract_id_from_bytes(pointer.baseAddress, pointer.count, &shard, &realm, &num)
+
+            if err != HEDERA_ERROR_OK {
+                throw HError(err)!
+            }
+
+            return Self(shard: shard, realm: realm, num: num)
+        }
+    }
+
+    public func toBytes() -> Data {
+        var buf: UnsafeMutablePointer<UInt8>?
+        let size = hedera_contract_id_to_bytes(shard, realm, num, &buf)
+
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+    }
 }
 
 /// The unique identifier for a topic on Hedera.
 public final class TopicId: EntityId {
+    public static func fromBytes(_ bytes: Data) throws -> Self {
+        try bytes.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) in
+            var shard: UInt64 = 0
+            var realm: UInt64 = 0
+            var num: UInt64 = 0
+
+            let err = hedera_topic_id_from_bytes(pointer.baseAddress, pointer.count, &shard, &realm, &num)
+
+            if err != HEDERA_ERROR_OK {
+                throw HError(err)!
+            }
+
+            return Self(shard: shard, realm: realm, num: num)
+        }
+    }
+
+    public func toBytes() -> Data {
+        var buf: UnsafeMutablePointer<UInt8>?
+        let size = hedera_topic_id_to_bytes(shard, realm, num, &buf)
+
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+    }
 }
 
 /// The unique identifier for a token on Hedera.
 public final class TokenId: EntityId {
+    public static func fromBytes(_ bytes: Data) throws -> Self {
+        try bytes.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) in
+            var shard: UInt64 = 0
+            var realm: UInt64 = 0
+            var num: UInt64 = 0
+
+            let err = hedera_token_id_from_bytes(pointer.baseAddress, pointer.count, &shard, &realm, &num)
+
+            if err != HEDERA_ERROR_OK {
+                throw HError(err)!
+            }
+
+            return Self(shard: shard, realm: realm, num: num)
+        }
+    }
+
+    public func toBytes() -> Data {
+        var buf: UnsafeMutablePointer<UInt8>?
+        let size = hedera_token_id_to_bytes(shard, realm, num, &buf)
+
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+    }
 }
 
 /// The unique identifier for a schedule on Hedera.
 public final class ScheduleId: EntityId {
+    public static func fromBytes(_ bytes: Data) throws -> Self {
+        try bytes.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) in
+            var shard: UInt64 = 0
+            var realm: UInt64 = 0
+            var num: UInt64 = 0
+
+            let err = hedera_schedule_id_from_bytes(pointer.baseAddress, pointer.count, &shard, &realm, &num)
+
+            if err != HEDERA_ERROR_OK {
+                throw HError(err)!
+            }
+
+            return Self(shard: shard, realm: realm, num: num)
+        }
+    }
+
+    public func toBytes() -> Data {
+        var buf: UnsafeMutablePointer<UInt8>?
+        let size = hedera_schedule_id_to_bytes(shard, realm, num, &buf)
+
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+    }
 }

--- a/sdk/swift/Sources/Hedera/NftId.swift
+++ b/sdk/swift/Sources/Hedera/NftId.swift
@@ -21,12 +21,6 @@
 import Foundation
 import CHedera
 
-// safety: `hedera_bytes_free` needs to be called so...
-// perf: might as well enable use of the no copy constructor.
-private let unsafeCHederaBytesFree: Data.Deallocator = .custom { (buf, size) in
-    hedera_bytes_free(buf, size)
-}
-
 /// The unique identifier for a non-fungible token (NFT) instance on Hedera.
 public final class NftId: Codable, LosslessStringConvertible, ExpressibleByStringLiteral, Equatable {
     /// The (non-fungible) token of which this NFT is an instance.
@@ -106,7 +100,7 @@ public final class NftId: Codable, LosslessStringConvertible, ExpressibleByStrin
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_nft_id_to_bytes(tokenId.shard, tokenId.realm, tokenId.num, serial, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
     }
 
     public static func == (lhs: NftId, rhs: NftId) -> Bool {

--- a/sdk/swift/Sources/Hedera/PrivateKey.swift
+++ b/sdk/swift/Sources/Hedera/PrivateKey.swift
@@ -23,12 +23,6 @@ import Foundation
 
 private typealias UnsafeFromBytesFunc = @convention(c) (UnsafePointer<UInt8>?, Int, UnsafeMutablePointer<OpaquePointer?>?) -> HederaError
 
-// safety: `hedera_bytes_free` needs to be called so...
-// perf: might as well enable use of the no copy constructor.
-private let unsafeCHederaBytesFree: Data.Deallocator = .custom { (buf, size) in
-    hedera_bytes_free(buf, size)
-}
-
 /// A private key on the Hedera network.
 public final class PrivateKey: LosslessStringConvertible, ExpressibleByStringLiteral {
     internal let ptr: OpaquePointer
@@ -163,21 +157,21 @@ public final class PrivateKey: LosslessStringConvertible, ExpressibleByStringLit
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_private_key_to_bytes_der(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
     }
 
     public func toBytes() -> Data {
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_private_key_to_bytes(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
     }
 
     public func toBytesRaw() -> Data {
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_private_key_to_bytes_raw(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
     }
 
     public var description: String {

--- a/sdk/swift/Sources/Hedera/PublicKey.swift
+++ b/sdk/swift/Sources/Hedera/PublicKey.swift
@@ -24,12 +24,6 @@ import Foundation
 // todo: deduplicate these with `PrivateKey.swift`
 private typealias UnsafeFromBytesFunc = @convention(c) (UnsafePointer<UInt8>?, Int, UnsafeMutablePointer<OpaquePointer?>?) -> HederaError
 
-// safety: `hedera_bytes_free` needs to be called so...
-// perf: might as well enable use of the no copy constructor.
-private let unsafeCHederaBytesFree: Data.Deallocator = .custom { (buf, size) in
-    hedera_bytes_free(buf, size)
-}
-
 /// A public key on the Hedera network.
 public final class PublicKey: LosslessStringConvertible, ExpressibleByStringLiteral, Codable {
     private let ptr: OpaquePointer
@@ -137,21 +131,21 @@ public final class PublicKey: LosslessStringConvertible, ExpressibleByStringLite
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_public_key_to_bytes_der(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
     }
 
     public func toBytes() -> Data {
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_public_key_to_bytes(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
     }
 
     public func toBytesRaw() -> Data {
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_public_key_to_bytes_raw(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
     }
 
     public var description: String {


### PR DESCRIPTION
Combinatorial explosion is annoying

**Description**:


- Add: toBytes/fromBytes to: FileId, ContractId, TopicId, TokenId, ScheduleId

**Related issue(s)**:

- #237 
- #230 
- #268 (TopicId, TokenId, ScheduleId)

Doesn't close any of these because they have more to do

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
