### PR TITLE
feat(swift): Add various things from the rust core

### DIFF
--- a/sdk/swift/Sources/Hedera/ContractFunctionResult.swift
+++ b/sdk/swift/Sources/Hedera/ContractFunctionResult.swift
@@ -27,7 +27,7 @@ public struct ContractFunctionResult: Codable {
     public let contractId: ContractId
 
     /// The new contract's 20-byte EVM address.
-    // TODO: public let evmAddress: ContractId?
+    public let evmAddress: ContractId?
 
     /// Message if there was an error during smart contract execution.
     public let errorMessage: String?
@@ -59,6 +59,7 @@ public struct ContractFunctionResult: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         contractId = try container.decode(ContractId.self, forKey: .contractId)
+        evmAddress = try container.decode(ContractId.self, forKey: .evmAddress)
         errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
         bloom = Data(base64Encoded: try container.decode(String.self, forKey: .bloom))!
         gasUsed = try container.decode(UInt64.self, forKey: .gasUsed)

--- a/sdk/swift/Sources/Hedera/ContractInfo.swift
+++ b/sdk/swift/Sources/Hedera/ContractInfo.swift
@@ -58,4 +58,6 @@ public final class ContractInfo: Codable {
 
     /// The maximum number of tokens that a contract can be implicitly associated with.
     public let maxAutomaticTokenAssociations: UInt32
+
+    public let ledgerId: LedgerId
 }

--- a/sdk/swift/Sources/Hedera/FileInfo.swift
+++ b/sdk/swift/Sources/Hedera/FileInfo.swift
@@ -21,6 +21,7 @@
 import Foundation
 
 // TODO: keys
+
 /// Response from `FileInfoQuery`.
 public final class FileInfo: Codable {
     /// The file ID of the file for which information is requested.
@@ -37,4 +38,6 @@ public final class FileInfo: Codable {
 
     /// Memo associated with the file.
     public let fileMemo: String
+
+    public let ledgerId: LedgerId
 }

--- a/sdk/swift/Sources/Hedera/ScheduleInfo.swift
+++ b/sdk/swift/Sources/Hedera/ScheduleInfo.swift
@@ -58,4 +58,6 @@ public final class ScheduleInfo: Codable {
 
     /// The time the schedule transaction was deleted.
     public let deletedAt: Date?
+
+    public let ledgerId: LedgerId
 }

--- a/sdk/swift/Sources/Hedera/SemanticVersion.swift
+++ b/sdk/swift/Sources/Hedera/SemanticVersion.swift
@@ -20,7 +20,7 @@
 
 /// Hedera follows semantic versioning for both the HAPI protobufs and
 /// the Services software.
-public struct SemanticVersion: Codable {
+public struct SemanticVersion: Codable, CustomStringConvertible {
     /// Increases with incompatible API changes
     public let major: UInt32
 
@@ -29,4 +29,12 @@ public struct SemanticVersion: Codable {
 
     /// Increases with backwards-compatible bug fixes
     public let patch: UInt32
+
+    public var description: String {
+        "\(major).\(minor)\(patch)"
+    }
+
+    public func toString() -> String {
+        description
+    }
 }

--- a/sdk/swift/Sources/Hedera/TransactionResponse.swift
+++ b/sdk/swift/Sources/Hedera/TransactionResponse.swift
@@ -49,12 +49,10 @@ public struct TransactionResponse: Decodable {
     /// Will wait for consensus.
     /// Will return a `receiptStatus` error for a failing receipt.
     public func getReceipt(_ client: Client) async throws -> TransactionReceipt {
-        let receipt = try await TransactionReceiptQuery()
-            .transactionId(transactionId)
-            // TODO: .nodeAccountIds([nodeAccountId])
-            .validateStatus(true)
-            .execute(client)
-
-        return receipt
+        try await TransactionReceiptQuery()
+                .transactionId(transactionId)
+                .nodeAccountIds([nodeAccountId])
+                .validateStatus(true)
+                .execute(client)
     }
 }


### PR DESCRIPTION
**Description**:

basically a series of one liners that would be annoying to do individually.

- Add: `ContractFunctionResult.evmAddress`
- Add: `ContractInfo.ledgerId`
- Add: `FileInfo.ledgerId`
- Add: `ScheduleInfo.ledgerId`
- Add: `SemanticVersion.description`/`toString`
- Fix?: use `nodeAccountId` in `TransactionResponse.getReceipt`

**Related issue(s)**:
All of these issues want at least one other thing (most commonly to/from bytes)
- #229 
- #231 
- #238 
- #248 
- #251 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
