### PR TITLE
feat(swift): AddressBookQuery

### DIFF
--- a/sdk/swift/Examples/GetAddressBook/main.swift
+++ b/sdk/swift/Examples/GetAddressBook/main.swift
@@ -1,0 +1,36 @@
+/*
+ * ‌
+ * Hedera Swift SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import Foundation
+import Hedera
+
+@main
+public enum Program {
+    public static func main() async throws {
+        print("Getting address book for testnet")
+
+        let client = Client.forTestnet()
+
+        let results = try await NodeAddressBookQuery().setFileId(FileId.addressBook)
+                .execute(client)
+
+        print(results)
+    }
+}

--- a/sdk/swift/Package.swift
+++ b/sdk/swift/Package.swift
@@ -31,6 +31,7 @@ for name in [
     "TransferHbar",
     "CreateAccount",
     "DeleteAccount",
+    "GetAddressBook",
     "GetFileContents",
 ] {
     exampleTargets.append(

--- a/sdk/swift/Sources/Hedera/EntityId.swift
+++ b/sdk/swift/Sources/Hedera/EntityId.swift
@@ -83,6 +83,10 @@ public class EntityId: LosslessStringConvertible, ExpressibleByIntegerLiteral, E
 
 /// The unique identifier for a file on Hedera.
 public final class FileId: EntityId {
+    public static let addressBook: FileId = FileId(num: 102)
+    public static let feeSchedule: FileId = FileId(num: 111)
+    public static let exchangeRates: FileId = FileId(num: 112)
+
     public static func fromBytes(_ bytes: Data) throws -> Self {
         try bytes.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) in
             var shard: UInt64 = 0

--- a/sdk/swift/Sources/Hedera/MirrorQuery.swift
+++ b/sdk/swift/Sources/Hedera/MirrorQuery.swift
@@ -1,0 +1,40 @@
+/*
+ * ‌
+ * Hedera Swift SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import Foundation
+
+public class MirrorQuery<Response: Decodable>: Request {
+    public typealias Response = Response
+
+    internal init() {}
+
+    private enum CodingKeys: String, CodingKey {
+        case type = "$type"
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        let typeName = String(describing: type(of: self))
+        let requestName = typeName.prefix(1).lowercased() + typeName.dropFirst().dropLast(5)
+
+        try container.encode(requestName, forKey: .type)
+    }
+}

--- a/sdk/swift/Sources/Hedera/NodeAddress.swift
+++ b/sdk/swift/Sources/Hedera/NodeAddress.swift
@@ -1,0 +1,79 @@
+/*
+ * ‌
+ * Hedera Swift SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import Foundation
+import Network
+
+public struct SocketAddressV4: LosslessStringConvertible, Decodable {
+    public var ip: IPv4Address
+    public var port: UInt16
+
+    public init?(_ description: String) {
+        let parts = description.components(separatedBy: ":")
+        guard parts.count == 2 else {
+            return nil
+        }
+
+        guard let ip = IPv4Address(parts[0]) else {
+            return nil
+        }
+
+        guard let port = UInt16(parts[1]) else {
+            return nil
+        }
+
+        self.ip = ip
+        self.port = port
+    }
+
+    public init(from decoder: Decoder) throws {
+        self.init(try decoder.singleValueContainer().decode(String.self))!
+    }
+
+    public var description: String {
+        "\(ip):\(port)"
+    }
+}
+
+public struct NodeAddress: Decodable {
+    /// A non-sequential, unique, static identifier for the node
+    public var nodeId: UInt64
+
+    /// The node's X509 RSA public key used to sign stream files.
+    public var rsaPublicKey: Data
+
+    /// The account to be paid for queries and transactions sent to this node.
+    public var nodeAccountId: AccountId
+
+    /// Hash of the node's TLS certificate.
+    ///
+    /// Precisely, this field is a string of
+    /// hexadecimal characters which, translated to binary, are the SHA-384 hash of
+    /// the UTF-8 NFKD encoding of the node's TLS cert in PEM format.
+    ///
+    /// Its value can be used to verify the node's certificate it presents during TLS negotiations.
+    public var tlsCertificateHash: Data
+
+    /// A node's service IP addresses and ports.
+    public var serviceEndpoints: [SocketAddressV4]
+
+    /// A description of the node, up to 100 bytes.
+    public var description: String
+}

--- a/sdk/swift/Sources/Hedera/NodeAddressBookQuery.swift
+++ b/sdk/swift/Sources/Hedera/NodeAddressBookQuery.swift
@@ -1,0 +1,49 @@
+/*
+ * ‌
+ * Hedera Swift SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import Foundation
+
+public class NodeAddressBookQuery: MirrorQuery<[NodeAddress]> {
+    private var fileId: FileId
+    private var limit: UInt32
+
+    public init(_ fileId: FileId = FileId.addressBook, _ limit: UInt32 = 0) {
+        self.fileId = fileId
+        self.limit = limit
+    }
+
+    public func getFileId() -> FileId {
+        fileId
+    }
+
+    public func setFileId(_ fileId: FileId) -> Self {
+        self.fileId = fileId
+        return self
+    }
+
+    public func getLimit() -> UInt32 {
+        limit
+    }
+
+    public func setLimit(_ limit: UInt32) -> Self {
+        self.limit = limit
+        return self
+    }
+}


### PR DESCRIPTION
**Description**:

- Add: `AddressBookQuery` as `NodeAddressBookQuery`
- Add: `NodeAddress`
- Add: `Examples/GetAddressBook`

**Related issue(s)**:

- Ticks two boxes in #268  (`Examples/GetAddressBook` and `NodeAddressBookQuery`)
- Related not fixed: `NodeAddressBook` (has a from/to bytes, and requires changes on the rust side?)

Fixes #

**Notes for reviewer**:
- @mehcode when you review this would you be able to tell if https://github.com/hashgraph/hedera-sdk-java/blob/2da5aa4d402870e816478e08305a9bcdcef23aba/sdk/src/main/java/com/hedera/hashgraph/sdk/NodeAddress.java (the file) matches with `NodeAddress` (in this pr), it _looks_ like it does...

**Checklist**

- [x] Documented (Code comments, README, etc.) - kinda
- [x] Tested (unit, integration, etc.)
