### PR TITLE
refactor!: hide serde dependency behind `ffi` feature

### DIFF
--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "byteorder"
@@ -212,6 +212,12 @@ dependencies = [
  "tempfile",
  "toml",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -294,6 +300,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,10 +371,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.14.1"
+name = "cxx"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -366,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -380,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
@@ -919,15 +979,26 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.50"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -1009,6 +1080,15 @@ name = "libc"
 version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "lock_api"
@@ -1535,6 +1615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2104,12 @@ name = "unicode-ident"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "version_check"

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -191,7 +191,6 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
 dependencies = [
- "clap 3.2.22",
  "heck",
  "indexmap",
  "log",
@@ -231,21 +230,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
-dependencies = [
- "atty",
- "bitflags",
- "clap_lex 0.2.4",
- "indexmap",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a1af219c3e254a8b4649d6ddaef886b2015089f35f2ac5e1db31410c0566ab8"
@@ -253,7 +237,7 @@ dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
- "clap_lex 0.3.0",
+ "clap_lex",
  "once_cell",
  "strsim",
  "termcolor",
@@ -270,15 +254,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -729,9 +704,8 @@ dependencies = [
  "async-stream",
  "async-trait",
  "backoff",
- "base64",
  "cbindgen",
- "clap 4.0.7",
+ "clap",
  "dotenvy",
  "ed25519-dalek",
  "expect-test",
@@ -742,7 +716,6 @@ dependencies = [
  "hex",
  "hex-literal",
  "hmac",
- "http",
  "itertools",
  "k256",
  "libc",
@@ -1189,26 +1162,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest",
- "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]
@@ -1711,12 +1670,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,19 +553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "expect-test"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,28 +606,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -657,23 +619,6 @@ name = "futures-core"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
@@ -704,13 +649,9 @@ version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -795,7 +736,6 @@ dependencies = [
  "ed25519-dalek",
  "expect-test",
  "fraction",
- "futures",
  "futures-core",
  "futures-util",
  "hedera-proto",
@@ -813,7 +753,6 @@ dependencies = [
  "pbkdf2",
  "pem-rfc7468",
  "pkcs8",
- "pretty_env_logger",
  "prost",
  "rand",
  "rust_decimal",
@@ -911,15 +850,6 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
 
 [[package]]
 name = "hyper"
@@ -1355,16 +1285,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,12 +1381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,8 +1445,6 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -316,12 +316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,19 +451,6 @@ checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
  "zeroize",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
 ]
 
 [[package]]
@@ -810,7 +791,6 @@ dependencies = [
  "base64",
  "cbindgen",
  "clap 4.0.7",
- "derive_more",
  "dotenvy",
  "ed25519-dalek",
  "expect-test",
@@ -1594,15 +1574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,12 +1604,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -50,13 +50,16 @@ rand = "0.8.5"
 rust_decimal = "1.26.1"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.79"
-serde_with = { version = "2.0.0", features = ["base64", "time_0_3"] }
 sha2 = "0.10.2"
 sha3 = "0.10.2"
 thiserror = "1.0.31"
 time = { version = "0.3.9", features = ["serde"] }
 tokio = { version = "1.18.1", features = ["rt-multi-thread"] }
 tonic = "0.8.0"
+
+[dependencies.serde_with]
+version = "2.0.0"
+features = ["base64", "time_0_3"]
 
 [dev-dependencies]
 anyhow = "1.0.57"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -15,22 +15,28 @@ bench = false
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [features]
-ffi = ["libc"]
+ffi = [
+    "libc",
+    "fraction/with-serde-support",
+    "ed25519-dalek/serde",
+    "hedera-proto/serde",
+    "serde",
+    "serde_with",
+    "serde_json",
+    "time/serde",
+    "serde/derive",
+]
 
 [dependencies]
 async-stream = "0.3.3"
 async-trait = "0.1.53"
 backoff = "0.4.0"
 base64 = "0.13.0"
-ed25519-dalek = { version = "1.0.1", features = ["rand", "serde"] }
-fraction = { version = "0.11.0", features = ["with-serde-support"] }
+ed25519-dalek = { version = "1.0.1", features = ["rand"] }
+fraction = "0.11.0"
 futures-core = "0.3.21"
 futures-util = "0.3.21"
-hedera-proto = { path = "./protobufs", features = [
-    "serde",
-    "time_0_3",
-    "fraction",
-] }
+hedera-proto = { path = "./protobufs", features = ["time_0_3", "fraction"] }
 hex = "0.4.3"
 hmac = "0.12.1"
 http = "0.2.7"
@@ -47,17 +53,24 @@ pkcs8 = "0.9.0"
 prost = "0.11.0"
 rand = "0.8.5"
 rust_decimal = "1.26.1"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.79"
 sha2 = "0.10.2"
 sha3 = "0.10.2"
 thiserror = "1.0.31"
-time = { version = "0.3.9", features = ["serde"] }
+time = "0.3.9"
 tokio = { version = "1.18.1", features = ["rt-multi-thread"] }
 tonic = "0.8.0"
 
+[dependencies.serde_json]
+version = "1.0.79"
+optional = true
+
+[dependencies.serde]
+version = "1.0.137"
+optional = true
+
 [dependencies.serde_with]
 version = "2.0.0"
+optional = true
 features = ["base64", "time_0_3"]
 
 [dev-dependencies]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [features]
-ffi = []
+ffi = ["libc"]
 
 [dependencies]
 async-stream = "0.3.3"
@@ -36,7 +36,7 @@ hmac = "0.12.1"
 http = "0.2.7"
 itertools = "0.10.3"
 k256 = "0.11.0"
-libc = "0.2.135"
+libc = { version = "0.2.135", optional = true }
 log = "0.4.17"
 num-bigint = "0.4.3"
 once_cell = "1.10.0"
@@ -66,9 +66,7 @@ assert_matches = "1.5.0"
 clap = { version = "4.0.0", features = ["derive", "env"] }
 dotenvy = "0.15.5"
 expect-test = "1.4.0"
-futures = "0.3"
 hex-literal = "0.3.4"
-pretty_env_logger = "0.4.0"
 tokio = { version = "1.18.1", features = ["full"] }
 
 [build-dependencies]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -22,7 +22,6 @@ async-stream = "0.3.3"
 async-trait = "0.1.53"
 backoff = "0.4.0"
 base64 = "0.13.0"
-derive_more = "0.99.17"
 ed25519-dalek = { version = "1.0.1", features = ["rand", "serde"] }
 fraction = { version = "0.11.0", features = ["with-serde-support"] }
 futures-core = "0.3.21"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -16,6 +16,8 @@ crate-type = ["lib", "staticlib", "cdylib"]
 
 [features]
 ffi = [
+    "anyhow",
+    "cbindgen",
     "libc",
     "fraction/with-serde-support",
     "ed25519-dalek/serde",
@@ -31,7 +33,6 @@ ffi = [
 async-stream = "0.3.3"
 async-trait = "0.1.53"
 backoff = "0.4.0"
-base64 = "0.13.0"
 ed25519-dalek = { version = "1.0.1", features = ["rand"] }
 fraction = "0.11.0"
 futures-core = "0.3.21"
@@ -39,7 +40,6 @@ futures-util = "0.3.21"
 hedera-proto = { path = "./protobufs", features = ["time_0_3", "fraction"] }
 hex = "0.4.3"
 hmac = "0.12.1"
-http = "0.2.7"
 itertools = "0.10.3"
 k256 = "0.11.0"
 libc = { version = "0.2.135", optional = true }
@@ -47,7 +47,7 @@ log = "0.4.17"
 num-bigint = "0.4.3"
 once_cell = "1.10.0"
 parking_lot = "0.12.0"
-pbkdf2 = "0.11.0"
+pbkdf2 = { version = "0.11.0", default-features = false }
 pem-rfc7468 = { version = "0.6.0", features = ["std"] }
 pkcs8 = "0.9.0"
 prost = "0.11.0"
@@ -83,8 +83,8 @@ hex-literal = "0.3.4"
 tokio = { version = "1.18.1", features = ["full"] }
 
 [build-dependencies]
-anyhow = "1.0.57"
-cbindgen = "0.24.3"
+anyhow = { version = "1.0.57", optional = true }
+cbindgen = { version = "0.24.3", default-features = false, optional = true }
 
 [profile.release]
 codegen-units = 1

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -18,16 +18,20 @@
  * ‍
  */
 
-use std::env;
+#[cfg(not(feature = "ffi"))]
+fn main() {}
 
-use cbindgen::{
-    Config,
-    EnumConfig,
-    Language,
-    RenameRule,
-};
-
+#[cfg(feature = "ffi")]
 fn main() -> anyhow::Result<()> {
+    use std::env;
+
+    use cbindgen::{
+        Config,
+        EnumConfig,
+        Language,
+        RenameRule,
+    };
+
     cbindgen::Builder::new()
         .with_config(Config {
             cpp_compat: true,

--- a/sdk/rust/examples/consensus.rs
+++ b/sdk/rust/examples/consensus.rs
@@ -23,7 +23,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use clap::Parser;
-use futures::TryStreamExt;
+// `use futures::TryStreamExt`, this is better practice though.
+use futures_util::TryStreamExt;
 use hedera::{
     AccountId, Client, PrivateKey, TopicId, TopicMessageQuery, TopicMessageSubmitTransaction
 };

--- a/sdk/rust/protobufs/Cargo.toml
+++ b/sdk/rust/protobufs/Cargo.toml
@@ -6,8 +6,6 @@ repository = "https://github.com/hashgraph/hedera-sdk-rust"
 version = "0.4.0"
 
 [features]
-# enable gRPC server generation
-server = []
 
 [dependencies]
 fraction = { version = "0.11.0", optional = true }
@@ -15,7 +13,10 @@ prost = "0.11.0"
 prost-types = "0.11.0"
 serde = { version = "1.0.136", features = ["derive"], optional = true }
 time_0_3 = { version = "0.3.9", optional = true, package = "time" }
-tonic = "0.8.0"
+
+# todo: get the tonic devs to actually make `channel` usable without `transport` (it *should*, it's *documented* as such, but it just doesn't work).
+[dependencies.tonic]
+version = "0.8.0"
 
 [build-dependencies]
 anyhow = "1.0.55"

--- a/sdk/rust/protobufs/build.rs
+++ b/sdk/rust/protobufs/build.rs
@@ -109,7 +109,7 @@ successful transaction.
     create_dir_all(&mirror_out_dir)?;
 
     tonic_build::configure()
-        .build_server(cfg!(feature = "server"))
+        .build_server(false)
         .extern_path(".proto.Timestamp", "crate::services::Timestamp")
         .extern_path(".proto.TopicID", "crate::services::TopicId")
         .extern_path(".proto.FileID", "crate::services::FileId")

--- a/sdk/rust/src/account/account_allowance_approve_transaction.rs
+++ b/sdk/rust/src/account/account_allowance_approve_transaction.rs
@@ -48,8 +48,9 @@ use crate::{
 ///
 pub type AccountAllowanceApproveTransaction = Transaction<AccountAllowanceApproveTransactionData>;
 
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct AccountAllowanceApproveTransactionData {
     /// List of hbar allowances approved by the account owner.
     hbar_allowances: Vec<HbarAllowance>,
@@ -151,8 +152,9 @@ impl AccountAllowanceApproveTransaction {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 struct HbarAllowance {
     /// The account ID of the hbar owner (ie. the grantor of the allowance).
     owner_account_id: AccountId,
@@ -164,8 +166,9 @@ struct HbarAllowance {
     amount: Hbar,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 struct TokenAllowance {
     /// The token that the allowance pertains to.
     token_id: TokenId,
@@ -180,8 +183,9 @@ struct TokenAllowance {
     amount: u64,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 struct NftAllowance {
     /// The token that the allowance pertains to.
     token_id: TokenId,

--- a/sdk/rust/src/account/account_allowance_delete_transaction.rs
+++ b/sdk/rust/src/account/account_allowance_delete_transaction.rs
@@ -43,14 +43,16 @@ use crate::{
 /// [`AccountAllowanceApproveTransaction`](crate::AccountAllowanceApproveTransaction).
 pub type AccountAllowanceDeleteTransaction = Transaction<AccountAllowanceDeleteTransactionData>;
 
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct AccountAllowanceDeleteTransactionData {
     pub nft_allowances: Vec<NftRemoveAllowance>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct NftRemoveAllowance {
     /// token that the allowance pertains to
     pub token_id: TokenId,

--- a/sdk/rust/src/account/account_balance.rs
+++ b/sdk/rust/src/account/account_balance.rs
@@ -30,8 +30,9 @@ use crate::{
 };
 
 /// Response from [`AccountBalanceQuery`][crate::AccountBalanceQuery].
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct AccountBalance {
     /// The account that is being referenced.
     pub account_id: AccountId,

--- a/sdk/rust/src/account/account_create_transaction.rs
+++ b/sdk/rust/src/account/account_create_transaction.rs
@@ -22,7 +22,6 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     DurationSeconds,
 };
@@ -48,7 +47,7 @@ pub type AccountCreateTransaction = Transaction<AccountCreateTransactionData>;
 // TODO: shard_id: Option<ShardId>
 // TODO: realm_id: Option<RealmId>
 // TODO: new_realm_admin_key: Option<Key>,
-#[serde_as]
+
 #[skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -66,7 +65,7 @@ pub struct AccountCreateTransactionData {
     pub receiver_signature_required: bool,
 
     /// The account is charged to extend its expiration date every this many seconds.
-    #[serde_as(as = "Option<DurationSeconds<i64>>")]
+    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
     pub auto_renew_period: Option<Duration>,
 
     /// The memo associated with the account.

--- a/sdk/rust/src/account/account_create_transaction.rs
+++ b/sdk/rust/src/account/account_create_transaction.rs
@@ -21,10 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
-use serde_with::{
-    skip_serializing_none,
-    DurationSeconds,
-};
 use time::Duration;
 use tonic::transport::Channel;
 
@@ -48,9 +44,10 @@ pub type AccountCreateTransaction = Transaction<AccountCreateTransactionData>;
 // TODO: realm_id: Option<RealmId>
 // TODO: new_realm_admin_key: Option<Key>,
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(default, rename_all = "camelCase"))]
 pub struct AccountCreateTransactionData {
     /// The key that must sign each transfer out of the account.
     ///
@@ -65,7 +62,10 @@ pub struct AccountCreateTransactionData {
     pub receiver_signature_required: bool,
 
     /// The account is charged to extend its expiration date every this many seconds.
-    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::DurationSeconds<i64>>>")
+    )]
     pub auto_renew_period: Option<Duration>,
 
     /// The memo associated with the account.
@@ -227,30 +227,32 @@ impl From<AccountCreateTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use std::str::FromStr;
 
-    use assert_matches::assert_matches;
-    use time::Duration;
+        use assert_matches::assert_matches;
+        use time::Duration;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountCreateTransaction,
-        AccountId,
-        Hbar,
-        Key,
-        PublicKey,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountCreateTransaction,
+            AccountId,
+            Hbar,
+            Key,
+            PublicKey,
+        };
 
-    // language=JSON
-    const ACCOUNT_CREATE_EMPTY: &str = r#"{
+        // language=JSON
+        const ACCOUNT_CREATE_EMPTY: &str = r#"{
   "$type": "accountCreate"
 }"#;
 
-    // language=JSON
-    const ACCOUNT_CREATE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const ACCOUNT_CREATE_TRANSACTION_JSON: &str = r#"{
   "$type": "accountCreate",
   "key": {
     "single": "302a300506032b6570032100d1ad76ed9b057a3d3f2ea2d03b41bcd79aeafd611f941924f0f6da528ab066fd"
@@ -265,62 +267,64 @@ mod tests {
   "declineStakingReward": false
 }"#;
 
-    const KEY: &str =
+        const KEY: &str =
         "302a300506032b6570032100d1ad76ed9b057a3d3f2ea2d03b41bcd79aeafd611f941924f0f6da528ab066fd";
 
-    #[test]
-    #[ignore = "auto renew period is `None`"]
-    fn it_should_deserialize_empty() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(ACCOUNT_CREATE_EMPTY)?;
+        #[test]
+        #[ignore = "auto renew period is `None`"]
+        fn it_should_deserialize_empty() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(ACCOUNT_CREATE_EMPTY)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::AccountCreate(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::AccountCreate(transaction) => transaction);
 
-        assert_eq!(data.auto_renew_period, Some(Duration::days(90)));
+            assert_eq!(data.auto_renew_period, Some(Duration::days(90)));
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = AccountCreateTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = AccountCreateTransaction::new();
 
-        transaction
-            .key(PublicKey::from_str(KEY)?)
-            .initial_balance(Hbar::from_tinybars(1000))
-            .receiver_signature_required(true)
-            .auto_renew_period(Duration::days(90))
-            .account_memo("An account memo")
-            .max_automatic_token_associations(256)
-            .staked_account_id(AccountId::from(1001))
-            .staked_node_id(7)
-            .decline_staking_reward(false);
+            transaction
+                .key(PublicKey::from_str(KEY)?)
+                .initial_balance(Hbar::from_tinybars(1000))
+                .receiver_signature_required(true)
+                .auto_renew_period(Duration::days(90))
+                .account_memo("An account memo")
+                .max_automatic_token_associations(256)
+                .staked_account_id(AccountId::from(1001))
+                .staked_node_id(7)
+                .decline_staking_reward(false);
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, ACCOUNT_CREATE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, ACCOUNT_CREATE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(ACCOUNT_CREATE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction =
+                serde_json::from_str(ACCOUNT_CREATE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::AccountCreate(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::AccountCreate(transaction) => transaction);
 
-        assert_eq!(data.initial_balance.to_tinybars(), 1000);
-        assert_eq!(data.receiver_signature_required, true);
-        assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
-        assert_eq!(data.account_memo, "An account memo");
-        assert_eq!(data.max_automatic_token_associations, 256);
-        assert_eq!(data.staked_node_id.unwrap(), 7);
-        assert_eq!(data.decline_staking_reward, false);
+            assert_eq!(data.initial_balance.to_tinybars(), 1000);
+            assert_eq!(data.receiver_signature_required, true);
+            assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
+            assert_eq!(data.account_memo, "An account memo");
+            assert_eq!(data.max_automatic_token_associations, 256);
+            assert_eq!(data.staked_node_id.unwrap(), 7);
+            assert_eq!(data.decline_staking_reward, false);
 
-        let key = assert_matches!(data.key.unwrap(), Key::Single(public_key) => public_key);
+            let key = assert_matches!(data.key.unwrap(), Key::Single(public_key) => public_key);
 
-        assert_eq!(key, PublicKey::from_str(KEY)?);
-        assert_eq!(data.staked_account_id, Some(AccountId::from(1001)));
+            assert_eq!(key, PublicKey::from_str(KEY)?);
+            assert_eq!(data.staked_account_id, Some(AccountId::from(1001)));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/account/account_delete_transaction.rs
+++ b/sdk/rust/src/account/account_delete_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -42,9 +41,10 @@ use crate::{
 ///
 pub type AccountDeleteTransaction = Transaction<AccountDeleteTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(default, rename_all = "camelCase"))]
 pub struct AccountDeleteTransactionData {
     /// The account ID which will receive all remaining hbars.
     pub transfer_account_id: Option<AccountId>,
@@ -102,46 +102,52 @@ impl From<AccountDeleteTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountDeleteTransaction,
-        AccountId,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountDeleteTransaction,
+            AccountId,
+        };
 
-    // language=JSON
-    const ACCOUNT_DELETE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const ACCOUNT_DELETE_TRANSACTION_JSON: &str = r#"{
   "$type": "accountDelete",
   "transferAccountId": "0.0.1001",
   "accountId": "0.0.1002"
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = AccountDeleteTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = AccountDeleteTransaction::new();
 
-        transaction.transfer_account_id(AccountId::from(1001)).account_id(AccountId::from(1002));
+            transaction
+                .transfer_account_id(AccountId::from(1001))
+                .account_id(AccountId::from(1002));
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, ACCOUNT_DELETE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, ACCOUNT_DELETE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(ACCOUNT_DELETE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction =
+                serde_json::from_str(ACCOUNT_DELETE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::AccountDelete(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::AccountDelete(transaction) => transaction);
 
-        assert_eq!(data.transfer_account_id, Some(AccountId::from(1001)));
-        assert_eq!(data.account_id, Some(AccountId::from(1002)));
+            assert_eq!(data.transfer_account_id, Some(AccountId::from(1001)));
+            assert_eq!(data.account_id, Some(AccountId::from(1002)));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/account/account_id.rs
+++ b/sdk/rust/src/account/account_id.rs
@@ -27,10 +27,6 @@ use std::fmt::{
 use std::str::FromStr;
 
 use hedera_proto::services;
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
 
 use crate::{
     EntityId,
@@ -42,7 +38,8 @@ use crate::{
 
 // TODO: checksum
 /// A unique identifier for a cryptocurrency account on Hedera.
-#[derive(SerializeDisplay, Copy, DeserializeFromStr, Hash, PartialEq, Eq, Clone)]
+#[derive(Copy, Hash, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct AccountId {
     /// A non-negative number identifying the shard containing this account.
     pub shard: u64,

--- a/sdk/rust/src/account/account_info.rs
+++ b/sdk/rust/src/account/account_info.rs
@@ -38,8 +38,9 @@ use crate::{
 };
 
 /// Response from [`AccountInfoQuery`][crate::AccountInfoQuery].
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct AccountInfo {
     /// The account that is being referenced.
     pub account_id: AccountId,

--- a/sdk/rust/src/account/account_info_query.rs
+++ b/sdk/rust/src/account/account_info_query.rs
@@ -41,8 +41,9 @@ use crate::{
 ///
 pub type AccountInfoQuery = Query<AccountInfoQueryData>;
 
-#[derive(Default, Clone, serde::Serialize, serde::Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct AccountInfoQueryData {
     account_id: Option<AccountId>,
 }

--- a/sdk/rust/src/account/account_records_query.rs
+++ b/sdk/rust/src/account/account_records_query.rs
@@ -40,8 +40,9 @@ use crate::{
 /// that were above the threshold, during the last 25 hours.
 pub type AccountRecordsQuery = Query<AccountRecordsQueryData>;
 
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct AccountRecordsQueryData {
     account_id: Option<AccountId>,
 }

--- a/sdk/rust/src/account/account_stakers_query.rs
+++ b/sdk/rust/src/account/account_stakers_query.rs
@@ -39,8 +39,9 @@ use crate::{
 /// For each of them, give the amount currently staked.
 pub type AccountStakersQuery = Query<AccountStakersQueryData>;
 
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct AccountStakersQueryData {
     account_id: Option<AccountId>,
 }

--- a/sdk/rust/src/account/account_update_transaction.rs
+++ b/sdk/rust/src/account/account_update_transaction.rs
@@ -22,7 +22,6 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     DurationSeconds,
     TimestampNanoSeconds,
@@ -57,7 +56,7 @@ pub type AccountUpdateTransaction = Transaction<AccountUpdateTransactionData>;
 // TODO: shard_id: Option<ShardId>
 // TODO: realm_id: Option<RealmId>
 // TODO: new_realm_admin_key: Option<Key>,
-#[serde_as]
+
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -72,11 +71,11 @@ pub struct AccountUpdateTransactionData {
     pub receiver_signature_required: Option<bool>,
 
     /// The account is charged to extend its expiration date every this many seconds.
-    #[serde_as(as = "Option<DurationSeconds<i64>>")]
+    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
     pub auto_renew_period: Option<Duration>,
 
     /// The new expiration time to extend to (ignored if equal to or before the current one).
-    #[serde_as(as = "Option<TimestampNanoSeconds>")]
+    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
     pub expiration_time: Option<OffsetDateTime>,
 
     /// The memo associated with the account.

--- a/sdk/rust/src/account/account_update_transaction.rs
+++ b/sdk/rust/src/account/account_update_transaction.rs
@@ -21,11 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
-use serde_with::{
-    skip_serializing_none,
-    DurationSeconds,
-    TimestampNanoSeconds,
-};
 use time::{
     Duration,
     OffsetDateTime,
@@ -57,9 +52,10 @@ pub type AccountUpdateTransaction = Transaction<AccountUpdateTransactionData>;
 // TODO: realm_id: Option<RealmId>
 // TODO: new_realm_admin_key: Option<Key>,
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct AccountUpdateTransactionData {
     /// The account ID which is being updated in this transaction.
     pub account_id: Option<AccountId>,
@@ -71,11 +67,17 @@ pub struct AccountUpdateTransactionData {
     pub receiver_signature_required: Option<bool>,
 
     /// The account is charged to extend its expiration date every this many seconds.
-    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::DurationSeconds<i64>>>")
+    )]
     pub auto_renew_period: Option<Duration>,
 
     /// The new expiration time to extend to (ignored if equal to or before the current one).
-    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::TimestampNanoSeconds>>")
+    )]
     pub expiration_time: Option<OffsetDateTime>,
 
     /// The memo associated with the account.
@@ -234,27 +236,29 @@ impl From<AccountUpdateTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use std::str::FromStr;
 
-    use assert_matches::assert_matches;
-    use time::{
-        Duration,
-        OffsetDateTime,
-    };
+        use assert_matches::assert_matches;
+        use time::{
+            Duration,
+            OffsetDateTime,
+        };
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountId,
-        AccountUpdateTransaction,
-        Key,
-        PublicKey,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountId,
+            AccountUpdateTransaction,
+            Key,
+            PublicKey,
+        };
 
-    // language=JSON
-    const ACCOUNT_UPDATE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const ACCOUNT_UPDATE_TRANSACTION_JSON: &str = r#"{
   "$type": "accountUpdate",
   "accountId": "0.0.1001",
   "key": {
@@ -270,54 +274,56 @@ mod tests {
   "declineStakingReward": false
 }"#;
 
-    const KEY: &str =
+        const KEY: &str =
         "302a300506032b6570032100d1ad76ed9b057a3d3f2ea2d03b41bcd79aeafd611f941924f0f6da528ab066fd";
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = AccountUpdateTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = AccountUpdateTransaction::new();
 
-        transaction
-            .account_id(AccountId::from(1001))
-            .expiration_time(OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?)
-            .key(PublicKey::from_str(KEY)?)
-            .receiver_signature_required(true)
-            .auto_renew_period(Duration::days(90))
-            .account_memo("An account memo")
-            .max_automatic_token_associations(256)
-            .staked_account_id(AccountId::from(1002))
-            .staked_node_id(7)
-            .decline_staking_reward(false);
+            transaction
+                .account_id(AccountId::from(1001))
+                .expiration_time(OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?)
+                .key(PublicKey::from_str(KEY)?)
+                .receiver_signature_required(true)
+                .auto_renew_period(Duration::days(90))
+                .account_memo("An account memo")
+                .max_automatic_token_associations(256)
+                .staked_account_id(AccountId::from(1002))
+                .staked_node_id(7)
+                .decline_staking_reward(false);
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, ACCOUNT_UPDATE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, ACCOUNT_UPDATE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(ACCOUNT_UPDATE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction =
+                serde_json::from_str(ACCOUNT_UPDATE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::AccountUpdate(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::AccountUpdate(transaction) => transaction);
 
-        assert_eq!(
-            data.expiration_time.unwrap(),
-            OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?
-        );
-        assert_eq!(data.receiver_signature_required.unwrap(), true);
-        assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
-        assert_eq!(data.account_memo.unwrap(), "An account memo");
-        assert_eq!(data.max_automatic_token_associations.unwrap(), 256);
-        assert_eq!(data.staked_node_id.unwrap(), 7);
-        assert_eq!(data.decline_staking_reward.unwrap(), false);
-        assert_eq!(data.account_id, Some(AccountId::from(1001)));
-        assert_eq!(data.staked_account_id, Some(AccountId::from(1002)));
+            assert_eq!(
+                data.expiration_time.unwrap(),
+                OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?
+            );
+            assert_eq!(data.receiver_signature_required.unwrap(), true);
+            assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
+            assert_eq!(data.account_memo.unwrap(), "An account memo");
+            assert_eq!(data.max_automatic_token_associations.unwrap(), 256);
+            assert_eq!(data.staked_node_id.unwrap(), 7);
+            assert_eq!(data.decline_staking_reward.unwrap(), false);
+            assert_eq!(data.account_id, Some(AccountId::from(1001)));
+            assert_eq!(data.staked_account_id, Some(AccountId::from(1002)));
 
-        let key = assert_matches!(data.key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(key, PublicKey::from_str(KEY)?);
+            let key = assert_matches!(data.key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(key, PublicKey::from_str(KEY)?);
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/account/proxy_staker.rs
+++ b/sdk/rust/src/account/proxy_staker.rs
@@ -30,8 +30,9 @@ use crate::{
 pub type AllProxyStakers = Vec<ProxyStaker>;
 
 /// Information about a single account that is proxy staking.
-#[derive(Debug, Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct ProxyStaker {
     /// The Account ID that is proxy staking.
     pub account_id: AccountId,

--- a/sdk/rust/src/contract/contract_bytecode_query.rs
+++ b/sdk/rust/src/contract/contract_bytecode_query.rs
@@ -21,11 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::query::{
@@ -43,9 +38,10 @@ use crate::{
 /// Get the runtime bytecode for a smart contract instance.
 pub type ContractBytecodeQuery = Query<ContractBytecodeQueryData>;
 
-#[skip_serializing_none]
-#[derive(Serialize, Deserialize, Default, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct ContractBytecodeQueryData {
     /// The contract for which information is requested.
     contract_id: Option<ContractId>,

--- a/sdk/rust/src/contract/contract_call_query.rs
+++ b/sdk/rust/src/contract/contract_call_query.rs
@@ -21,12 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use serde_with::base64::Base64;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::query::{
@@ -51,9 +45,10 @@ use crate::{
 ///
 pub type ContractCallQuery = Query<ContractCallQueryData>;
 
-#[skip_serializing_none]
-#[derive(Serialize, Deserialize, Default, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct ContractCallQueryData {
     /// The contract instance to call.
     pub contract_id: Option<ContractId>,
@@ -62,7 +57,7 @@ pub struct ContractCallQueryData {
     pub gas: u64,
 
     /// The function parameters as their raw bytes.
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub function_parameters: Vec<u8>,
 
     /// The sender for this transaction.

--- a/sdk/rust/src/contract/contract_call_query.rs
+++ b/sdk/rust/src/contract/contract_call_query.rs
@@ -26,10 +26,7 @@ use serde::{
     Serialize,
 };
 use serde_with::base64::Base64;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::query::{
@@ -54,7 +51,6 @@ use crate::{
 ///
 pub type ContractCallQuery = Query<ContractCallQueryData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -66,7 +62,7 @@ pub struct ContractCallQueryData {
     pub gas: u64,
 
     /// The function parameters as their raw bytes.
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub function_parameters: Vec<u8>,
 
     /// The sender for this transaction.

--- a/sdk/rust/src/contract/contract_create_transaction.rs
+++ b/sdk/rust/src/contract/contract_create_transaction.rs
@@ -27,7 +27,6 @@ use serde::{
 };
 use serde_with::base64::Base64;
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     DurationSeconds,
 };
@@ -51,12 +50,11 @@ use crate::{
 /// Start a new smart contract instance.
 pub type ContractCreateTransaction = Transaction<ContractCreateTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(default, rename_all = "camelCase")]
 pub struct ContractCreateTransactionData {
-    #[serde_as(as = "Option<Base64>")]
+    #[serde(with = "serde_with::As::<Option<Base64>>")]
     bytecode: Option<Vec<u8>>,
 
     bytecode_file_id: Option<FileId>,
@@ -67,10 +65,10 @@ pub struct ContractCreateTransactionData {
 
     initial_balance: Hbar,
 
-    #[serde_as(as = "DurationSeconds<i64>")]
+    #[serde(with = "serde_with::As::<DurationSeconds<i64>>")]
     auto_renew_period: Duration,
 
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     constructor_parameters: Vec<u8>,
 
     contract_memo: String,

--- a/sdk/rust/src/contract/contract_create_transaction.rs
+++ b/sdk/rust/src/contract/contract_create_transaction.rs
@@ -21,15 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use serde_with::base64::Base64;
-use serde_with::{
-    skip_serializing_none,
-    DurationSeconds,
-};
 use time::Duration;
 use tonic::transport::Channel;
 
@@ -50,11 +41,15 @@ use crate::{
 /// Start a new smart contract instance.
 pub type ContractCreateTransaction = Transaction<ContractCreateTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(default, rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(default, rename_all = "camelCase"))]
 pub struct ContractCreateTransactionData {
-    #[serde(with = "serde_with::As::<Option<Base64>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::base64::Base64>>")
+    )]
     bytecode: Option<Vec<u8>>,
 
     bytecode_file_id: Option<FileId>,
@@ -65,10 +60,13 @@ pub struct ContractCreateTransactionData {
 
     initial_balance: Hbar,
 
-    #[serde(with = "serde_with::As::<DurationSeconds<i64>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<serde_with::DurationSeconds<i64>>")
+    )]
     auto_renew_period: Duration,
 
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     constructor_parameters: Vec<u8>,
 
     contract_memo: String,
@@ -270,31 +268,33 @@ impl From<ContractCreateTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use std::str::FromStr;
 
-    use assert_matches::assert_matches;
-    use time::Duration;
+        use assert_matches::assert_matches;
+        use time::Duration;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountId,
-        ContractCreateTransaction,
-        FileId,
-        Hbar,
-        Key,
-        PublicKey,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountId,
+            ContractCreateTransaction,
+            FileId,
+            Hbar,
+            Key,
+            PublicKey,
+        };
 
-    // language=JSON
-    const CONTRACT_CREATE_EMPTY: &str = r#"{
+        // language=JSON
+        const CONTRACT_CREATE_EMPTY: &str = r#"{
   "$type": "contractCreate"
 }"#;
 
-    // language=JSON
-    const CONTRACT_CREATE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const CONTRACT_CREATE_TRANSACTION_JSON: &str = r#"{
   "$type": "contractCreate",
   "bytecode": "SGVsbG8sIHdvcmxkIQ==",
   "bytecodeFileId": "0.0.1001",
@@ -313,73 +313,75 @@ mod tests {
   "declineStakingReward": false
 }"#;
 
-    const ADMIN_KEY: &str =
+        const ADMIN_KEY: &str =
         "302a300506032b6570032100d1ad76ed9b057a3d3f2ea2d03b41bcd79aeafd611f941924f0f6da528ab066fd";
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = ContractCreateTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = ContractCreateTransaction::new();
 
-        transaction
-            .bytecode("Hello, world!")
-            .bytecode_file_id(FileId::from(1001))
-            .admin_key(PublicKey::from_str(ADMIN_KEY)?)
-            .gas(1000)
-            .initial_balance(Hbar::from_tinybars(1_000_000))
-            .auto_renew_period(Duration::days(90))
-            .constructor_parameters([5, 10, 15])
-            .contract_memo("A contract memo")
-            .max_automatic_token_associations(512)
-            .auto_renew_account_id(AccountId::from(1002))
-            .staked_account_id(AccountId::from(1003))
-            .staked_node_id(7)
-            .decline_staking_reward(false);
+            transaction
+                .bytecode("Hello, world!")
+                .bytecode_file_id(FileId::from(1001))
+                .admin_key(PublicKey::from_str(ADMIN_KEY)?)
+                .gas(1000)
+                .initial_balance(Hbar::from_tinybars(1_000_000))
+                .auto_renew_period(Duration::days(90))
+                .constructor_parameters([5, 10, 15])
+                .contract_memo("A contract memo")
+                .max_automatic_token_associations(512)
+                .auto_renew_account_id(AccountId::from(1002))
+                .staked_account_id(AccountId::from(1003))
+                .staked_node_id(7)
+                .decline_staking_reward(false);
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, CONTRACT_CREATE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, CONTRACT_CREATE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(CONTRACT_CREATE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction =
+                serde_json::from_str(CONTRACT_CREATE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::ContractCreate(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::ContractCreate(transaction) => transaction);
 
-        assert_eq!(data.bytecode_file_id.unwrap(), FileId::from(1001));
-        assert_eq!(data.gas, 1000);
-        assert_eq!(data.initial_balance.to_tinybars(), 1_000_000);
-        assert_eq!(data.auto_renew_period, Duration::days(90));
-        assert_eq!(data.constructor_parameters, [5, 10, 15]);
-        assert_eq!(data.contract_memo, "A contract memo");
-        assert_eq!(data.max_automatic_token_associations, 512);
-        assert_eq!(data.staked_node_id.unwrap(), 7);
-        assert_eq!(data.decline_staking_reward, false);
+            assert_eq!(data.bytecode_file_id.unwrap(), FileId::from(1001));
+            assert_eq!(data.gas, 1000);
+            assert_eq!(data.initial_balance.to_tinybars(), 1_000_000);
+            assert_eq!(data.auto_renew_period, Duration::days(90));
+            assert_eq!(data.constructor_parameters, [5, 10, 15]);
+            assert_eq!(data.contract_memo, "A contract memo");
+            assert_eq!(data.max_automatic_token_associations, 512);
+            assert_eq!(data.staked_node_id.unwrap(), 7);
+            assert_eq!(data.decline_staking_reward, false);
 
-        let bytes: Vec<u8> = "Hello, world!".into();
-        assert_eq!(data.bytecode.unwrap(), bytes);
+            let bytes: Vec<u8> = "Hello, world!".into();
+            assert_eq!(data.bytecode.unwrap(), bytes);
 
-        let admin_key =
-            assert_matches!(data.admin_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(admin_key, PublicKey::from_str(ADMIN_KEY)?);
+            let admin_key =
+                assert_matches!(data.admin_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(admin_key, PublicKey::from_str(ADMIN_KEY)?);
 
-        assert_eq!(data.auto_renew_account_id, Some(AccountId::from(1002)));
-        assert_eq!(data.staked_account_id, Some(AccountId::from(1003)));
+            assert_eq!(data.auto_renew_account_id, Some(AccountId::from(1002)));
+            assert_eq!(data.staked_account_id, Some(AccountId::from(1003)));
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize_empty() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(CONTRACT_CREATE_EMPTY)?;
+        #[test]
+        fn it_should_deserialize_empty() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(CONTRACT_CREATE_EMPTY)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::ContractCreate(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::ContractCreate(transaction) => transaction);
 
-        assert_eq!(data.auto_renew_period, Duration::days(90));
-        assert_eq!(data.decline_staking_reward, false);
+            assert_eq!(data.auto_renew_period, Duration::days(90));
+            assert_eq!(data.decline_staking_reward, false);
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/contract/contract_execute_transaction.rs
+++ b/sdk/rust/src/contract/contract_execute_transaction.rs
@@ -25,10 +25,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::transaction::{
@@ -56,7 +53,6 @@ use crate::{
 ///
 pub type ContractExecuteTransaction = Transaction<ContractExecuteTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/rust/src/contract/contract_execute_transaction.rs
+++ b/sdk/rust/src/contract/contract_execute_transaction.rs
@@ -21,11 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::transaction::{
@@ -53,9 +48,10 @@ use crate::{
 ///
 pub type ContractExecuteTransaction = Transaction<ContractExecuteTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Serialize, Deserialize, Default, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct ContractExecuteTransactionData {
     /// The contract instance to call.
     contract_id: Option<ContractId>,
@@ -135,20 +131,22 @@ impl From<ContractExecuteTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        ContractExecuteTransaction,
-        ContractId,
-        Hbar,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            ContractExecuteTransaction,
+            ContractId,
+            Hbar,
+        };
 
-    // language=JSON
-    const CONTRACT_EXECUTE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const CONTRACT_EXECUTE_TRANSACTION_JSON: &str = r#"{
   "$type": "contractExecute",
   "contractId": "0.0.1001",
   "gas": 1000,
@@ -170,36 +168,38 @@ mod tests {
   ]
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = ContractExecuteTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = ContractExecuteTransaction::new();
 
-        transaction
-            .contract_id(ContractId::from(1001))
-            .gas(1000)
-            .payable_amount(Hbar::from_tinybars(10))
-            .function_parameters("Hello, world!".into());
+            transaction
+                .contract_id(ContractId::from(1001))
+                .gas(1000)
+                .payable_amount(Hbar::from_tinybars(10))
+                .function_parameters("Hello, world!".into());
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, CONTRACT_EXECUTE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, CONTRACT_EXECUTE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(CONTRACT_EXECUTE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction =
+                serde_json::from_str(CONTRACT_EXECUTE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::ContractExecute(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::ContractExecute(transaction) => transaction);
 
-        assert_eq!(data.contract_id.unwrap(), ContractId::from(1001));
-        assert_eq!(data.gas, 1000);
-        assert_eq!(data.payable_amount.to_tinybars(), 10);
+            assert_eq!(data.contract_id.unwrap(), ContractId::from(1001));
+            assert_eq!(data.gas, 1000);
+            assert_eq!(data.payable_amount.to_tinybars(), 10);
 
-        let bytes: Vec<u8> = "Hello, world!".into();
-        assert_eq!(data.function_parameters, bytes);
+            let bytes: Vec<u8> = "Hello, world!".into();
+            assert_eq!(data.function_parameters, bytes);
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/contract/contract_function_result.rs
+++ b/sdk/rust/src/contract/contract_function_result.rs
@@ -24,7 +24,6 @@ use serde::{
     Serialize,
 };
 use serde_with::base64::Base64;
-use serde_with::serde_as;
 
 use crate::{
     AccountId,
@@ -34,7 +33,7 @@ use crate::{
 
 // TODO: log info
 /// The result returned by a call to a smart contract function.
-#[serde_as]
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ContractFunctionResult {
@@ -45,14 +44,14 @@ pub struct ContractFunctionResult {
     pub evm_address: Option<ContractId>,
 
     /// The raw bytes returned by the function.
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub bytes: Vec<u8>,
 
     /// Message if there was an error during smart contract execution.
     pub error_message: Option<String>,
 
     /// Bloom filter for record.
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub bloom: Vec<u8>,
 
     /// Units of gas used to execute contract.
@@ -65,7 +64,7 @@ pub struct ContractFunctionResult {
     pub hbar_amount: u64,
 
     /// The parameters passed into the contract call.
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub contract_function_parameters_bytes: Vec<u8>,
 
     /// The account that is the "sender." If not present it is the accountId from the transactionId.

--- a/sdk/rust/src/contract/contract_function_result.rs
+++ b/sdk/rust/src/contract/contract_function_result.rs
@@ -19,11 +19,6 @@
  */
 
 use hedera_proto::services;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use serde_with::base64::Base64;
 
 use crate::{
     AccountId,
@@ -34,8 +29,9 @@ use crate::{
 // TODO: log info
 /// The result returned by a call to a smart contract function.
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct ContractFunctionResult {
     /// The smart contract instance whose function was called.
     pub contract_id: ContractId,
@@ -44,14 +40,14 @@ pub struct ContractFunctionResult {
     pub evm_address: Option<ContractId>,
 
     /// The raw bytes returned by the function.
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub bytes: Vec<u8>,
 
     /// Message if there was an error during smart contract execution.
     pub error_message: Option<String>,
 
     /// Bloom filter for record.
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub bloom: Vec<u8>,
 
     /// Units of gas used to execute contract.
@@ -64,7 +60,7 @@ pub struct ContractFunctionResult {
     pub hbar_amount: u64,
 
     /// The parameters passed into the contract call.
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub contract_function_parameters_bytes: Vec<u8>,
 
     /// The account that is the "sender." If not present it is the accountId from the transactionId.

--- a/sdk/rust/src/contract/contract_id.rs
+++ b/sdk/rust/src/contract/contract_id.rs
@@ -27,10 +27,6 @@ use std::fmt::{
 use std::str::FromStr;
 
 use hedera_proto::services;
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
 
 use crate::{
     EntityId,
@@ -40,7 +36,8 @@ use crate::{
 
 // TODO: checksum
 /// A unique identifier for a smart contract on Hedera.
-#[derive(SerializeDisplay, DeserializeFromStr, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct ContractId {
     /// A non-negative number identifying the shard containing this contract instance.
     pub shard: u64,

--- a/sdk/rust/src/contract/contract_info.rs
+++ b/sdk/rust/src/contract/contract_info.rs
@@ -24,7 +24,6 @@ use serde::{
     Deserialize,
     Serialize,
 };
-use serde_with::serde_as;
 use time::{
     Duration,
     OffsetDateTime,
@@ -41,7 +40,7 @@ use crate::{
 
 // TODO: staking_info
 /// Current information on a smart contract instance.
-#[serde_as]
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContractInfo {
     /// ID of the contract instance, in the format used by transactions.

--- a/sdk/rust/src/contract/contract_info.rs
+++ b/sdk/rust/src/contract/contract_info.rs
@@ -20,10 +20,6 @@
 
 use hedera_proto::services;
 use prost::Message;
-use serde::{
-    Deserialize,
-    Serialize,
-};
 use time::{
     Duration,
     OffsetDateTime,
@@ -41,7 +37,9 @@ use crate::{
 // TODO: staking_info
 /// Current information on a smart contract instance.
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+// fixme: `renameAll = "camelCase"`
 pub struct ContractInfo {
     /// ID of the contract instance, in the format used by transactions.
     pub contract_id: ContractId,

--- a/sdk/rust/src/contract/contract_info_query.rs
+++ b/sdk/rust/src/contract/contract_info_query.rs
@@ -21,11 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::query::{
@@ -43,9 +38,10 @@ use crate::{
 /// Get information about a smart contract instance.
 pub type ContractInfoQuery = Query<ContractInfoQueryData>;
 
-#[skip_serializing_none]
-#[derive(Serialize, Deserialize, Default, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct ContractInfoQueryData {
     /// The contract for which information is requested.
     contract_id: Option<ContractId>,

--- a/sdk/rust/src/contract/contract_update_transaction.rs
+++ b/sdk/rust/src/contract/contract_update_transaction.rs
@@ -26,7 +26,6 @@ use serde::{
     Serialize,
 };
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     DurationSeconds,
     TimestampNanoSeconds,
@@ -53,19 +52,18 @@ use crate::{
 /// Updates the fields of a smart contract to the given values.
 pub type ContractUpdateTransaction = Transaction<ContractUpdateTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[serde(default, rename_all = "camelCase")]
 pub struct ContractUpdateTransactionData {
     contract_id: Option<ContractId>,
 
-    #[serde_as(as = "Option<TimestampNanoSeconds>")]
+    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
     expiration_time: Option<OffsetDateTime>,
 
     admin_key: Option<Key>,
 
-    #[serde_as(as = "Option<DurationSeconds<i64>>")]
+    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
     auto_renew_period: Option<Duration>,
 
     contract_memo: Option<String>,

--- a/sdk/rust/src/entity_id.rs
+++ b/sdk/rust/src/entity_id.rs
@@ -27,15 +27,12 @@ use std::fmt::{
 use std::str::FromStr;
 
 use itertools::Itertools;
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
 
 use crate::Error;
 
 /// The ID of an entity on the Hedera network.
-#[derive(SerializeDisplay, DeserializeFromStr, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct EntityId {
     /// A non-negative number identifying the shard containing this entity.
     pub shard: u64,

--- a/sdk/rust/src/ethereum_transaction.rs
+++ b/sdk/rust/src/ethereum_transaction.rs
@@ -22,7 +22,6 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use serde_with::base64::Base64;
-use serde_with::serde_as;
 use tonic::transport::Channel;
 
 use crate::transaction::{
@@ -39,12 +38,11 @@ use crate::{
 /// Submit an Ethereum transaction.
 pub type EthereumTransaction = Transaction<EthereumTransactionData>;
 
-#[serde_as]
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EthereumTransactionData {
     /// The raw Ethereum transaction (RLP encoded type 0, 1, and 2).
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub ethereum_data: Vec<u8>,
 
     /// For large transactions (for example contract create) this should be used to

--- a/sdk/rust/src/ethereum_transaction.rs
+++ b/sdk/rust/src/ethereum_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
-use serde_with::base64::Base64;
 use tonic::transport::Channel;
 
 use crate::transaction::{
@@ -38,11 +37,12 @@ use crate::{
 /// Submit an Ethereum transaction.
 pub type EthereumTransaction = Transaction<EthereumTransactionData>;
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct EthereumTransactionData {
     /// The raw Ethereum transaction (RLP encoded type 0, 1, and 2).
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub ethereum_data: Vec<u8>,
 
     /// For large transactions (for example contract create) this should be used to

--- a/sdk/rust/src/ffi/execute.rs
+++ b/sdk/rust/src/ffi/execute.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 
 #[derive(serde::Deserialize)]
-#[serde(untagged)]
+#[cfg_attr(feature = "ffi", serde(untagged))]
 enum AnyRequest {
     Transaction(Box<AnyTransaction>),
     Query(Box<AnyQuery>),

--- a/sdk/rust/src/file/file_append_transaction.rs
+++ b/sdk/rust/src/file/file_append_transaction.rs
@@ -22,10 +22,7 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::file_service_client::FileServiceClient;
 use serde_with::base64::Base64;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -45,7 +42,6 @@ use crate::{
 ///
 pub type FileAppendTransaction = Transaction<FileAppendTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -54,7 +50,7 @@ pub struct FileAppendTransactionData {
     file_id: Option<FileId>,
 
     /// The bytes that will be appended to the end of the specified file.
-    #[serde_as(as = "Option<Base64>")]
+    #[serde(with = "serde_with::As::<Option<Base64>>")]
     contents: Option<Vec<u8>>,
 }
 

--- a/sdk/rust/src/file/file_append_transaction.rs
+++ b/sdk/rust/src/file/file_append_transaction.rs
@@ -21,8 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::file_service_client::FileServiceClient;
-use serde_with::base64::Base64;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -42,15 +40,19 @@ use crate::{
 ///
 pub type FileAppendTransaction = Transaction<FileAppendTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct FileAppendTransactionData {
     /// The file to which the bytes will be appended.
     file_id: Option<FileId>,
 
     /// The bytes that will be appended to the end of the specified file.
-    #[serde(with = "serde_with::As::<Option<Base64>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::base64::Base64>>")
+    )]
     contents: Option<Vec<u8>>,
 }
 
@@ -102,50 +104,53 @@ impl From<FileAppendTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        FileAppendTransaction,
-        FileId,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            FileAppendTransaction,
+            FileId,
+        };
 
-    // language=JSON
-    const FILE_APPEND_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const FILE_APPEND_TRANSACTION_JSON: &str = r#"{
   "$type": "fileAppend",
   "fileId": "0.0.1001",
   "contents": "QXBwZW5kaW5nIHRoZXNlIGJ5dGVzIHRvIGZpbGUgMTAwMQ=="
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = FileAppendTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = FileAppendTransaction::new();
 
-        transaction
-            .file_id(FileId::from(1001))
-            .contents("Appending these bytes to file 1001".into());
+            transaction
+                .file_id(FileId::from(1001))
+                .contents("Appending these bytes to file 1001".into());
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, FILE_APPEND_TRANSACTION_JSON);
+            assert_eq!(transaction_json, FILE_APPEND_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(FILE_APPEND_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(FILE_APPEND_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::FileAppend(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::FileAppend(transaction) => transaction);
 
-        assert_eq!(data.file_id.unwrap(), FileId::from(1001));
+            assert_eq!(data.file_id.unwrap(), FileId::from(1001));
 
-        let bytes: Vec<u8> = "Appending these bytes to file 1001".into();
-        assert_eq!(data.contents.unwrap(), bytes);
+            let bytes: Vec<u8> = "Appending these bytes to file 1001".into();
+            assert_eq!(data.contents.unwrap(), bytes);
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/file/file_contents_query.rs
+++ b/sdk/rust/src/file/file_contents_query.rs
@@ -38,8 +38,9 @@ use crate::{
 /// Get the contents of a file.
 pub type FileContentsQuery = Query<FileContentsQueryData>;
 
-#[derive(Clone, Default, serde::Serialize, serde::Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct FileContentsQueryData {
     /// The file ID for which contents are requested.
     file_id: Option<FileId>,

--- a/sdk/rust/src/file/file_contents_response.rs
+++ b/sdk/rust/src/file/file_contents_response.rs
@@ -19,11 +19,6 @@
  */
 
 use hedera_proto::services;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use serde_with::base64::Base64;
 
 use crate::{
     FileId,
@@ -32,15 +27,16 @@ use crate::{
 
 /// Response from [`FileContentsQuery`][crate::FileContentsQuery].
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct FileContentsResponse {
     /// The file ID of the file whose contents are being returned.
     pub file_id: FileId,
 
     // TODO: .contents vs .bytes (?)
     /// The bytes contained in the file.
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub contents: Vec<u8>,
 }
 

--- a/sdk/rust/src/file/file_contents_response.rs
+++ b/sdk/rust/src/file/file_contents_response.rs
@@ -24,7 +24,6 @@ use serde::{
     Serialize,
 };
 use serde_with::base64::Base64;
-use serde_with::serde_as;
 
 use crate::{
     FileId,
@@ -32,7 +31,7 @@ use crate::{
 };
 
 /// Response from [`FileContentsQuery`][crate::FileContentsQuery].
-#[serde_as]
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FileContentsResponse {
@@ -41,7 +40,7 @@ pub struct FileContentsResponse {
 
     // TODO: .contents vs .bytes (?)
     /// The bytes contained in the file.
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub contents: Vec<u8>,
 }
 

--- a/sdk/rust/src/file/file_create_transaction.rs
+++ b/sdk/rust/src/file/file_create_transaction.rs
@@ -23,7 +23,6 @@ use hedera_proto::services;
 use hedera_proto::services::file_service_client::FileServiceClient;
 use serde_with::base64::Base64;
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     TimestampNanoSeconds,
 };
@@ -49,7 +48,6 @@ use crate::{
 /// Create a new file, containing the given contents.
 pub type FileCreateTransaction = Transaction<FileCreateTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -64,11 +62,11 @@ pub struct FileCreateTransactionData {
     keys: Option<Vec<Key>>,
 
     /// The bytes that are to be the contents of the file.
-    #[serde_as(as = "Option<Base64>")]
+    #[serde(with = "serde_with::As::<Option<Base64>>")]
     contents: Option<Vec<u8>>,
 
     /// The time at which this file should expire.
-    #[serde_as(as = "Option<TimestampNanoSeconds>")]
+    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
     expiration_time: Option<OffsetDateTime>,
 }
 

--- a/sdk/rust/src/file/file_id.rs
+++ b/sdk/rust/src/file/file_id.rs
@@ -27,10 +27,6 @@ use std::fmt::{
 use std::str::FromStr;
 
 use hedera_proto::services;
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
 
 use crate::{
     EntityId,
@@ -40,7 +36,8 @@ use crate::{
 };
 
 /// The unique identifier for a file on Hedera.
-#[derive(SerializeDisplay, DeserializeFromStr, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct FileId {
     /// The shard number.
     pub shard: u64,

--- a/sdk/rust/src/file/file_info.rs
+++ b/sdk/rust/src/file/file_info.rs
@@ -30,8 +30,9 @@ use crate::{
 };
 
 /// Response from [`FileInfoQuery`][crate::FileInfoQuery].
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct FileInfo {
     /// The file ID of the file for which information is requested.
     pub file_id: FileId,

--- a/sdk/rust/src/file/file_info_query.rs
+++ b/sdk/rust/src/file/file_info_query.rs
@@ -38,8 +38,9 @@ use crate::{
 /// Get all the information about a file.
 pub type FileInfoQuery = Query<FileInfoQueryData>;
 
-#[derive(Default, Clone, serde::Serialize, serde::Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct FileInfoQueryData {
     file_id: Option<FileId>,
 }

--- a/sdk/rust/src/file/file_update_transaction.rs
+++ b/sdk/rust/src/file/file_update_transaction.rs
@@ -23,7 +23,6 @@ use hedera_proto::services;
 use hedera_proto::services::file_service_client::FileServiceClient;
 use serde_with::base64::Base64;
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     TimestampNanoSeconds,
 };
@@ -51,7 +50,6 @@ use crate::{
 ///
 pub type FileUpdateTransaction = Transaction<FileUpdateTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -68,11 +66,11 @@ pub struct FileUpdateTransactionData {
     keys: Option<Vec<Key>>,
 
     /// The bytes that are to be the contents of the file.
-    #[serde_as(as = "Option<Base64>")]
+    #[serde(with = "serde_with::As::<Option<Base64>>")]
     contents: Option<Vec<u8>>,
 
     /// The time at which this file should expire.
-    #[serde_as(as = "Option<TimestampNanoSeconds>")]
+    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
     expiration_time: Option<OffsetDateTime>,
 }
 

--- a/sdk/rust/src/file/file_update_transaction.rs
+++ b/sdk/rust/src/file/file_update_transaction.rs
@@ -21,11 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::file_service_client::FileServiceClient;
-use serde_with::base64::Base64;
-use serde_with::{
-    skip_serializing_none,
-    TimestampNanoSeconds,
-};
 use time::OffsetDateTime;
 use tonic::transport::Channel;
 
@@ -50,9 +45,10 @@ use crate::{
 ///
 pub type FileUpdateTransaction = Transaction<FileUpdateTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct FileUpdateTransactionData {
     /// The file ID which is being updated in this transaction.
     file_id: Option<FileId>,
@@ -66,11 +62,17 @@ pub struct FileUpdateTransactionData {
     keys: Option<Vec<Key>>,
 
     /// The bytes that are to be the contents of the file.
-    #[serde(with = "serde_with::As::<Option<Base64>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::base64::Base64>>")
+    )]
     contents: Option<Vec<u8>>,
 
     /// The time at which this file should expire.
-    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::TimestampNanoSeconds>>")
+    )]
     expiration_time: Option<OffsetDateTime>,
 }
 
@@ -153,24 +155,26 @@ impl From<FileUpdateTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use std::str::FromStr;
 
-    use assert_matches::assert_matches;
-    use time::OffsetDateTime;
+        use assert_matches::assert_matches;
+        use time::OffsetDateTime;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        FileId,
-        FileUpdateTransaction,
-        Key,
-        PublicKey,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            FileId,
+            FileUpdateTransaction,
+            Key,
+            PublicKey,
+        };
 
-    // language=JSON
-    const FILE_UPDATE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const FILE_UPDATE_TRANSACTION_JSON: &str = r#"{
   "$type": "fileUpdate",
   "fileId": "0.0.1001",
   "fileMemo": "File memo",
@@ -183,47 +187,47 @@ mod tests {
   "expirationTime": 1656352251277559886
 }"#;
 
-    const SIGN_KEY: &str =
+        const SIGN_KEY: &str =
         "302a300506032b6570032100d1ad76ed9b057a3d3f2ea2d03b41bcd79aeafd611f941924f0f6da528ab066fd";
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = FileUpdateTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = FileUpdateTransaction::new();
 
-        transaction
-            .file_id(FileId::from(1001))
-            .file_memo("File memo")
-            .keys([PublicKey::from_str(SIGN_KEY)?])
-            .contents("Hello, world!".into())
-            .expiration_time(OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?);
+            transaction
+                .file_id(FileId::from(1001))
+                .file_memo("File memo")
+                .keys([PublicKey::from_str(SIGN_KEY)?])
+                .contents("Hello, world!".into())
+                .expiration_time(OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?);
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, FILE_UPDATE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, FILE_UPDATE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(FILE_UPDATE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(FILE_UPDATE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::FileUpdate(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::FileUpdate(transaction) => transaction);
 
-        assert_eq!(data.file_id.unwrap(), FileId::from(1001));
-        assert_eq!(data.file_memo.unwrap(), "File memo");
-        assert_eq!(
-            data.expiration_time.unwrap(),
-            OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?
-        );
+            assert_eq!(data.file_id.unwrap(), FileId::from(1001));
+            assert_eq!(data.file_memo.unwrap(), "File memo");
+            assert_eq!(
+                data.expiration_time.unwrap(),
+                OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?
+            );
 
-        let sign_key =
-            assert_matches!(data.keys.unwrap().remove(0), Key::Single(public_key) => public_key);
-        assert_eq!(sign_key, PublicKey::from_str(SIGN_KEY)?);
+            let sign_key = assert_matches!(data.keys.unwrap().remove(0), Key::Single(public_key) => public_key);
+            assert_eq!(sign_key, PublicKey::from_str(SIGN_KEY)?);
 
-        let bytes: Vec<u8> = "Hello, world!".into();
-        assert_eq!(data.contents.unwrap(), bytes);
+            let bytes: Vec<u8> = "Hello, world!".into();
+            assert_eq!(data.contents.unwrap(), bytes);
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/hbar.rs
+++ b/sdk/rust/src/hbar.rs
@@ -3,19 +3,9 @@ use std::fmt::{
     Display,
     Formatter,
 };
+use std::ops;
 use std::str::FromStr;
 
-use derive_more::{
-    Add,
-    AddAssign,
-    Div,
-    DivAssign,
-    Mul,
-    MulAssign,
-    Neg,
-    Sub,
-    SubAssign,
-};
 use rust_decimal::prelude::*;
 use serde::{
     Deserialize,
@@ -124,27 +114,7 @@ impl FromStr for HbarUnit {
 }
 
 /// A quantity of `hbar`.
-#[derive(
-    Serialize,
-    Deserialize,
-    Default,
-    Copy,
-    Clone,
-    Hash,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-    Add,
-    Sub,
-    Mul,
-    Div,
-    Neg,
-    AddAssign,
-    SubAssign,
-    MulAssign,
-    DivAssign,
-)]
+#[derive(Serialize, Deserialize, Default, Copy, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Hbar(i64);
 
 impl Hbar {
@@ -278,6 +248,82 @@ impl FromStr for Hbar {
         let amount: Decimal = amount.parse().map_err(Error::basic_parse)?;
         let unit = HbarUnit::from_str(unit)?;
         Ok(Hbar::from_unit(amount, unit))
+    }
+}
+
+impl ops::Neg for Hbar {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self(-self.0)
+    }
+}
+
+impl ops::Add for Hbar {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl ops::AddAssign for Hbar {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0
+    }
+}
+
+impl ops::Sub for Hbar {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
+impl ops::SubAssign for Hbar {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0 -= rhs.0
+    }
+}
+
+impl<T> ops::Mul<T> for Hbar
+where
+    i64: ops::Mul<T, Output = i64>,
+{
+    type Output = Self;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        Self(self.0 * rhs)
+    }
+}
+
+impl<T> ops::MulAssign<T> for Hbar
+where
+    i64: ops::MulAssign<T>,
+{
+    fn mul_assign(&mut self, rhs: T) {
+        self.0 *= rhs
+    }
+}
+
+impl<T> ops::Div<T> for Hbar
+where
+    i64: ops::Div<T, Output = i64>,
+{
+    type Output = Self;
+
+    fn div(self, rhs: T) -> Self::Output {
+        Self(self.0 / rhs)
+    }
+}
+
+impl<T> ops::DivAssign<T> for Hbar
+where
+    i64: ops::DivAssign<T>,
+{
+    fn div_assign(&mut self, rhs: T) {
+        self.0 /= rhs
     }
 }
 

--- a/sdk/rust/src/hbar.rs
+++ b/sdk/rust/src/hbar.rs
@@ -7,14 +7,6 @@ use std::ops;
 use std::str::FromStr;
 
 use rust_decimal::prelude::*;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
 
 use crate::Error;
 
@@ -25,7 +17,7 @@ pub type Tinybar = i64;
 ///
 /// See the [Hedera Documentation](https://docs.hedera.com/guides/docs/sdks/hbars#hbar-units).
 #[repr(i64)]
-#[derive(Debug, SerializeDisplay, Copy, DeserializeFromStr, Hash, PartialEq, Eq, Clone)]
+#[derive(Debug, Copy, Hash, PartialEq, Eq, Clone)]
 pub enum HbarUnit {
     /// The atomic (smallest) unit of [`Hbar`], used natively by the Hedera network.
     ///
@@ -114,7 +106,8 @@ impl FromStr for HbarUnit {
 }
 
 /// A quantity of `hbar`.
-#[derive(Serialize, Deserialize, Default, Copy, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Default, Copy, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
 pub struct Hbar(i64);
 
 impl Hbar {

--- a/sdk/rust/src/key/key.rs
+++ b/sdk/rust/src/key/key.rs
@@ -29,8 +29,9 @@ use crate::{
 };
 
 /// Any method that can be used to authorize an operation on Hedera.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub enum Key {
     // todo(sr): not happy with any of these (fix before merge)
     /// A single public key.

--- a/sdk/rust/src/key/public_key/mod.rs
+++ b/sdk/rust/src/key/public_key/mod.rs
@@ -41,10 +41,6 @@ use pkcs8::der::{
     Encode,
 };
 use prost::Message;
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
 
 use crate::key::private_key::ED25519_OID;
 use crate::protobuf::ToProtobuf;
@@ -58,7 +54,8 @@ use crate::{
 mod tests;
 
 /// A public key on the Hedera network.
-#[derive(Clone, Eq, Copy, Hash, PartialEq, SerializeDisplay, DeserializeFromStr)]
+#[derive(Clone, Eq, Copy, Hash, PartialEq)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct PublicKey(PublicKeyData);
 
 #[derive(Clone, Copy)]

--- a/sdk/rust/src/ledger_id.rs
+++ b/sdk/rust/src/ledger_id.rs
@@ -6,11 +6,6 @@ use std::fmt::{
 };
 use std::str::FromStr;
 
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
-
 use crate::Error;
 
 // todo: use `Box<[u8]>` (16 bytes on cpus with 64 bit pointers)
@@ -18,7 +13,8 @@ use crate::Error;
 // `Other` would be `Box<[u8]>`, but nothing else would have an alloc, the whole struct would be 24 bytes on x86-64,
 // wouldn't allocate 99.99% of the time, and could be const constructable in 99.999% of cases.
 /// The ID of a Hedera Ledger.
-#[derive(Eq, PartialEq, Clone, SerializeDisplay, DeserializeFromStr)]
+#[derive(Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct LedgerId(Vec<u8>);
 
 impl LedgerId {

--- a/sdk/rust/src/mirror_query/any.rs
+++ b/sdk/rust/src/mirror_query/any.rs
@@ -23,12 +23,6 @@ use hedera_proto::{
     mirror,
     services,
 };
-use serde::{
-    Deserialize,
-    Deserializer,
-    Serialize,
-    Serializer,
-};
 use tonic::transport::Channel;
 use tonic::{
     Code,
@@ -49,8 +43,9 @@ use crate::{
 /// Represents any possible query to the mirror network.
 pub type AnyMirrorQuery = MirrorQuery<AnyMirrorQueryData>;
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
-#[serde(rename_all = "camelCase", tag = "$type")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase", tag = "$type"))]
 pub enum AnyMirrorQueryData {
     NodeAddressBook(NodeAddressBookQueryData),
     TopicMessage(TopicMessageQueryData),
@@ -59,8 +54,9 @@ pub enum AnyMirrorQueryData {
 /// Represents the response of any possible query to the mirror network.
 pub type AnyMirrorQueryResponse = Vec<AnyMirrorQueryMessage>;
 
-#[derive(Debug, serde::Serialize, Clone)]
-#[serde(rename_all = "camelCase", tag = "$type")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase", tag = "$type"))]
 pub enum AnyMirrorQueryMessage {
     NodeAddressBook(NodeAddress),
     TopicMessage(TopicMessage),
@@ -142,19 +138,21 @@ impl FromProtobuf<AnyMirrorQueryGrpcMessage> for AnyMirrorQueryMessage {
 //  we create a proxy type that has the same layout but is only for AnyMirrorQueryData and does
 //  derive(Deserialize).
 
-#[derive(serde::Deserialize, serde::Serialize)]
+#[cfg(feature = "ffi")]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
 struct AnyMirrorQueryProxy {
-    #[serde(flatten)]
+    #[cfg_attr(feature = "ffi", serde(flatten))]
     data: AnyMirrorQueryData,
 }
 
-impl<D> Serialize for MirrorQuery<D>
+#[cfg(feature = "ffi")]
+impl<D> serde::Serialize for MirrorQuery<D>
 where
     D: MirrorQuerySubscribe,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         // TODO: remove the clones, should be possible with Cows
 
@@ -162,12 +160,13 @@ where
     }
 }
 
-impl<'de> Deserialize<'de> for AnyMirrorQuery {
+#[cfg(feature = "ffi")]
+impl<'de> serde::Deserialize<'de> for AnyMirrorQuery {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde::Deserializer<'de>,
     {
-        <AnyMirrorQueryProxy as Deserialize>::deserialize(deserializer)
+        <AnyMirrorQueryProxy as serde::Deserialize>::deserialize(deserializer)
             .map(|query| Self { data: query.data })
     }
 }

--- a/sdk/rust/src/network_version_info.rs
+++ b/sdk/rust/src/network_version_info.rs
@@ -28,8 +28,9 @@ use crate::{
 };
 
 /// Versions of Hedera Services, and the protobuf schema.
-#[derive(Debug, Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct NetworkVersionInfo {
     /// Version of the protobuf schema in use by the network.
     pub protobuf_version: SemanticVersion,

--- a/sdk/rust/src/network_version_info_query.rs
+++ b/sdk/rust/src/network_version_info_query.rs
@@ -37,8 +37,9 @@ use crate::{
 ///
 pub type NetworkVersionInfoQuery = Query<NetworkVersionInfoQueryData>;
 
-#[derive(Default, Clone, serde::Serialize, serde::Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct NetworkVersionInfoQueryData {}
 
 impl From<NetworkVersionInfoQueryData> for AnyQueryData {

--- a/sdk/rust/src/node_address.rs
+++ b/sdk/rust/src/node_address.rs
@@ -21,7 +21,6 @@
 use std::net::SocketAddrV4;
 
 use hedera_proto::services;
-use serde_with::base64::Base64;
 
 use crate::{
     AccountId,
@@ -30,14 +29,15 @@ use crate::{
 
 /// The data about a node, including its service endpoints and the Hedera account to be paid for
 /// services provided by the node (that is, queries answered and transactions submitted.).
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct NodeAddress {
     /// A non-sequential, unique, static identifier for the node
     pub node_id: u64,
 
     /// The node's X509 RSA public key used to sign stream files.
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub rsa_public_key: Vec<u8>,
 
     /// The account to be paid for queries and transactions sent to this node.
@@ -50,7 +50,7 @@ pub struct NodeAddress {
     /// the UTF-8 NFKD encoding of the node's TLS cert in PEM format.
     ///
     /// Its value can be used to verify the node's certificate it presents during TLS negotiations.
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub tls_certificate_hash: Vec<u8>,
 
     /// A node's service IP addresses and ports.

--- a/sdk/rust/src/node_address.rs
+++ b/sdk/rust/src/node_address.rs
@@ -22,7 +22,6 @@ use std::net::SocketAddrV4;
 
 use hedera_proto::services;
 use serde_with::base64::Base64;
-use serde_with::serde_as;
 
 use crate::{
     AccountId,
@@ -31,7 +30,6 @@ use crate::{
 
 /// The data about a node, including its service endpoints and the Hedera account to be paid for
 /// services provided by the node (that is, queries answered and transactions submitted.).
-#[serde_as]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeAddress {
@@ -39,7 +37,7 @@ pub struct NodeAddress {
     pub node_id: u64,
 
     /// The node's X509 RSA public key used to sign stream files.
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub rsa_public_key: Vec<u8>,
 
     /// The account to be paid for queries and transactions sent to this node.
@@ -52,7 +50,7 @@ pub struct NodeAddress {
     /// the UTF-8 NFKD encoding of the node's TLS cert in PEM format.
     ///
     /// Its value can be used to verify the node's certificate it presents during TLS negotiations.
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub tls_certificate_hash: Vec<u8>,
 
     /// A node's service IP addresses and ports.

--- a/sdk/rust/src/node_address_book_query.rs
+++ b/sdk/rust/src/node_address_book_query.rs
@@ -42,8 +42,9 @@ use crate::{
 /// The nodes are returned in ascending order by node ID.
 pub type NodeAddressBookQuery = MirrorQuery<NodeAddressBookQueryData>;
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(default, rename_all = "camelCase"))]
 pub struct NodeAddressBookQueryData {
     /// The ID of the address book file on the network.
     /// Can either be `0.0.101` or `0.0.102`. Defaults to `0.0.102`.

--- a/sdk/rust/src/query/execute.rs
+++ b/sdk/rust/src/query/execute.rs
@@ -22,8 +22,6 @@ use std::fmt::Debug;
 
 use async_trait::async_trait;
 use hedera_proto::services;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use tonic::transport::Channel;
 
 use crate::execute::Execute;
@@ -44,9 +42,7 @@ use crate::{
 
 /// Describes a specific query that can be executed on the Hedera network.
 #[async_trait]
-pub trait QueryExecute:
-    Sync + Send + Into<AnyQueryData> + Clone + Debug + Serialize + DeserializeOwned + ToQueryProtobuf
-{
+pub trait QueryExecute: Sync + Send + Into<AnyQueryData> + Clone + Debug + ToQueryProtobuf {
     type Response: FromProtobuf<services::response::Response>;
 
     /// Returns `true` if this query requires a payment to be submitted.

--- a/sdk/rust/src/query/payment_transaction.rs
+++ b/sdk/rust/src/query/payment_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::transaction::{
@@ -39,9 +38,10 @@ use crate::{
 
 pub type PaymentTransaction = Transaction<PaymentTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct PaymentTransactionData {
     pub(crate) amount: Option<Hbar>,
     pub(crate) max_amount: Option<Hbar>,

--- a/sdk/rust/src/schedule/schedule_create_transaction.rs
+++ b/sdk/rust/src/schedule/schedule_create_transaction.rs
@@ -25,10 +25,6 @@ use hedera_proto::services::{
     schedulable_transaction_body,
     transaction_body,
 };
-use serde::{
-    Deserialize,
-    Serialize,
-};
 use time::OffsetDateTime;
 use tonic::transport::Channel;
 
@@ -56,8 +52,9 @@ use crate::{
 ///
 pub type ScheduleCreateTransaction = Transaction<ScheduleCreateTransactionData>;
 
-#[derive(Serialize, Default, Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct ScheduleCreateTransactionData {
     scheduled_transaction: Option<SchedulableTransactionBody>,
 
@@ -72,16 +69,17 @@ pub struct ScheduleCreateTransactionData {
     wait_for_expiry: bool,
 }
 
-#[derive(Serialize, Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 struct SchedulableTransactionBody {
-    #[serde(flatten)]
+    #[cfg_attr(feature = "ffi", serde(flatten))]
     data: Box<AnyTransactionData>,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     max_transaction_fee: Option<Hbar>,
 
-    #[serde(default, skip_serializing_if = "String::is_empty")]
+    #[cfg_attr(feature = "ffi", serde(default, skip_serializing_if = "String::is_empty"))]
     transaction_memo: String,
 }
 

--- a/sdk/rust/src/schedule/schedule_delete_transaction.rs
+++ b/sdk/rust/src/schedule/schedule_delete_transaction.rs
@@ -21,10 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::schedule_service_client::ScheduleServiceClient;
-use serde::{
-    Deserialize,
-    Serialize,
-};
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -45,7 +41,8 @@ use crate::{
 /// receive any additional signing keys, nor will it be executed.
 pub type ScheduleDeleteTransaction = Transaction<ScheduleDeleteTransactionData>;
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScheduleDeleteTransactionData {
     schedule_id: Option<ScheduleId>,
 }

--- a/sdk/rust/src/schedule/schedule_id.rs
+++ b/sdk/rust/src/schedule/schedule_id.rs
@@ -27,10 +27,6 @@ use std::fmt::{
 use std::str::FromStr;
 
 use hedera_proto::services;
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
 
 use crate::{
     EntityId,
@@ -39,7 +35,8 @@ use crate::{
 };
 
 /// The unique identifier for a scheduled transaction on Hedera.
-#[derive(SerializeDisplay, DeserializeFromStr, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 #[repr(C)]
 pub struct ScheduleId {
     /// A non-negative number identifying the shard containing this scheduled transaction.

--- a/sdk/rust/src/schedule/schedule_info.rs
+++ b/sdk/rust/src/schedule/schedule_info.rs
@@ -20,10 +20,6 @@
 
 use hedera_proto::services;
 use prost::Message;
-use serde::{
-    Deserialize,
-    Serialize,
-};
 use time::OffsetDateTime;
 
 use crate::protobuf::ToProtobuf;
@@ -38,7 +34,8 @@ use crate::{
 
 // TODO: scheduled_transaction
 /// Response from [`ScheduleInfoQuery`][crate::ScheduleInfoQuery].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScheduleInfo {
     /// The ID of the schedule for which information is requested.
     pub schedule_id: ScheduleId,

--- a/sdk/rust/src/schedule/schedule_info_query.rs
+++ b/sdk/rust/src/schedule/schedule_info_query.rs
@@ -38,8 +38,9 @@ use crate::{
 /// Get all the information about a schedule.
 pub type ScheduleInfoQuery = Query<ScheduleInfoQueryData>;
 
-#[derive(Default, Clone, serde::Serialize, serde::Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct ScheduleInfoQueryData {
     schedule_id: Option<ScheduleId>,
 }

--- a/sdk/rust/src/schedule/schedule_sign_transaction.rs
+++ b/sdk/rust/src/schedule/schedule_sign_transaction.rs
@@ -21,10 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::schedule_service_client::ScheduleServiceClient;
-use serde::{
-    Deserialize,
-    Serialize,
-};
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -43,7 +39,9 @@ use crate::{
 /// Adds zero or more signing keys to a schedule.
 pub type ScheduleSignTransaction = Transaction<ScheduleSignTransactionData>;
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+// fixme: `rename_all = "camelCase"`
 pub struct ScheduleSignTransactionData {
     schedule_id: Option<ScheduleId>,
 }

--- a/sdk/rust/src/semantic_version/mod.rs
+++ b/sdk/rust/src/semantic_version/mod.rs
@@ -34,7 +34,9 @@ mod tests;
 
 /// Hedera follows [semantic versioning](https://semver.org) for both the HAPI protobufs and
 /// the Services software.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct SemanticVersion {
     /// Increases with incompatible API changes
     pub major: u32,
@@ -47,13 +49,13 @@ pub struct SemanticVersion {
 
     /// A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers (https://semver.org/#spec-item-9);
     /// so given a semver 0.14.0-alpha.1+21AF26D3, this field would contain ‘alpha.1’
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[cfg_attr(feature = "ffi", serde(skip_serializing_if = "String::is_empty"))]
     pub prerelease: String,
 
     /// Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers
     /// immediately following the patch or pre-release version (https://semver.org/#spec-item-10);
     /// so given a semver 0.14.0-alpha.1+21AF26D3, this field would contain ‘21AF26D3’
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[cfg_attr(feature = "ffi", serde(skip_serializing_if = "String::is_empty"))]
     pub build: String,
 }
 

--- a/sdk/rust/src/staking_info.rs
+++ b/sdk/rust/src/staking_info.rs
@@ -1,8 +1,5 @@
 use hedera_proto::services;
-use serde_with::{
-    serde_as,
-    TimestampNanoSeconds,
-};
+use serde_with::TimestampNanoSeconds;
 use time::OffsetDateTime;
 
 use crate::protobuf::ToProtobuf;
@@ -14,7 +11,6 @@ use crate::{
 
 // todo(sr): is this right?
 /// Info related to account/contract staking settings.
-#[serde_as]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StakingInfo {
@@ -24,7 +20,7 @@ pub struct StakingInfo {
     /// The staking period during which either the staking settings for this account or contract changed (such as starting
     /// staking or changing staked_node_id) or the most recent reward was earned, whichever is later. If this account or contract
     /// is not currently staked to a node, then this field is not set.
-    #[serde_as(as = "Option<TimestampNanoSeconds>")]
+    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
     pub stake_period_start: Option<OffsetDateTime>,
 
     /// The amount in `Hbar` that will be received in the next reward situation.

--- a/sdk/rust/src/staking_info.rs
+++ b/sdk/rust/src/staking_info.rs
@@ -1,5 +1,4 @@
 use hedera_proto::services;
-use serde_with::TimestampNanoSeconds;
 use time::OffsetDateTime;
 
 use crate::protobuf::ToProtobuf;
@@ -11,8 +10,9 @@ use crate::{
 
 // todo(sr): is this right?
 /// Info related to account/contract staking settings.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct StakingInfo {
     /// If `true`, the contract declines receiving a staking reward. The default value is `false`.
     pub decline_staking_reward: bool,
@@ -20,7 +20,10 @@ pub struct StakingInfo {
     /// The staking period during which either the staking settings for this account or contract changed (such as starting
     /// staking or changing staked_node_id) or the most recent reward was earned, whichever is later. If this account or contract
     /// is not currently staked to a node, then this field is not set.
-    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::TimestampNanoSeconds>>")
+    )]
     pub stake_period_start: Option<OffsetDateTime>,
 
     /// The amount in `Hbar` that will be received in the next reward situation.

--- a/sdk/rust/src/system/freeze_transaction.rs
+++ b/sdk/rust/src/system/freeze_transaction.rs
@@ -21,10 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::freeze_service_client::FreezeServiceClient;
-use serde::{
-    Deserialize,
-    Serialize,
-};
 use time::OffsetDateTime;
 use tonic::transport::Channel;
 
@@ -48,8 +44,9 @@ use crate::{
 ///
 pub type FreezeTransaction = Transaction<FreezeTransactionData>;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(default, rename_all = "camelCase"))]
 pub struct FreezeTransactionData {
     start_time: Option<OffsetDateTime>,
     file_id: Option<FileId>,

--- a/sdk/rust/src/system/freeze_type.rs
+++ b/sdk/rust/src/system/freeze_type.rs
@@ -18,15 +18,11 @@
  * ‍
  */
 
-use serde::{
-    Deserialize,
-    Serialize,
-};
-
 // todo(sr): Not happy with this doc.
 /// What type of freeze should be executed?
-#[derive(Serialize, Default, Deserialize, Debug, Hash, PartialEq, Eq, Clone, Copy)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 #[repr(C)]
 pub enum FreezeType {
     /// An (invalid) default value for this enum, to ensure the client explicitly sets

--- a/sdk/rust/src/system/system_delete_transaction.rs
+++ b/sdk/rust/src/system/system_delete_transaction.rs
@@ -22,10 +22,7 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::file_service_client::FileServiceClient;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
-use serde_with::{
-    serde_as,
-    TimestampNanoSeconds,
-};
+use serde_with::TimestampNanoSeconds;
 use time::OffsetDateTime;
 use tonic::transport::Channel;
 
@@ -55,11 +52,11 @@ pub type SystemDeleteTransaction = Transaction<SystemDeleteTransactionData>;
 /// When a smart contract is deleted, the cryptocurrency account within it continues
 /// to exist, and is not affected by the expiration time here.
 ///
-#[serde_as]
+
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct SystemDeleteTransactionData {
-    #[serde_as(as = "Option<TimestampNanoSeconds>")]
+    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
     pub expiration_time: Option<OffsetDateTime>,
     pub file_id: Option<FileId>,
     pub contract_id: Option<ContractId>,

--- a/sdk/rust/src/system/system_delete_transaction.rs
+++ b/sdk/rust/src/system/system_delete_transaction.rs
@@ -22,7 +22,6 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::file_service_client::FileServiceClient;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
-use serde_with::TimestampNanoSeconds;
 use time::OffsetDateTime;
 use tonic::transport::Channel;
 
@@ -53,10 +52,14 @@ pub type SystemDeleteTransaction = Transaction<SystemDeleteTransactionData>;
 /// to exist, and is not affected by the expiration time here.
 ///
 
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(default, rename_all = "camelCase"))]
 pub struct SystemDeleteTransactionData {
-    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::TimestampNanoSeconds>>")
+    )]
     pub expiration_time: Option<OffsetDateTime>,
     pub file_id: Option<FileId>,
     pub contract_id: Option<ContractId>,

--- a/sdk/rust/src/system/system_undelete_transaction.rs
+++ b/sdk/rust/src/system/system_undelete_transaction.rs
@@ -41,8 +41,9 @@ use crate::{
 pub type SystemUndeleteTransaction = Transaction<SystemUndeleteTransactionData>;
 
 /// Undelete a file or smart contract that was deleted by  [`SystemDeleteTransaction`](crate::SystemDeleteTransaction).
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(default, rename_all = "camelCase"))]
 pub struct SystemUndeleteTransactionData {
     pub file_id: Option<FileId>,
     pub contract_id: Option<ContractId>,

--- a/sdk/rust/src/token/custom_fees.rs
+++ b/sdk/rust/src/token/custom_fees.rs
@@ -32,7 +32,8 @@ use crate::{
 /// A transfer fee to assess during a `CryptoTransfer` that transfers units of the token to which the
 /// fee is attached. A custom fee may be either fixed or fractional, and must specify a fee collector
 /// account to receive the assessed fees. Only positive fees may be assessed.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Hash, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
 #[repr(C)]
 pub struct CustomFee {
     /// The fee to be charged.
@@ -64,7 +65,8 @@ impl ToProtobuf for CustomFee {
 }
 
 /// Represents the possible fee types.
-#[derive(Debug, serde::Serialize, serde::Deserialize, Hash, PartialEq, Eq, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub enum Fee {
     /// Fixed fee to be charged.
@@ -127,7 +129,8 @@ impl From<FractionalFee> for Fee {
 
 /// A fixed number of units (hbar or token) to assess as a fee during a `CryptoTransfer` that transfers
 /// units of the token to which this fixed fee is attached.
-#[derive(Debug, serde::Serialize, serde::Deserialize, Hash, PartialEq, Eq, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct FixedFee {
     /// The number of units to assess as a fee
@@ -177,7 +180,8 @@ impl ToProtobuf for FixedFee {
 /// A fraction of the transferred units of a token to assess as a fee. The amount assessed will never
 /// be less than the given `minimum_amount`, and never greater than the given `maximum_amount`.  The
 /// denomination is always units of the token to which this fractional fee is attached.
-#[derive(Debug, serde::Serialize, serde::Deserialize, Hash, PartialEq, Eq, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct FractionalFee {
     /// The fraction of the transferred units to assess as a fee
@@ -224,7 +228,8 @@ impl ToProtobuf for FractionalFee {
 /// value" includes both ℏ and units of fungible HTS tokens.) When the NFT sender does not receive
 /// any fungible value, the ledger will assess the fallback fee, if present, to the new NFT owner.
 /// Royalty fees can only be added to tokens of type type `NON_FUNGIBLE_UNIQUE`.
-#[derive(Debug, serde::Serialize, serde::Deserialize, Hash, PartialEq, Eq, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
 #[repr(C)]
 pub struct RoyaltyFee {
     /// The fraction of fungible value exchanged for an NFT to collect as royalty

--- a/sdk/rust/src/token/nft_id.rs
+++ b/sdk/rust/src/token/nft_id.rs
@@ -27,10 +27,6 @@ use std::fmt::{
 use std::str::FromStr;
 
 use hedera_proto::services;
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
 
 use crate::{
     Error,
@@ -40,7 +36,8 @@ use crate::{
 };
 
 /// The unique identifier for a token on Hedera.
-#[derive(SerializeDisplay, DeserializeFromStr, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 #[repr(C)]
 pub struct NftId {
     /// The (non-fungible) token of which this NFT is an instance.

--- a/sdk/rust/src/token/token_associate_transaction.rs
+++ b/sdk/rust/src/token/token_associate_transaction.rs
@@ -21,10 +21,7 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::transaction::{
@@ -55,7 +52,6 @@ use crate::{
 /// ready to interact with the tokens.
 pub type TokenAssociateTransaction = Transaction<TokenAssociateTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/rust/src/token/token_association.rs
+++ b/sdk/rust/src/token/token_association.rs
@@ -28,8 +28,9 @@ use crate::{
 };
 
 /// A token <-> account association.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenAssociation {
     /// The token involved in the association.
     pub token_id: TokenId,

--- a/sdk/rust/src/token/token_burn_transaction.rs
+++ b/sdk/rust/src/token/token_burn_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -62,9 +61,10 @@ use crate::{
 /// response code will be returned.
 pub type TokenBurnTransaction = Transaction<TokenBurnTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenBurnTransactionData {
     /// The token for which to burn tokens.
     token_id: Option<TokenId>,
@@ -133,19 +133,21 @@ impl From<TokenBurnTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        TokenBurnTransaction,
-        TokenId,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            TokenBurnTransaction,
+            TokenId,
+        };
 
-    // language=JSON
-    const TOKEN_BURN_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOKEN_BURN_TRANSACTION_JSON: &str = r#"{
   "$type": "tokenBurn",
   "tokenId": "0.0.1002",
   "amount": 100,
@@ -156,29 +158,30 @@ mod tests {
   ]
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TokenBurnTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TokenBurnTransaction::new();
 
-        transaction.token_id(TokenId::from(1002)).amount(100u64).serials([1, 2, 3]);
+            transaction.token_id(TokenId::from(1002)).amount(100u64).serials([1, 2, 3]);
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOKEN_BURN_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOKEN_BURN_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOKEN_BURN_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOKEN_BURN_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenBurn(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenBurn(transaction) => transaction);
 
-        assert_eq!(data.token_id, Some(TokenId::from(1002)));
-        assert_eq!(data.amount, 100);
-        assert_eq!(data.serials, vec![1, 2, 3]);
+            assert_eq!(data.token_id, Some(TokenId::from(1002)));
+            assert_eq!(data.amount, 100);
+            assert_eq!(data.serials, vec![1, 2, 3]);
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_burn_transaction.rs
+++ b/sdk/rust/src/token/token_burn_transaction.rs
@@ -21,10 +21,7 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -65,7 +62,6 @@ use crate::{
 /// response code will be returned.
 pub type TokenBurnTransaction = Transaction<TokenBurnTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/rust/src/token/token_create_transaction.rs
+++ b/sdk/rust/src/token/token_create_transaction.rs
@@ -22,7 +22,6 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     DurationSeconds,
     TimestampNanoSeconds,
@@ -73,7 +72,6 @@ use crate::{
 ///
 pub type TokenCreateTransaction = Transaction<TokenCreateTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -113,7 +111,7 @@ pub struct TokenCreateTransactionData {
     freeze_default: bool,
 
     /// The time at which the token should expire.
-    #[serde_as(as = "Option<TimestampNanoSeconds>")]
+    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
     expiration_time: Option<OffsetDateTime>,
 
     /// An account which will be automatically charged to renew the token's expiration, at
@@ -121,7 +119,7 @@ pub struct TokenCreateTransactionData {
     auto_renew_account_id: Option<AccountId>,
 
     /// The interval at which the auto-renew account will be charged to extend the token's expiry
-    #[serde_as(as = "Option<DurationSeconds<i64>>")]
+    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
     auto_renew_period: Option<Duration>,
 
     /// The memo associated with the token.

--- a/sdk/rust/src/token/token_delete_transaction.rs
+++ b/sdk/rust/src/token/token_delete_transaction.rs
@@ -21,10 +21,7 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -51,7 +48,6 @@ use crate::{
 /// - If invalid token is specified, transaction will result in `INVALID_TOKEN_ID`
 pub type TokenDeleteTransaction = Transaction<TokenDeleteTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/rust/src/token/token_delete_transaction.rs
+++ b/sdk/rust/src/token/token_delete_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -48,9 +47,10 @@ use crate::{
 /// - If invalid token is specified, transaction will result in `INVALID_TOKEN_ID`
 pub type TokenDeleteTransaction = Transaction<TokenDeleteTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenDeleteTransactionData {
     /// The token to be deleted.
     token_id: Option<TokenId>,
@@ -97,44 +97,47 @@ impl From<TokenDeleteTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        TokenDeleteTransaction,
-        TokenId,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            TokenDeleteTransaction,
+            TokenId,
+        };
 
-    //language=JSON
-    const TOKEN_DELETE_TRANSACTION_JSON: &str = r#"{
+        //language=JSON
+        const TOKEN_DELETE_TRANSACTION_JSON: &str = r#"{
   "$type": "tokenDelete",
   "tokenId": "0.0.1002"
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TokenDeleteTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TokenDeleteTransaction::new();
 
-        transaction.token_id(TokenId::from(1002));
+            transaction.token_id(TokenId::from(1002));
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOKEN_DELETE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOKEN_DELETE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOKEN_DELETE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOKEN_DELETE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenDelete(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenDelete(transaction) => transaction);
 
-        assert_eq!(data.token_id.unwrap(), TokenId::from(1002));
+            assert_eq!(data.token_id.unwrap(), TokenId::from(1002));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_dissociate_transaction.rs
+++ b/sdk/rust/src/token/token_dissociate_transaction.rs
@@ -21,10 +21,7 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -59,7 +56,6 @@ use crate::{
 /// balance is not zero. The transaction will resolve to `TRANSACTION_REQUIRED_ZERO_TOKEN_BALANCES`.
 pub type TokenDissociateTransaction = Transaction<TokenDissociateTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/rust/src/token/token_fee_schedule_update_transaction.rs
+++ b/sdk/rust/src/token/token_fee_schedule_update_transaction.rs
@@ -21,10 +21,7 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -51,7 +48,6 @@ use crate::{
 /// `CustomScheduleAlreadyHasNoFees` if the fee schedule was already empty.
 pub type TokenFeeScheduleUpdateTransaction = Transaction<TokenFeeScheduleUpdateTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/rust/src/token/token_fee_schedule_update_transaction.rs
+++ b/sdk/rust/src/token/token_fee_schedule_update_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -48,9 +47,10 @@ use crate::{
 /// `CustomScheduleAlreadyHasNoFees` if the fee schedule was already empty.
 pub type TokenFeeScheduleUpdateTransaction = Transaction<TokenFeeScheduleUpdateTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenFeeScheduleUpdateTransactionData {
     /// The token whose fee schedule is to be updated.
     token_id: Option<TokenId>,
@@ -107,25 +107,27 @@ impl From<TokenFeeScheduleUpdateTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::token::custom_fees::{
-        CustomFee,
-        Fee,
-        FixedFee,
-    };
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountId,
-        TokenFeeScheduleUpdateTransaction,
-        TokenId,
-    };
+        use crate::token::custom_fees::{
+            CustomFee,
+            Fee,
+            FixedFee,
+        };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountId,
+            TokenFeeScheduleUpdateTransaction,
+            TokenId,
+        };
 
-    // language=JSON
-    const TOKEN_FEE_SCHEDULE_UPDATE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOKEN_FEE_SCHEDULE_UPDATE_TRANSACTION_JSON: &str = r#"{
   "$type": "tokenFeeScheduleUpdate",
   "tokenId": "0.0.1001",
   "customFees": [
@@ -141,38 +143,42 @@ mod tests {
   ]
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TokenFeeScheduleUpdateTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TokenFeeScheduleUpdateTransaction::new();
 
-        transaction.token_id(TokenId::from(1001)).custom_fees([CustomFee {
-            fee: Fee::FixedFee(FixedFee { amount: 1, denominating_token_id: TokenId::from(7) }),
-            fee_collector_account_id: AccountId::from(8),
-        }]);
-
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
-
-        assert_eq!(transaction_json, TOKEN_FEE_SCHEDULE_UPDATE_TRANSACTION_JSON);
-
-        Ok(())
-    }
-
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction =
-            serde_json::from_str(TOKEN_FEE_SCHEDULE_UPDATE_TRANSACTION_JSON)?;
-
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenFeeScheduleUpdate(transaction) => transaction);
-
-        assert_eq!(data.token_id.unwrap(), TokenId::from(1001));
-        assert_eq!(
-            data.custom_fees,
-            [CustomFee {
+            transaction.token_id(TokenId::from(1001)).custom_fees([CustomFee {
                 fee: Fee::FixedFee(FixedFee { amount: 1, denominating_token_id: TokenId::from(7) }),
-                fee_collector_account_id: AccountId::from(8)
-            }]
-        );
+                fee_collector_account_id: AccountId::from(8),
+            }]);
 
-        Ok(())
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
+
+            assert_eq!(transaction_json, TOKEN_FEE_SCHEDULE_UPDATE_TRANSACTION_JSON);
+
+            Ok(())
+        }
+
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction =
+                serde_json::from_str(TOKEN_FEE_SCHEDULE_UPDATE_TRANSACTION_JSON)?;
+
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenFeeScheduleUpdate(transaction) => transaction);
+
+            assert_eq!(data.token_id.unwrap(), TokenId::from(1001));
+            assert_eq!(
+                data.custom_fees,
+                [CustomFee {
+                    fee: Fee::FixedFee(FixedFee {
+                        amount: 1,
+                        denominating_token_id: TokenId::from(7)
+                    }),
+                    fee_collector_account_id: AccountId::from(8)
+                }]
+            );
+
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_freeze_transaction.rs
+++ b/sdk/rust/src/token/token_freeze_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -51,9 +50,10 @@ use crate::{
 /// - If no Freeze Key is defined, the transaction will resolve to `TOKEN_HAS_NO_FREEZE_KEY`.
 pub type TokenFreezeTransaction = Transaction<TokenFreezeTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenFreezeTransactionData {
     /// The account to be frozen.
     account_id: Option<AccountId>,
@@ -111,47 +111,50 @@ impl From<TokenFreezeTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountId,
-        TokenFreezeTransaction,
-        TokenId,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountId,
+            TokenFreezeTransaction,
+            TokenId,
+        };
 
-    // language=JSON
-    const TOKEN_FREEZE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOKEN_FREEZE_TRANSACTION_JSON: &str = r#"{
   "$type": "tokenFreeze",
   "accountId": "0.0.1001",
   "tokenId": "0.0.1002"
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TokenFreezeTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TokenFreezeTransaction::new();
 
-        transaction.account_id(AccountId::from(1001)).token_id(TokenId::from(1002));
+            transaction.account_id(AccountId::from(1001)).token_id(TokenId::from(1002));
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOKEN_FREEZE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOKEN_FREEZE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOKEN_FREEZE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOKEN_FREEZE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenFreeze(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenFreeze(transaction) => transaction);
 
-        assert_eq!(data.token_id.unwrap(), TokenId::from(1002));
-        assert_eq!(data.account_id, Some(AccountId::from(1001)));
+            assert_eq!(data.token_id.unwrap(), TokenId::from(1002));
+            assert_eq!(data.account_id, Some(AccountId::from(1001)));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_grant_kyc_transaction.rs
+++ b/sdk/rust/src/token/token_grant_kyc_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -50,9 +49,10 @@ use crate::{
 /// - If no KYC Key is defined, the transaction will resolve to `TOKEN_HAS_NO_KYC_KEY`.
 pub type TokenGrantKycTransaction = Transaction<TokenGrantKycTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenGrantKycTransactionData {
     /// The account to be granted KYC.
     account_id: Option<AccountId>,
@@ -110,47 +110,51 @@ impl From<TokenGrantKycTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountId,
-        TokenGrantKycTransaction,
-        TokenId,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountId,
+            TokenGrantKycTransaction,
+            TokenId,
+        };
 
-    //language=JSON
-    const TOKEN_GRANT_KYC_TRANSACTION_JSON: &str = r#"{
+        //language=JSON
+        const TOKEN_GRANT_KYC_TRANSACTION_JSON: &str = r#"{
   "$type": "tokenGrantKyc",
   "accountId": "0.0.1001",
   "tokenId": "0.0.1002"
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TokenGrantKycTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TokenGrantKycTransaction::new();
 
-        transaction.account_id(AccountId::from(1001)).token_id(TokenId::from(1002));
+            transaction.account_id(AccountId::from(1001)).token_id(TokenId::from(1002));
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOKEN_GRANT_KYC_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOKEN_GRANT_KYC_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOKEN_GRANT_KYC_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction =
+                serde_json::from_str(TOKEN_GRANT_KYC_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenGrantKyc(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenGrantKyc(transaction) => transaction);
 
-        assert_eq!(data.token_id.unwrap(), TokenId::from(1002));
-        assert_eq!(data.account_id, Some(AccountId::from(1001)));
+            assert_eq!(data.token_id.unwrap(), TokenId::from(1002));
+            assert_eq!(data.account_id, Some(AccountId::from(1001)));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_id.rs
+++ b/sdk/rust/src/token/token_id.rs
@@ -27,10 +27,6 @@ use std::fmt::{
 use std::str::FromStr;
 
 use hedera_proto::services;
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
 
 use crate::{
     EntityId,
@@ -40,7 +36,8 @@ use crate::{
 };
 
 /// The unique identifier for a token on Hedera.
-#[derive(SerializeDisplay, DeserializeFromStr, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 #[repr(C)]
 pub struct TokenId {
     /// A non-negative number identifying the shard containing this token.

--- a/sdk/rust/src/token/token_info.rs
+++ b/sdk/rust/src/token/token_info.rs
@@ -41,8 +41,9 @@ use crate::{
 };
 
 /// Response from [`TokenInfoQuery`][crate::TokenInfoQuery].
-#[derive(Debug, Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenInfo {
     /// The ID of the token for which information is requested.
     pub token_id: TokenId,

--- a/sdk/rust/src/token/token_info_query.rs
+++ b/sdk/rust/src/token/token_info_query.rs
@@ -39,8 +39,9 @@ use crate::{
 ///
 pub type TokenInfoQuery = Query<TokenInfoQueryData>;
 
-#[derive(Default, Clone, serde::Serialize, serde::Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenInfoQueryData {
     token_id: Option<TokenId>,
 }
@@ -88,39 +89,42 @@ impl QueryExecute for TokenInfoQueryData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::query::AnyQueryData;
-    use crate::{
-        AnyQuery,
-        TokenId,
-        TokenInfoQuery,
-    };
+        use crate::query::AnyQueryData;
+        use crate::{
+            AnyQuery,
+            TokenId,
+            TokenInfoQuery,
+        };
 
-    // language=JSON
-    const TOKEN_INFO: &str = r#"{
+        // language=JSON
+        const TOKEN_INFO: &str = r#"{
   "$type": "tokenInfo",
   "tokenId": "0.0.1001",
   "payment": {}
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut query = TokenInfoQuery::new();
-        query.token_id(TokenId::from(1001));
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut query = TokenInfoQuery::new();
+            query.token_id(TokenId::from(1001));
 
-        let s = serde_json::to_string_pretty(&query)?;
-        assert_eq!(s, TOKEN_INFO);
+            let s = serde_json::to_string_pretty(&query)?;
+            assert_eq!(s, TOKEN_INFO);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let query: AnyQuery = serde_json::from_str(TOKEN_INFO)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let query: AnyQuery = serde_json::from_str(TOKEN_INFO)?;
 
-        let data = assert_matches!(query.data, AnyQueryData::TokenInfo(query) => query);
-        assert_eq!(data.token_id, Some(TokenId { shard: 0, realm: 0, num: 1001 }));
-        Ok(())
+            let data = assert_matches!(query.data, AnyQueryData::TokenInfo(query) => query);
+            assert_eq!(data.token_id, Some(TokenId { shard: 0, realm: 0, num: 1001 }));
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_mint_transaction.rs
+++ b/sdk/rust/src/token/token_mint_transaction.rs
@@ -22,10 +22,7 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use serde_with::base64::Base64;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -61,7 +58,6 @@ use crate::{
 /// `BatchSizeLimitExceeded` response code will be returned.
 pub type TokenMintTransaction = Transaction<TokenMintTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -73,7 +69,7 @@ pub struct TokenMintTransactionData {
     amount: u64,
 
     /// The list of metadata for a non-fungible token to mint to the treasury account.
-    #[serde_as(as = "Vec<Base64>")]
+    #[serde(with = "serde_with::As::<Vec<Base64>>")]
     metadata: Vec<Vec<u8>>,
 }
 

--- a/sdk/rust/src/token/token_mint_transaction.rs
+++ b/sdk/rust/src/token/token_mint_transaction.rs
@@ -21,8 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::base64::Base64;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -58,9 +56,10 @@ use crate::{
 /// `BatchSizeLimitExceeded` response code will be returned.
 pub type TokenMintTransaction = Transaction<TokenMintTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenMintTransactionData {
     /// The token for which to mint tokens.
     token_id: Option<TokenId>,
@@ -69,7 +68,7 @@ pub struct TokenMintTransactionData {
     amount: u64,
 
     /// The list of metadata for a non-fungible token to mint to the treasury account.
-    #[serde(with = "serde_with::As::<Vec<Base64>>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<Vec<serde_with::base64::Base64>>"))]
     metadata: Vec<Vec<u8>>,
 }
 
@@ -135,19 +134,21 @@ impl From<TokenMintTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        TokenId,
-        TokenMintTransaction,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            TokenId,
+            TokenMintTransaction,
+        };
 
-    // language=JSON
-    const TOKEN_MINT_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOKEN_MINT_TRANSACTION_JSON: &str = r#"{
   "$type": "tokenMint",
   "tokenId": "0.0.1981",
   "amount": 8675309,
@@ -156,34 +157,35 @@ mod tests {
   ]
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TokenMintTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TokenMintTransaction::new();
 
-        transaction
-            .token_id(TokenId::from(1981))
-            .amount(8675309)
-            .metadata(["Jenny I've got your number"]);
+            transaction
+                .token_id(TokenId::from(1981))
+                .amount(8675309)
+                .metadata(["Jenny I've got your number"]);
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOKEN_MINT_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOKEN_MINT_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOKEN_MINT_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOKEN_MINT_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenMint(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenMint(transaction) => transaction);
 
-        assert_eq!(data.token_id.unwrap(), TokenId::from(1981));
-        assert_eq!(data.amount, 8675309);
+            assert_eq!(data.token_id.unwrap(), TokenId::from(1981));
+            assert_eq!(data.amount, 8675309);
 
-        let bytes: Vec<u8> = "Jenny I've got your number".into();
-        assert_eq!(data.metadata, [bytes]);
+            let bytes: Vec<u8> = "Jenny I've got your number".into();
+            assert_eq!(data.metadata, [bytes]);
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_nft_info.rs
+++ b/sdk/rust/src/token/token_nft_info.rs
@@ -19,11 +19,6 @@
  */
 
 use hedera_proto::services;
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use serde_with::base64::Base64;
 use time::OffsetDateTime;
 
 use crate::{
@@ -35,8 +30,9 @@ use crate::{
 // TODO pub ledger_id: LedgerId, --- also shows as todo in account_info.rs
 /// Response from [`TokenNftInfoQuery`][crate::TokenNftInfoQuery].
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenNftInfo {
     /// The ID of the NFT.
     pub nft_id: NftId,
@@ -48,7 +44,7 @@ pub struct TokenNftInfo {
     pub creation_time: OffsetDateTime,
 
     /// The unique metadata of the NFT.
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub metadata: Vec<u8>,
 
     /// If an allowance is granted for the NFT, its corresponding spender account.

--- a/sdk/rust/src/token/token_nft_info.rs
+++ b/sdk/rust/src/token/token_nft_info.rs
@@ -24,7 +24,6 @@ use serde::{
     Serialize,
 };
 use serde_with::base64::Base64;
-use serde_with::serde_as;
 use time::OffsetDateTime;
 
 use crate::{
@@ -35,7 +34,7 @@ use crate::{
 
 // TODO pub ledger_id: LedgerId, --- also shows as todo in account_info.rs
 /// Response from [`TokenNftInfoQuery`][crate::TokenNftInfoQuery].
-#[serde_as]
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenNftInfo {
@@ -49,7 +48,7 @@ pub struct TokenNftInfo {
     pub creation_time: OffsetDateTime,
 
     /// The unique metadata of the NFT.
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub metadata: Vec<u8>,
 
     /// If an allowance is granted for the NFT, its corresponding spender account.

--- a/sdk/rust/src/token/token_nft_info_query.rs
+++ b/sdk/rust/src/token/token_nft_info_query.rs
@@ -38,8 +38,9 @@ use crate::{
 /// Gets info on an NFT for a given `TokenID` and serial number.
 pub type TokenNftInfoQuery = Query<TokenNftInfoQueryData>;
 
-#[derive(Clone, Default, serde::Serialize, serde::Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenNftInfoQueryData {
     /// The ID of the NFT
     nft_id: Option<NftId>,

--- a/sdk/rust/src/token/token_pause_transaction.rs
+++ b/sdk/rust/src/token/token_pause_transaction.rs
@@ -21,10 +21,7 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -52,7 +49,6 @@ use crate::{
 /// - If no Pause Key is defined, the transaction will resolve to `TOKEN_HAS_NO_PAUSE_KEY`.
 pub type TokenPauseTransaction = Transaction<TokenPauseTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/rust/src/token/token_pause_transaction.rs
+++ b/sdk/rust/src/token/token_pause_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -49,9 +48,10 @@ use crate::{
 /// - If no Pause Key is defined, the transaction will resolve to `TOKEN_HAS_NO_PAUSE_KEY`.
 pub type TokenPauseTransaction = Transaction<TokenPauseTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenPauseTransactionData {
     /// The token to be paused.
     token_id: Option<TokenId>,
@@ -96,44 +96,47 @@ impl From<TokenPauseTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        TokenId,
-        TokenPauseTransaction,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            TokenId,
+            TokenPauseTransaction,
+        };
 
-    // language=JSON
-    const TOKEN_PAUSE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOKEN_PAUSE_TRANSACTION_JSON: &str = r#"{
   "$type": "tokenPause",
   "tokenId": "0.0.1001"
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TokenPauseTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TokenPauseTransaction::new();
 
-        transaction.token_id(TokenId::from(1001));
+            transaction.token_id(TokenId::from(1001));
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOKEN_PAUSE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOKEN_PAUSE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOKEN_PAUSE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOKEN_PAUSE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenPause(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenPause(transaction) => transaction);
 
-        assert_eq!(data.token_id.unwrap(), TokenId::from(1001));
+            assert_eq!(data.token_id.unwrap(), TokenId::from(1001));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_revoke_kyc_transaction.rs
+++ b/sdk/rust/src/token/token_revoke_kyc_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -52,9 +51,10 @@ use crate::{
 /// - If no KYC Key is defined, the transaction will resolve to `TOKEN_HAS_NO_KYC_KEY`.
 pub type TokenRevokeKycTransaction = Transaction<TokenRevokeKycTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenRevokeKycTransactionData {
     /// The account to have their KYC revoked.
     account_id: Option<AccountId>,
@@ -112,47 +112,51 @@ impl From<TokenRevokeKycTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountId,
-        TokenId,
-        TokenRevokeKycTransaction,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountId,
+            TokenId,
+            TokenRevokeKycTransaction,
+        };
 
-    // language=JSON
-    const TOKEN_REVOKE_KYC_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOKEN_REVOKE_KYC_TRANSACTION_JSON: &str = r#"{
   "$type": "tokenRevokeKyc",
   "accountId": "0.0.1001",
   "tokenId": "0.0.1002"
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TokenRevokeKycTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TokenRevokeKycTransaction::new();
 
-        transaction.account_id(AccountId::from(1001)).token_id(TokenId::from(1002));
+            transaction.account_id(AccountId::from(1001)).token_id(TokenId::from(1002));
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOKEN_REVOKE_KYC_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOKEN_REVOKE_KYC_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOKEN_REVOKE_KYC_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction =
+                serde_json::from_str(TOKEN_REVOKE_KYC_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenRevokeKyc(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenRevokeKyc(transaction) => transaction);
 
-        assert_eq!(data.token_id, Some(TokenId::from(1002)));
-        assert_eq!(data.account_id, Some(AccountId::from(1001)));
+            assert_eq!(data.token_id, Some(TokenId::from(1002)));
+            assert_eq!(data.account_id, Some(AccountId::from(1001)));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_revoke_kyc_transaction.rs
+++ b/sdk/rust/src/token/token_revoke_kyc_transaction.rs
@@ -21,10 +21,7 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -55,7 +52,6 @@ use crate::{
 /// - If no KYC Key is defined, the transaction will resolve to `TOKEN_HAS_NO_KYC_KEY`.
 pub type TokenRevokeKycTransaction = Transaction<TokenRevokeKycTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/rust/src/token/token_supply_type.rs
+++ b/sdk/rust/src/token/token_supply_type.rs
@@ -19,10 +19,6 @@
  */
 
 use hedera_proto::services;
-use serde::{
-    Deserialize,
-    Serialize,
-};
 
 use crate::{
     FromProtobuf,
@@ -32,8 +28,9 @@ use crate::{
 /// Possible token supply types.
 /// Can be used to restrict supply to a set maximum.
 /// Defaults to [`Infinite`](Self::Infinite).
-#[derive(Serialize, Deserialize, Debug, Hash, PartialEq, Eq, Clone, Copy)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 #[repr(C)]
 pub enum TokenSupplyType {
     /// Indicates the token has a maximum supply of [`u64::MAX`].

--- a/sdk/rust/src/token/token_type.rs
+++ b/sdk/rust/src/token/token_type.rs
@@ -19,10 +19,6 @@
  */
 
 use hedera_proto::services;
-use serde::{
-    Deserialize,
-    Serialize,
-};
 
 use crate::{
     FromProtobuf,
@@ -37,8 +33,9 @@ use crate::{
 /// Only `FungibleCommon` and `NonFungibleUnique` are supported right now. More
 /// may be added in the future.
 ///
-#[derive(Serialize, Deserialize, Debug, Hash, PartialEq, Eq, Clone, Copy)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 #[repr(C)]
 pub enum TokenType {
     /// Interchangeable value with one another, where any quantity of them has the same value as

--- a/sdk/rust/src/token/token_unfreeze_transaction.rs
+++ b/sdk/rust/src/token/token_unfreeze_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -51,9 +50,10 @@ use crate::{
 /// - If no Freeze Key is defined, the transaction will resolve to `TOKEN_HAS_NO_FREEZE_KEY`.
 pub type TokenUnfreezeTransaction = Transaction<TokenUnfreezeTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenUnfreezeTransactionData {
     /// The account to be unfrozen.
     account_id: Option<AccountId>,
@@ -110,47 +110,51 @@ impl From<TokenUnfreezeTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountId,
-        TokenId,
-        TokenUnfreezeTransaction,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountId,
+            TokenId,
+            TokenUnfreezeTransaction,
+        };
 
-    // language=JSON
-    const TOKEN_UNFREEZE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOKEN_UNFREEZE_TRANSACTION_JSON: &str = r#"{
   "$type": "tokenUnfreeze",
   "accountId": "0.0.1001",
   "tokenId": "0.0.1002"
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TokenUnfreezeTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TokenUnfreezeTransaction::new();
 
-        transaction.account_id(AccountId::from(1001)).token_id(TokenId::from(1002));
+            transaction.account_id(AccountId::from(1001)).token_id(TokenId::from(1002));
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOKEN_UNFREEZE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOKEN_UNFREEZE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOKEN_UNFREEZE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction =
+                serde_json::from_str(TOKEN_UNFREEZE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenUnfreeze(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenUnfreeze(transaction) => transaction);
 
-        assert_eq!(data.token_id.unwrap(), TokenId::from(1002));
-        assert_eq!(data.account_id, Some(AccountId::from(1001)));
+            assert_eq!(data.token_id.unwrap(), TokenId::from(1002));
+            assert_eq!(data.account_id, Some(AccountId::from(1001)));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_unpause_transaction.rs
+++ b/sdk/rust/src/token/token_unpause_transaction.rs
@@ -21,10 +21,7 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -51,7 +48,6 @@ use crate::{
 /// - If no Pause Key is defined, the transaction will resolve to `TOKEN_HAS_NO_PAUSE_KEY`.
 pub type TokenUnpauseTransaction = Transaction<TokenUnpauseTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/rust/src/token/token_unpause_transaction.rs
+++ b/sdk/rust/src/token/token_unpause_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -48,9 +47,10 @@ use crate::{
 /// - If no Pause Key is defined, the transaction will resolve to `TOKEN_HAS_NO_PAUSE_KEY`.
 pub type TokenUnpauseTransaction = Transaction<TokenUnpauseTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenUnpauseTransactionData {
     /// The token to be unpaused.
     token_id: Option<TokenId>,
@@ -97,44 +97,47 @@ impl From<TokenUnpauseTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        TokenId,
-        TokenUnpauseTransaction,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            TokenId,
+            TokenUnpauseTransaction,
+        };
 
-    // language=JSON
-    const TOKEN_UNPAUSE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOKEN_UNPAUSE_TRANSACTION_JSON: &str = r#"{
   "$type": "tokenUnpause",
   "tokenId": "0.0.1001"
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TokenUnpauseTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TokenUnpauseTransaction::new();
 
-        transaction.token_id(TokenId::from(1001));
+            transaction.token_id(TokenId::from(1001));
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOKEN_UNPAUSE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOKEN_UNPAUSE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOKEN_UNPAUSE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOKEN_UNPAUSE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenUnpause(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenUnpause(transaction) => transaction);
 
-        assert_eq!(data.token_id.unwrap(), TokenId::from(1001));
+            assert_eq!(data.token_id.unwrap(), TokenId::from(1001));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_update_transaction.rs
+++ b/sdk/rust/src/token/token_update_transaction.rs
@@ -22,7 +22,6 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     DurationSeconds,
     TimestampNanoSeconds,
@@ -68,7 +67,6 @@ use crate::{
 ///    `CurrentTreasuryStillOwnsNfts`.
 pub type TokenUpdateTransaction = Transaction<TokenUpdateTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -105,11 +103,11 @@ pub struct TokenUpdateTransactionData {
     auto_renew_account_id: Option<AccountId>,
 
     /// The interval at which the auto-renew account will be charged to extend the token's expiry
-    #[serde_as(as = "Option<DurationSeconds<i64>>")]
+    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
     auto_renew_period: Option<Duration>,
 
     /// Sets the time at which the token should expire.
-    #[serde_as(as = "Option<TimestampNanoSeconds>")]
+    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
     expiration_time: Option<OffsetDateTime>,
 
     /// The memo associated with the token (UTF-8 encoding max 100 bytes)

--- a/sdk/rust/src/token/token_update_transaction.rs
+++ b/sdk/rust/src/token/token_update_transaction.rs
@@ -21,11 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::{
-    skip_serializing_none,
-    DurationSeconds,
-    TimestampNanoSeconds,
-};
 use time::{
     Duration,
     OffsetDateTime,
@@ -67,9 +62,10 @@ use crate::{
 ///    `CurrentTreasuryStillOwnsNfts`.
 pub type TokenUpdateTransaction = Transaction<TokenUpdateTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TokenUpdateTransactionData {
     /// The token to be updated.
     token_id: Option<TokenId>,
@@ -103,11 +99,17 @@ pub struct TokenUpdateTransactionData {
     auto_renew_account_id: Option<AccountId>,
 
     /// The interval at which the auto-renew account will be charged to extend the token's expiry
-    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::DurationSeconds<i64>>>")
+    )]
     auto_renew_period: Option<Duration>,
 
     /// Sets the time at which the token should expire.
-    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::TimestampNanoSeconds>>")
+    )]
     expiration_time: Option<OffsetDateTime>,
 
     /// The memo associated with the token (UTF-8 encoding max 100 bytes)
@@ -288,28 +290,30 @@ impl From<TokenUpdateTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use std::str::FromStr;
 
-    use assert_matches::assert_matches;
-    use time::{
-        Duration,
-        OffsetDateTime,
-    };
+        use assert_matches::assert_matches;
+        use time::{
+            Duration,
+            OffsetDateTime,
+        };
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountId,
-        Key,
-        PublicKey,
-        TokenId,
-        TokenUpdateTransaction,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountId,
+            Key,
+            PublicKey,
+            TokenId,
+            TokenUpdateTransaction,
+        };
 
-    // language=JSON
-    const TOKEN_UPDATE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOKEN_UPDATE_TRANSACTION_JSON: &str = r#"{
   "$type": "tokenUpdate",
   "tokenId": "0.0.1001",
   "name": "Pound",
@@ -342,95 +346,96 @@ mod tests {
   }
 }"#;
 
-    const ADMIN_KEY: &str =
+        const ADMIN_KEY: &str =
         "302a300506032b6570032100d1ad76ed9b057a3d3f2ea2d03b41bcd79aeafd611f941924f0f6da528ab066fd";
-    const KYC_KEY: &str =
+        const KYC_KEY: &str =
         "302a300506032b6570032100b5b4d9351ebdf266ef3989aed4fd8f0cfcf24b75ba3d0df19cd3946771b40500";
-    const FREEZE_KEY: &str =
+        const FREEZE_KEY: &str =
         "302a300506032b657003210004e540b5fba8fc1ee1cc5cc450019c578b36311733507fabf4f85bf2744583e7";
-    const WIPE_KEY: &str =
+        const WIPE_KEY: &str =
         "302a300506032b657003210099f8981cad75fc7322bf5c89d5f4ce4f2af76b2a63780b22cbce1bfdfa237f4e";
-    const SUPPLY_KEY: &str =
+        const SUPPLY_KEY: &str =
         "302a300506032b6570032100c80c04aaca1783aafbaf6eba462bac89236ec82ac4db31953329ffbfeacdb88b";
-    const FEE_SCHEDULE_KEY: &str =
+        const FEE_SCHEDULE_KEY: &str =
         "302a300506032b65700321000cd029bfd4a818de944c21799f4b5f6b5616702d0495520c818d92488e5395fc";
-    const PAUSE_KEY: &str =
+        const PAUSE_KEY: &str =
         "302a300506032b65700321008b020177031eae1e4a721c814b08a3ef2c3f473781a570e9daaf9f7ad27f8967";
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TokenUpdateTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TokenUpdateTransaction::new();
 
-        transaction
-            .token_id(TokenId::from(1001))
-            .name("Pound")
-            .symbol("LB")
-            .treasury_account_id(AccountId::from(1002))
-            .admin_key(PublicKey::from_str(ADMIN_KEY)?)
-            .kyc_key(PublicKey::from_str(KYC_KEY)?)
-            .freeze_key(PublicKey::from_str(FREEZE_KEY)?)
-            .wipe_key(PublicKey::from_str(WIPE_KEY)?)
-            .supply_key(PublicKey::from_str(SUPPLY_KEY)?)
-            .expiration_time(OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?)
-            .auto_renew_account_id(AccountId::from(1003))
-            .auto_renew_period(Duration::days(90))
-            .token_memo("A new memo")
-            .fee_schedule_key(PublicKey::from_str(FEE_SCHEDULE_KEY)?)
-            .pause_key(PublicKey::from_str(PAUSE_KEY)?);
+            transaction
+                .token_id(TokenId::from(1001))
+                .name("Pound")
+                .symbol("LB")
+                .treasury_account_id(AccountId::from(1002))
+                .admin_key(PublicKey::from_str(ADMIN_KEY)?)
+                .kyc_key(PublicKey::from_str(KYC_KEY)?)
+                .freeze_key(PublicKey::from_str(FREEZE_KEY)?)
+                .wipe_key(PublicKey::from_str(WIPE_KEY)?)
+                .supply_key(PublicKey::from_str(SUPPLY_KEY)?)
+                .expiration_time(OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?)
+                .auto_renew_account_id(AccountId::from(1003))
+                .auto_renew_period(Duration::days(90))
+                .token_memo("A new memo")
+                .fee_schedule_key(PublicKey::from_str(FEE_SCHEDULE_KEY)?)
+                .pause_key(PublicKey::from_str(PAUSE_KEY)?);
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOKEN_UPDATE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOKEN_UPDATE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOKEN_UPDATE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOKEN_UPDATE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenUpdate(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TokenUpdate(transaction) => transaction);
 
-        assert_eq!(data.token_id.unwrap(), TokenId::from(1001));
-        assert_eq!(data.name, "Pound");
-        assert_eq!(data.symbol, "LB");
-        assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
-        assert_eq!(data.token_memo, "A new memo");
-        assert_eq!(
-            data.expiration_time.unwrap(),
-            OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?
-        );
+            assert_eq!(data.token_id.unwrap(), TokenId::from(1001));
+            assert_eq!(data.name, "Pound");
+            assert_eq!(data.symbol, "LB");
+            assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
+            assert_eq!(data.token_memo, "A new memo");
+            assert_eq!(
+                data.expiration_time.unwrap(),
+                OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?
+            );
 
-        assert_eq!(data.treasury_account_id, Some(AccountId::from(1002)));
-        assert_eq!(data.auto_renew_account_id, Some(AccountId::from(1003)));
+            assert_eq!(data.treasury_account_id, Some(AccountId::from(1002)));
+            assert_eq!(data.auto_renew_account_id, Some(AccountId::from(1003)));
 
-        let admin_key =
-            assert_matches!(data.admin_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(admin_key, PublicKey::from_str(ADMIN_KEY)?);
+            let admin_key =
+                assert_matches!(data.admin_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(admin_key, PublicKey::from_str(ADMIN_KEY)?);
 
-        let kyc_key = assert_matches!(data.kyc_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(kyc_key, PublicKey::from_str(KYC_KEY)?);
+            let kyc_key =
+                assert_matches!(data.kyc_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(kyc_key, PublicKey::from_str(KYC_KEY)?);
 
-        let freeze_key =
-            assert_matches!(data.freeze_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(freeze_key, PublicKey::from_str(FREEZE_KEY)?);
+            let freeze_key =
+                assert_matches!(data.freeze_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(freeze_key, PublicKey::from_str(FREEZE_KEY)?);
 
-        let wipe_key =
-            assert_matches!(data.wipe_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(wipe_key, PublicKey::from_str(WIPE_KEY)?);
+            let wipe_key =
+                assert_matches!(data.wipe_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(wipe_key, PublicKey::from_str(WIPE_KEY)?);
 
-        let supply_key =
-            assert_matches!(data.supply_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(supply_key, PublicKey::from_str(SUPPLY_KEY)?);
+            let supply_key =
+                assert_matches!(data.supply_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(supply_key, PublicKey::from_str(SUPPLY_KEY)?);
 
-        let fee_schedule_key =
-            assert_matches!(data.fee_schedule_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(fee_schedule_key, PublicKey::from_str(FEE_SCHEDULE_KEY)?);
+            let fee_schedule_key = assert_matches!(data.fee_schedule_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(fee_schedule_key, PublicKey::from_str(FEE_SCHEDULE_KEY)?);
 
-        let pause_key =
-            assert_matches!(data.pause_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(pause_key, PublicKey::from_str(PAUSE_KEY)?);
+            let pause_key =
+                assert_matches!(data.pause_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(pause_key, PublicKey::from_str(PAUSE_KEY)?);
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/token/token_wipe_transaction.rs
+++ b/sdk/rust/src/token/token_wipe_transaction.rs
@@ -21,10 +21,7 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -70,7 +67,6 @@ use crate::{
 ///
 pub type TokenWipeTransaction = Transaction<TokenWipeTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/rust/src/topic/topic_create_transaction.rs
+++ b/sdk/rust/src/topic/topic_create_transaction.rs
@@ -22,7 +22,6 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     DurationSeconds,
 };
@@ -52,7 +51,6 @@ use crate::{
 ///
 pub type TopicCreateTransaction = Transaction<TopicCreateTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -70,7 +68,7 @@ pub struct TopicCreateTransactionData {
     /// The initial lifetime of the topic and the amount of time to attempt to
     /// extend the topic's lifetime by automatically at the topic's expiration time, if
     /// the `auto_renew_account_id` is configured.
-    #[serde_as(as = "Option<DurationSeconds<i64>>")]
+    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
     auto_renew_period: Option<Duration>,
 
     /// Account to be used at the topic's expiration time to extend the life of the topic.

--- a/sdk/rust/src/topic/topic_create_transaction.rs
+++ b/sdk/rust/src/topic/topic_create_transaction.rs
@@ -21,10 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
-use serde_with::{
-    skip_serializing_none,
-    DurationSeconds,
-};
 use time::Duration;
 use tonic::transport::Channel;
 
@@ -51,12 +47,13 @@ use crate::{
 ///
 pub type TopicCreateTransaction = Transaction<TopicCreateTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(default, rename_all = "camelCase"))]
 pub struct TopicCreateTransactionData {
     /// Short publicly visible memo about the topic. No guarantee of uniqueness.
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[cfg_attr(feature = "ffi", serde(skip_serializing_if = "String::is_empty"))]
     topic_memo: String,
 
     /// Access control for `TopicUpdateTransaction` and `TopicDeleteTransaction`.
@@ -68,7 +65,10 @@ pub struct TopicCreateTransactionData {
     /// The initial lifetime of the topic and the amount of time to attempt to
     /// extend the topic's lifetime by automatically at the topic's expiration time, if
     /// the `auto_renew_account_id` is configured.
-    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::DurationSeconds<i64>>>")
+    )]
     auto_renew_period: Option<Duration>,
 
     /// Account to be used at the topic's expiration time to extend the life of the topic.
@@ -165,29 +165,31 @@ impl From<TopicCreateTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use std::str::FromStr;
 
-    use assert_matches::assert_matches;
-    use time::Duration;
+        use assert_matches::assert_matches;
+        use time::Duration;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountId,
-        Key,
-        PublicKey,
-        TopicCreateTransaction,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountId,
+            Key,
+            PublicKey,
+            TopicCreateTransaction,
+        };
 
-    // language=JSON
-    const TOPIC_CREATE_EMPTY: &str = r#"{
+        // language=JSON
+        const TOPIC_CREATE_EMPTY: &str = r#"{
   "$type": "topicCreate"
 }"#;
 
-    // language=JSON
-    const TOPIC_CREATE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOPIC_CREATE_TRANSACTION_JSON: &str = r#"{
   "$type": "topicCreate",
   "topicMemo": "A topic memo",
   "adminKey": {
@@ -200,60 +202,61 @@ mod tests {
   "autoRenewAccountId": "0.0.1001"
 }"#;
 
-    const ADMIN_KEY: &str =
+        const ADMIN_KEY: &str =
         "302a300506032b6570032100d1ad76ed9b057a3d3f2ea2d03b41bcd79aeafd611f941924f0f6da528ab066fd";
-    const SUBMIT_KEY: &str =
+        const SUBMIT_KEY: &str =
         "302a300506032b6570032100b5b4d9351ebdf266ef3989aed4fd8f0cfcf24b75ba3d0df19cd3946771b40500";
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TopicCreateTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TopicCreateTransaction::new();
 
-        transaction
-            .topic_memo("A topic memo")
-            .admin_key(PublicKey::from_str(ADMIN_KEY)?)
-            .submit_key(PublicKey::from_str(SUBMIT_KEY)?)
-            .auto_renew_period(Duration::days(90))
-            .auto_renew_account_id(AccountId::from(1001));
+            transaction
+                .topic_memo("A topic memo")
+                .admin_key(PublicKey::from_str(ADMIN_KEY)?)
+                .submit_key(PublicKey::from_str(SUBMIT_KEY)?)
+                .auto_renew_period(Duration::days(90))
+                .auto_renew_account_id(AccountId::from(1001));
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOPIC_CREATE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOPIC_CREATE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOPIC_CREATE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOPIC_CREATE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicCreate(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicCreate(transaction) => transaction);
 
-        assert_eq!(data.topic_memo, "A topic memo");
-        assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
+            assert_eq!(data.topic_memo, "A topic memo");
+            assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
 
-        let admin_key =
-            assert_matches!(data.admin_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(admin_key, PublicKey::from_str(ADMIN_KEY)?);
+            let admin_key =
+                assert_matches!(data.admin_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(admin_key, PublicKey::from_str(ADMIN_KEY)?);
 
-        let submit_key =
-            assert_matches!(data.submit_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(submit_key, PublicKey::from_str(SUBMIT_KEY)?);
+            let submit_key =
+                assert_matches!(data.submit_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(submit_key, PublicKey::from_str(SUBMIT_KEY)?);
 
-        assert_eq!(data.auto_renew_account_id, Some(AccountId::from(1001)));
+            assert_eq!(data.auto_renew_account_id, Some(AccountId::from(1001)));
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    #[ignore = "auto renew period is `None`"]
-    fn it_should_deserialize_empty() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOPIC_CREATE_EMPTY)?;
+        #[test]
+        #[ignore = "auto renew period is `None`"]
+        fn it_should_deserialize_empty() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOPIC_CREATE_EMPTY)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicCreate(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicCreate(transaction) => transaction);
 
-        assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
+            assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/topic/topic_delete_transaction.rs
+++ b/sdk/rust/src/topic/topic_delete_transaction.rs
@@ -21,7 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -46,9 +45,10 @@ use crate::{
 ///
 pub type TopicDeleteTransaction = Transaction<TopicDeleteTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TopicDeleteTransactionData {
     /// The topic ID which is being deleted in this transaction.
     topic_id: Option<TopicId>,
@@ -95,44 +95,47 @@ impl From<TopicDeleteTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        TopicDeleteTransaction,
-        TopicId,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            TopicDeleteTransaction,
+            TopicId,
+        };
 
-    // language=JSON
-    const TOPIC_DELETE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOPIC_DELETE_TRANSACTION_JSON: &str = r#"{
   "$type": "topicDelete",
   "topicId": "0.0.1001"
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TopicDeleteTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TopicDeleteTransaction::new();
 
-        transaction.topic_id(TopicId::from(1001));
+            transaction.topic_id(TopicId::from(1001));
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOPIC_DELETE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOPIC_DELETE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOPIC_DELETE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOPIC_DELETE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicDelete(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicDelete(transaction) => transaction);
 
-        assert_eq!(data.topic_id.unwrap(), TopicId::from(1001));
+            assert_eq!(data.topic_id.unwrap(), TopicId::from(1001));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/topic/topic_id.rs
+++ b/sdk/rust/src/topic/topic_id.rs
@@ -27,10 +27,6 @@ use std::fmt::{
 use std::str::FromStr;
 
 use hedera_proto::services;
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
 
 use crate::{
     EntityId,
@@ -39,7 +35,8 @@ use crate::{
 };
 
 /// The unique identifier for a topic on Hedera.
-#[derive(SerializeDisplay, DeserializeFromStr, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 #[repr(C)]
 pub struct TopicId {
     /// A non-negative number identifying the shard containing this topic.

--- a/sdk/rust/src/topic/topic_info.rs
+++ b/sdk/rust/src/topic/topic_info.rs
@@ -20,10 +20,7 @@
 
 use hedera_proto::services;
 use serde_with::base64::Base64;
-use serde_with::{
-    serde_as,
-    TimestampNanoSeconds,
-};
+use serde_with::TimestampNanoSeconds;
 use time::{
     Duration,
     OffsetDateTime,
@@ -38,7 +35,7 @@ use crate::{
 };
 
 /// Response from [`TopicInfoQuery`][crate::TopicInfoQuery].
-#[serde_as]
+
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TopicInfo {
@@ -49,14 +46,14 @@ pub struct TopicInfo {
     pub topic_memo: String,
 
     /// SHA-384 running hash of (previousRunningHash, topicId, consensusTimestamp, sequenceNumber, message).
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub running_hash: Vec<u8>,
 
     /// Sequence number (starting at 1 for the first submitMessage) of messages on the topic.
     pub sequence_number: u64,
 
     /// Effective consensus timestamp at (and after) which submitMessage calls will no longer succeed on the topic.
-    #[serde_as(as = "Option<TimestampNanoSeconds>")]
+    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
     pub expiration_time: Option<OffsetDateTime>,
 
     /// Access control for update/delete of the topic.

--- a/sdk/rust/src/topic/topic_info.rs
+++ b/sdk/rust/src/topic/topic_info.rs
@@ -19,8 +19,6 @@
  */
 
 use hedera_proto::services;
-use serde_with::base64::Base64;
-use serde_with::TimestampNanoSeconds;
 use time::{
     Duration,
     OffsetDateTime,
@@ -36,8 +34,9 @@ use crate::{
 
 /// Response from [`TopicInfoQuery`][crate::TopicInfoQuery].
 
-#[derive(Debug, Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TopicInfo {
     /// The ID of the topic for which information is requested.
     pub topic_id: TopicId,
@@ -46,14 +45,17 @@ pub struct TopicInfo {
     pub topic_memo: String,
 
     /// SHA-384 running hash of (previousRunningHash, topicId, consensusTimestamp, sequenceNumber, message).
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub running_hash: Vec<u8>,
 
     /// Sequence number (starting at 1 for the first submitMessage) of messages on the topic.
     pub sequence_number: u64,
 
     /// Effective consensus timestamp at (and after) which submitMessage calls will no longer succeed on the topic.
-    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::TimestampNanoSeconds>>")
+    )]
     pub expiration_time: Option<OffsetDateTime>,
 
     /// Access control for update/delete of the topic.

--- a/sdk/rust/src/topic/topic_info_query.rs
+++ b/sdk/rust/src/topic/topic_info_query.rs
@@ -38,8 +38,9 @@ use crate::{
 /// Retrieve the latest state of a topic.
 pub type TopicInfoQuery = Query<TopicInfoQueryData>;
 
-#[derive(Default, Clone, serde::Serialize, serde::Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TopicInfoQueryData {
     topic_id: Option<TopicId>,
 }

--- a/sdk/rust/src/topic/topic_message.rs
+++ b/sdk/rust/src/topic/topic_message.rs
@@ -19,8 +19,6 @@
  */
 
 use hedera_proto::mirror;
-use serde::Serialize;
-use serde_with::base64::Base64;
 use time::OffsetDateTime;
 
 use crate::{
@@ -30,17 +28,18 @@ use crate::{
 
 /// Topic message records.
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
 pub struct TopicMessage {
     /// The consensus timestamp of the message.
     pub consensus_at: OffsetDateTime,
 
     /// The content of the message.
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub contents: Vec<u8>,
 
     /// The new running hash of the topic that received the message.
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub running_hash: Vec<u8>,
 
     /// Version of the SHA-384 digest used to update the running hash.

--- a/sdk/rust/src/topic/topic_message.rs
+++ b/sdk/rust/src/topic/topic_message.rs
@@ -21,7 +21,6 @@
 use hedera_proto::mirror;
 use serde::Serialize;
 use serde_with::base64::Base64;
-use serde_with::serde_as;
 use time::OffsetDateTime;
 
 use crate::{
@@ -30,18 +29,18 @@ use crate::{
 };
 
 /// Topic message records.
-#[serde_as]
+
 #[derive(Serialize, Clone, Debug)]
 pub struct TopicMessage {
     /// The consensus timestamp of the message.
     pub consensus_at: OffsetDateTime,
 
     /// The content of the message.
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub contents: Vec<u8>,
 
     /// The new running hash of the topic that received the message.
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub running_hash: Vec<u8>,
 
     /// Version of the SHA-384 digest used to update the running hash.

--- a/sdk/rust/src/topic/topic_message_query.rs
+++ b/sdk/rust/src/topic/topic_message_query.rs
@@ -44,8 +44,9 @@ use crate::{
 /// messages for an HCS Topic via a specific (possibly open-ended) time range.
 pub type TopicMessageQuery = MirrorQuery<TopicMessageQueryData>;
 
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(default, rename_all = "camelCase"))]
 pub struct TopicMessageQueryData {
     /// The topic ID to retrieve messages for.
     topic_id: Option<TopicId>,

--- a/sdk/rust/src/topic/topic_message_submit_transaction.rs
+++ b/sdk/rust/src/topic/topic_message_submit_transaction.rs
@@ -21,8 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
-use serde_with::base64::Base64;
-use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -50,16 +48,20 @@ use crate::{
 ///
 pub type TopicMessageSubmitTransaction = Transaction<TopicMessageSubmitTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(default, rename_all = "camelCase"))]
 pub struct TopicMessageSubmitTransactionData {
     /// The topic ID to submit this message to.
     topic_id: Option<TopicId>,
 
     /// Message to be submitted.
     /// Max size of the Transaction (including signatures) is 6KiB.
-    #[serde(with = "serde_with::As::<Option<Base64>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::base64::Base64>>")
+    )]
     message: Option<Vec<u8>>,
 
     /// The `TransactionId` of the first chunk.
@@ -169,27 +171,29 @@ impl From<TopicMessageSubmitTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use std::str::FromStr;
 
-    use assert_matches::assert_matches;
+        use assert_matches::assert_matches;
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        TopicId,
-        TopicMessageSubmitTransaction,
-        TransactionId,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            TopicId,
+            TopicMessageSubmitTransaction,
+            TransactionId,
+        };
 
-    // language=JSON
-    const TOPIC_MESSAGE_SUBMIT_EMPTY: &str = r#"{
+        // language=JSON
+        const TOPIC_MESSAGE_SUBMIT_EMPTY: &str = r#"{
   "$type": "topicMessageSubmit"
 }"#;
 
-    // language=JSON
-    const TOPIC_MESSAGE_SUBMIT_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOPIC_MESSAGE_SUBMIT_TRANSACTION_JSON: &str = r#"{
   "$type": "topicMessageSubmit",
   "topicId": "0.0.1001",
   "message": "TWVzc2FnZQ==",
@@ -198,54 +202,55 @@ mod tests {
   "chunkNumber": 1
 }"#;
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TopicMessageSubmitTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TopicMessageSubmitTransaction::new();
 
-        transaction
-            .topic_id(TopicId::from(1001))
-            .message("Message")
-            .initial_transaction_id(TransactionId::from_str("1001@1656352251.277559886")?)
-            .chunk_total(1)
-            .chunk_number(1);
+            transaction
+                .topic_id(TopicId::from(1001))
+                .message("Message")
+                .initial_transaction_id(TransactionId::from_str("1001@1656352251.277559886")?)
+                .chunk_total(1)
+                .chunk_number(1);
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOPIC_MESSAGE_SUBMIT_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOPIC_MESSAGE_SUBMIT_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction =
-            serde_json::from_str(TOPIC_MESSAGE_SUBMIT_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction =
+                serde_json::from_str(TOPIC_MESSAGE_SUBMIT_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicMessageSubmit(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicMessageSubmit(transaction) => transaction);
 
-        assert_eq!(data.topic_id.unwrap(), TopicId::from(1001));
-        assert_eq!(
-            data.initial_transaction_id.unwrap(),
-            TransactionId::from_str("1001@1656352251.277559886")?
-        );
-        assert_eq!(data.chunk_total, 1);
-        assert_eq!(data.chunk_number, 1);
+            assert_eq!(data.topic_id.unwrap(), TopicId::from(1001));
+            assert_eq!(
+                data.initial_transaction_id.unwrap(),
+                TransactionId::from_str("1001@1656352251.277559886")?
+            );
+            assert_eq!(data.chunk_total, 1);
+            assert_eq!(data.chunk_number, 1);
 
-        let bytes: Vec<u8> = "Message".into();
-        assert_eq!(data.message.unwrap(), bytes);
+            let bytes: Vec<u8> = "Message".into();
+            assert_eq!(data.message.unwrap(), bytes);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize_empty() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOPIC_MESSAGE_SUBMIT_EMPTY)?;
+        #[test]
+        fn it_should_deserialize_empty() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOPIC_MESSAGE_SUBMIT_EMPTY)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicMessageSubmit(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicMessageSubmit(transaction) => transaction);
 
-        assert_eq!(data.chunk_number, 1);
-        assert_eq!(data.chunk_total, 1);
+            assert_eq!(data.chunk_number, 1);
+            assert_eq!(data.chunk_total, 1);
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/topic/topic_message_submit_transaction.rs
+++ b/sdk/rust/src/topic/topic_message_submit_transaction.rs
@@ -22,10 +22,7 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
 use serde_with::base64::Base64;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 use tonic::transport::Channel;
 
 use crate::protobuf::ToProtobuf;
@@ -53,7 +50,6 @@ use crate::{
 ///
 pub type TopicMessageSubmitTransaction = Transaction<TopicMessageSubmitTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -63,7 +59,7 @@ pub struct TopicMessageSubmitTransactionData {
 
     /// Message to be submitted.
     /// Max size of the Transaction (including signatures) is 6KiB.
-    #[serde_as(as = "Option<Base64>")]
+    #[serde(with = "serde_with::As::<Option<Base64>>")]
     message: Option<Vec<u8>>,
 
     /// The `TransactionId` of the first chunk.

--- a/sdk/rust/src/topic/topic_update_transaction.rs
+++ b/sdk/rust/src/topic/topic_update_transaction.rs
@@ -22,7 +22,6 @@ use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     DurationSeconds,
     TimestampNanoSeconds,
@@ -53,7 +52,6 @@ use crate::{
 ///
 pub type TopicUpdateTransaction = Transaction<TopicUpdateTransactionData>;
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -62,7 +60,7 @@ pub struct TopicUpdateTransactionData {
     topic_id: Option<TopicId>,
 
     /// The new expiration time to extend to (ignored if equal to or before the current one).
-    #[serde_as(as = "Option<TimestampNanoSeconds>")]
+    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
     expiration_time: Option<OffsetDateTime>,
 
     /// Short publicly visible memo about the topic. No guarantee of uniqueness.
@@ -77,7 +75,7 @@ pub struct TopicUpdateTransactionData {
     /// The initial lifetime of the topic and the amount of time to attempt to
     /// extend the topic's lifetime by automatically at the topic's expiration time, if
     /// the `auto_renew_account_id` is configured.
-    #[serde_as(as = "Option<DurationSeconds<i64>>")]
+    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
     auto_renew_period: Option<Duration>,
 
     /// Optional account to be used at the topic's expiration time to extend the life of the topic.

--- a/sdk/rust/src/topic/topic_update_transaction.rs
+++ b/sdk/rust/src/topic/topic_update_transaction.rs
@@ -21,11 +21,6 @@
 use async_trait::async_trait;
 use hedera_proto::services;
 use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
-use serde_with::{
-    skip_serializing_none,
-    DurationSeconds,
-    TimestampNanoSeconds,
-};
 use time::{
     Duration,
     OffsetDateTime,
@@ -52,15 +47,19 @@ use crate::{
 ///
 pub type TopicUpdateTransaction = Transaction<TopicUpdateTransactionData>;
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TopicUpdateTransactionData {
     /// The topic ID which is being updated in this transaction.
     topic_id: Option<TopicId>,
 
     /// The new expiration time to extend to (ignored if equal to or before the current one).
-    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::TimestampNanoSeconds>>")
+    )]
     expiration_time: Option<OffsetDateTime>,
 
     /// Short publicly visible memo about the topic. No guarantee of uniqueness.
@@ -75,7 +74,10 @@ pub struct TopicUpdateTransactionData {
     /// The initial lifetime of the topic and the amount of time to attempt to
     /// extend the topic's lifetime by automatically at the topic's expiration time, if
     /// the `auto_renew_account_id` is configured.
-    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::DurationSeconds<i64>>>")
+    )]
     auto_renew_period: Option<Duration>,
 
     /// Optional account to be used at the topic's expiration time to extend the life of the topic.
@@ -176,28 +178,30 @@ impl From<TopicUpdateTransactionData> for AnyTransactionData {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    #[cfg(feature = "ffi")]
+    mod ffi {
+        use std::str::FromStr;
 
-    use assert_matches::assert_matches;
-    use time::{
-        Duration,
-        OffsetDateTime,
-    };
+        use assert_matches::assert_matches;
+        use time::{
+            Duration,
+            OffsetDateTime,
+        };
 
-    use crate::transaction::{
-        AnyTransaction,
-        AnyTransactionData,
-    };
-    use crate::{
-        AccountId,
-        Key,
-        PublicKey,
-        TopicId,
-        TopicUpdateTransaction,
-    };
+        use crate::transaction::{
+            AnyTransaction,
+            AnyTransactionData,
+        };
+        use crate::{
+            AccountId,
+            Key,
+            PublicKey,
+            TopicId,
+            TopicUpdateTransaction,
+        };
 
-    // language=JSON
-    const TOPIC_UPDATE_TRANSACTION_JSON: &str = r#"{
+        // language=JSON
+        const TOPIC_UPDATE_TRANSACTION_JSON: &str = r#"{
   "$type": "topicUpdate",
   "topicId": "0.0.1001",
   "expirationTime": 1656352251277559886,
@@ -212,55 +216,56 @@ mod tests {
   "autoRenewAccountId": "0.0.1001"
 }"#;
 
-    const ADMIN_KEY: &str =
-        "302a300506032b6570032100d1ad76ed9b057a3d3f2ea2d03b41bcd79aeafd611f941924f0f6da528ab066fd";
-    const SUBMIT_KEY: &str =
-        "302a300506032b6570032100b5b4d9351ebdf266ef3989aed4fd8f0cfcf24b75ba3d0df19cd3946771b40500";
+        const ADMIN_KEY: &str =
+            "302a300506032b6570032100d1ad76ed9b057a3d3f2ea2d03b41bcd79aeafd611f941924f0f6da528ab066fd";
+        const SUBMIT_KEY: &str =
+            "302a300506032b6570032100b5b4d9351ebdf266ef3989aed4fd8f0cfcf24b75ba3d0df19cd3946771b40500";
 
-    #[test]
-    fn it_should_serialize() -> anyhow::Result<()> {
-        let mut transaction = TopicUpdateTransaction::new();
+        #[test]
+        fn it_should_serialize() -> anyhow::Result<()> {
+            let mut transaction = TopicUpdateTransaction::new();
 
-        transaction
-            .topic_id(TopicId::from(1001))
-            .expiration_time(OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?)
-            .topic_memo("A topic memo")
-            .admin_key(PublicKey::from_str(ADMIN_KEY)?)
-            .submit_key(PublicKey::from_str(SUBMIT_KEY)?)
-            .auto_renew_period(Duration::days(90))
-            .auto_renew_account_id(AccountId::from(1001));
+            transaction
+                .topic_id(TopicId::from(1001))
+                .expiration_time(OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?)
+                .topic_memo("A topic memo")
+                .admin_key(PublicKey::from_str(ADMIN_KEY)?)
+                .submit_key(PublicKey::from_str(SUBMIT_KEY)?)
+                .auto_renew_period(Duration::days(90))
+                .auto_renew_account_id(AccountId::from(1001));
 
-        let transaction_json = serde_json::to_string_pretty(&transaction)?;
+            let transaction_json = serde_json::to_string_pretty(&transaction)?;
 
-        assert_eq!(transaction_json, TOPIC_UPDATE_TRANSACTION_JSON);
+            assert_eq!(transaction_json, TOPIC_UPDATE_TRANSACTION_JSON);
 
-        Ok(())
-    }
+            Ok(())
+        }
 
-    #[test]
-    fn it_should_deserialize() -> anyhow::Result<()> {
-        let transaction: AnyTransaction = serde_json::from_str(TOPIC_UPDATE_TRANSACTION_JSON)?;
+        #[test]
+        fn it_should_deserialize() -> anyhow::Result<()> {
+            let transaction: AnyTransaction = serde_json::from_str(TOPIC_UPDATE_TRANSACTION_JSON)?;
 
-        let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicUpdate(transaction) => transaction);
+            let data = assert_matches!(transaction.body.data, AnyTransactionData::TopicUpdate(transaction) => transaction);
 
-        assert_eq!(data.topic_id.unwrap(), TopicId::from(1001));
-        assert_eq!(
-            data.expiration_time.unwrap(),
-            OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?
-        );
-        assert_eq!(data.topic_memo.unwrap(), "A topic memo");
-        assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
+            assert_eq!(data.topic_id.unwrap(), TopicId::from(1001));
+            assert_eq!(
+                data.expiration_time.unwrap(),
+                OffsetDateTime::from_unix_timestamp_nanos(1656352251277559886)?
+            );
+            assert_eq!(data.topic_memo.unwrap(), "A topic memo");
+            assert_eq!(data.auto_renew_period.unwrap(), Duration::days(90));
 
-        let admin_key =
-            assert_matches!(data.admin_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(admin_key, PublicKey::from_str(ADMIN_KEY)?);
+            let admin_key =
+                assert_matches!(data.admin_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(admin_key, PublicKey::from_str(ADMIN_KEY)?);
 
-        let submit_key =
-            assert_matches!(data.submit_key.unwrap(), Key::Single(public_key) => public_key);
-        assert_eq!(submit_key, PublicKey::from_str(SUBMIT_KEY)?);
+            let submit_key =
+                assert_matches!(data.submit_key.unwrap(), Key::Single(public_key) => public_key);
+            assert_eq!(submit_key, PublicKey::from_str(SUBMIT_KEY)?);
 
-        assert_eq!(data.auto_renew_account_id, Some(AccountId::from(1001)));
+            assert_eq!(data.auto_renew_account_id, Some(AccountId::from(1001)));
 
-        Ok(())
+            Ok(())
+        }
     }
 }

--- a/sdk/rust/src/transaction/any.rs
+++ b/sdk/rust/src/transaction/any.rs
@@ -25,7 +25,6 @@ use serde::{
     Deserializer,
 };
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     DurationSeconds,
 };
@@ -429,7 +428,6 @@ impl TransactionExecute for AnyTransactionData {
 //  we create a proxy type that has the same layout but is only for AnyQueryData and does
 //  derive(Deserialize).
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(serde::Deserialize, serde::Serialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
@@ -440,7 +438,7 @@ pub(crate) struct AnyTransactionBody<D> {
     #[serde(default)]
     node_account_ids: Option<Vec<AccountId>>,
 
-    #[serde_as(as = "Option<DurationSeconds<i64>>")]
+    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
     #[serde(default)]
     transaction_valid_duration: Option<Duration>,
 

--- a/sdk/rust/src/transaction/any.rs
+++ b/sdk/rust/src/transaction/any.rs
@@ -20,14 +20,6 @@
 
 use async_trait::async_trait;
 use hedera_proto::services;
-use serde::{
-    Deserialize,
-    Deserializer,
-};
-use serde_with::{
-    skip_serializing_none,
-    DurationSeconds,
-};
 use time::Duration;
 use tonic::transport::Channel;
 use tonic::{
@@ -101,11 +93,13 @@ use crate::{
     TransactionId,
 };
 
+#[cfg(feature = "ffi")]
 /// Any possible transaction that may be executed on the Hedera network.
 pub type AnyTransaction = Transaction<AnyTransactionData>;
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase", tag = "$type")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase", tag = "$type"))]
 pub enum AnyTransactionData {
     AccountCreate(AccountCreateTransactionData),
     AccountUpdate(AccountUpdateTransactionData),
@@ -428,30 +422,34 @@ impl TransactionExecute for AnyTransactionData {
 //  we create a proxy type that has the same layout but is only for AnyQueryData and does
 //  derive(Deserialize).
 
-#[skip_serializing_none]
-#[derive(serde::Deserialize, serde::Serialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub(crate) struct AnyTransactionBody<D> {
-    #[serde(flatten)]
+    #[cfg_attr(feature = "ffi", serde(flatten))]
     data: D,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     node_account_ids: Option<Vec<AccountId>>,
 
-    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
-    #[serde(default)]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::DurationSeconds<i64>>>")
+    )]
+    #[cfg_attr(feature = "ffi", serde(default))]
     transaction_valid_duration: Option<Duration>,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     max_transaction_fee: Option<Hbar>,
 
-    #[serde(default, skip_serializing_if = "String::is_empty")]
+    #[cfg_attr(feature = "ffi", serde(default, skip_serializing_if = "String::is_empty"))]
     transaction_memo: String,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     payer_account_id: Option<AccountId>,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     transaction_id: Option<TransactionId>,
 }
 
@@ -498,12 +496,13 @@ where
     }
 }
 
-impl<'de> Deserialize<'de> for AnyTransaction {
+#[cfg(feature = "ffi")]
+impl<'de> serde::Deserialize<'de> for AnyTransaction {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde::Deserializer<'de>,
     {
-        <AnyTransactionBody<AnyTransactionData> as Deserialize>::deserialize(deserializer)
+        <AnyTransactionBody<AnyTransactionData> as serde::Deserialize>::deserialize(deserializer)
             .map(AnyTransactionBody::into)
     }
 }

--- a/sdk/rust/src/transaction/mod.rs
+++ b/sdk/rust/src/transaction/mod.rs
@@ -25,7 +25,6 @@ use std::fmt::{
 };
 
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     DurationSeconds,
     FromInto,
@@ -69,7 +68,6 @@ where
     pub(crate) signers: Vec<Box<dyn Signer>>,
 }
 
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Default, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -80,12 +78,12 @@ where
     D: TransactionExecute,
 {
     #[serde(flatten)]
-    #[serde_as(as = "FromInto<AnyTransactionData>")]
+    #[serde(with = "serde_with::As::<FromInto<AnyTransactionData>>")]
     pub(crate) data: D,
 
     pub(crate) node_account_ids: Option<Vec<AccountId>>,
 
-    #[serde_as(as = "Option<DurationSeconds<i64>>")]
+    #[serde(with = "serde_with::As::<Option<DurationSeconds<i64>>>")]
     pub(crate) transaction_valid_duration: Option<Duration>,
 
     pub(crate) max_transaction_fee: Option<Hbar>,

--- a/sdk/rust/src/transaction_hash.rs
+++ b/sdk/rust/src/transaction_hash.rs
@@ -25,7 +25,6 @@ use std::fmt::{
     Formatter,
 };
 
-use serde_with::SerializeDisplay;
 use sha2::{
     Digest,
     Sha384,
@@ -34,7 +33,8 @@ use sha2::{
 /// The client-generated SHA-384 hash of a transaction that was submitted.
 ///
 /// This can be used to lookup the transaction in an explorer.
-#[derive(Copy, Clone, Hash, SerializeDisplay)]
+#[derive(Copy, Clone, Hash)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay))]
 pub struct TransactionHash(pub [u8; 48]);
 
 impl TransactionHash {

--- a/sdk/rust/src/transaction_id.rs
+++ b/sdk/rust/src/transaction_id.rs
@@ -31,10 +31,6 @@ use rand::{
     thread_rng,
     Rng,
 };
-use serde_with::{
-    DeserializeFromStr,
-    SerializeDisplay,
-};
 use time::{
     Duration,
     OffsetDateTime,
@@ -53,7 +49,8 @@ use crate::{
 /// right after creating it, for instantiating a smart contract with bytecode in a file just created,
 /// and internally by the network for detecting when duplicate transactions are submitted.
 ///
-#[derive(Clone, Copy, Eq, PartialEq, Hash, SerializeDisplay, DeserializeFromStr)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "ffi", derive(serde_with::SerializeDisplay, serde_with::DeserializeFromStr))]
 pub struct TransactionId {
     /// The account that pays for this transaction.
     pub account_id: AccountId,

--- a/sdk/rust/src/transaction_receipt.rs
+++ b/sdk/rust/src/transaction_receipt.rs
@@ -22,10 +22,7 @@ use std::ops::Not;
 
 use hedera_proto::services;
 use serde_with::base64::Base64;
-use serde_with::{
-    serde_as,
-    skip_serializing_none,
-};
+use serde_with::skip_serializing_none;
 
 use crate::protobuf::ToProtobuf;
 use crate::{
@@ -43,7 +40,7 @@ use crate::{
 
 /// The summary of a transaction's result so far, if the transaction has reached consensus.
 /// Response from [`TransactionReceiptQuery`][crate::TransactionReceiptQuery].
-#[serde_as]
+
 #[skip_serializing_none]
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -73,7 +70,7 @@ pub struct TransactionReceipt {
     // TODO: use a hash type (for display/debug/serialize purposes)
     /// In the receipt for a `TopicMessageSubmitTransaction`, the new running hash of the
     /// topic that received the message.
-    #[serde_as(as = "Option<Base64>")]
+    #[serde(with = "serde_with::As::<Option<Base64>>")]
     pub topic_running_hash: Option<Vec<u8>>,
 
     /// In the receipt of a `TopicMessageSubmitTransaction`, the version of the SHA-384

--- a/sdk/rust/src/transaction_receipt.rs
+++ b/sdk/rust/src/transaction_receipt.rs
@@ -21,8 +21,6 @@
 use std::ops::Not;
 
 use hedera_proto::services;
-use serde_with::base64::Base64;
-use serde_with::skip_serializing_none;
 
 use crate::protobuf::ToProtobuf;
 use crate::{
@@ -41,9 +39,10 @@ use crate::{
 /// The summary of a transaction's result so far, if the transaction has reached consensus.
 /// Response from [`TransactionReceiptQuery`][crate::TransactionReceiptQuery].
 
-#[skip_serializing_none]
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TransactionReceipt {
     /// The consensus status of the transaction; is UNKNOWN if consensus has not been reached, or if
     /// the associated transaction did not have a valid payer signature.
@@ -70,7 +69,10 @@ pub struct TransactionReceipt {
     // TODO: use a hash type (for display/debug/serialize purposes)
     /// In the receipt for a `TopicMessageSubmitTransaction`, the new running hash of the
     /// topic that received the message.
-    #[serde(with = "serde_with::As::<Option<Base64>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::base64::Base64>>")
+    )]
     pub topic_running_hash: Option<Vec<u8>>,
 
     /// In the receipt of a `TopicMessageSubmitTransaction`, the version of the SHA-384

--- a/sdk/rust/src/transaction_receipt_query.rs
+++ b/sdk/rust/src/transaction_receipt_query.rs
@@ -46,8 +46,9 @@ use crate::{
 ///
 pub type TransactionReceiptQuery = Query<TransactionReceiptQueryData>;
 
-#[derive(Default, Clone, serde::Serialize, serde::Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TransactionReceiptQueryData {
     transaction_id: Option<TransactionId>,
     include_children: bool,

--- a/sdk/rust/src/transaction_record.rs
+++ b/sdk/rust/src/transaction_record.rs
@@ -19,11 +19,6 @@
  */
 
 use hedera_proto::services;
-use serde_with::base64::Base64;
-use serde_with::{
-    skip_serializing_none,
-    TimestampNanoSeconds,
-};
 use time::OffsetDateTime;
 
 use crate::{
@@ -39,9 +34,10 @@ use crate::{
 
 /// The complete record for a transaction on Hedera that has reached consensus.
 /// Response from [`TransactionRecordQuery`][crate::TransactionRecordQuery].
-#[skip_serializing_none]
-#[derive(Debug, Clone, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", serde_with::skip_serializing_none)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TransactionRecord {
     /// The status (reach consensus, or failed, or is unknown) and the ID of
     /// any new account/file/instance created.
@@ -49,11 +45,14 @@ pub struct TransactionRecord {
 
     /// The hash of the Transaction that executed (not the hash of any Transaction that failed for
     /// having a duplicate TransactionID).
-    #[serde(with = "serde_with::As::<Base64>")]
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub transaction_hash: Vec<u8>,
 
     /// The consensus timestamp.
-    #[serde(with = "serde_with::As::<TimestampNanoSeconds>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<serde_with::TimestampNanoSeconds>")
+    )]
     pub consensus_timestamp: OffsetDateTime,
 
     /// The ID of the transaction this record represents.
@@ -76,7 +75,10 @@ pub struct TransactionRecord {
 
     /// In the record of an internal transaction, the consensus timestamp of the user
     /// transaction that spawned it.
-    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
+    #[cfg_attr(
+        feature = "ffi",
+        serde(with = "serde_with::As::<Option<serde_with::TimestampNanoSeconds>>")
+    )]
     pub parent_consensus_timestamp: Option<OffsetDateTime>,
 
     /// In the record of an internal CryptoCreate transaction triggered by a user

--- a/sdk/rust/src/transaction_record.rs
+++ b/sdk/rust/src/transaction_record.rs
@@ -21,7 +21,6 @@
 use hedera_proto::services;
 use serde_with::base64::Base64;
 use serde_with::{
-    serde_as,
     skip_serializing_none,
     TimestampNanoSeconds,
 };
@@ -40,7 +39,6 @@ use crate::{
 
 /// The complete record for a transaction on Hedera that has reached consensus.
 /// Response from [`TransactionRecordQuery`][crate::TransactionRecordQuery].
-#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -51,11 +49,11 @@ pub struct TransactionRecord {
 
     /// The hash of the Transaction that executed (not the hash of any Transaction that failed for
     /// having a duplicate TransactionID).
-    #[serde_as(as = "Base64")]
+    #[serde(with = "serde_with::As::<Base64>")]
     pub transaction_hash: Vec<u8>,
 
     /// The consensus timestamp.
-    #[serde_as(as = "TimestampNanoSeconds")]
+    #[serde(with = "serde_with::As::<TimestampNanoSeconds>")]
     pub consensus_timestamp: OffsetDateTime,
 
     /// The ID of the transaction this record represents.
@@ -78,7 +76,7 @@ pub struct TransactionRecord {
 
     /// In the record of an internal transaction, the consensus timestamp of the user
     /// transaction that spawned it.
-    #[serde_as(as = "Option<TimestampNanoSeconds>")]
+    #[serde(with = "serde_with::As::<Option<TimestampNanoSeconds>>")]
     pub parent_consensus_timestamp: Option<OffsetDateTime>,
 
     /// In the record of an internal CryptoCreate transaction triggered by a user

--- a/sdk/rust/src/transaction_record_query.rs
+++ b/sdk/rust/src/transaction_record_query.rs
@@ -43,8 +43,9 @@ use crate::{
 ///
 pub type TransactionRecordQuery = Query<TransactionRecordQueryData>;
 
-#[derive(Default, Clone, serde::Serialize, serde::Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TransactionRecordQueryData {
     transaction_id: Option<TransactionId>,
     include_children: bool,

--- a/sdk/rust/src/transaction_response.rs
+++ b/sdk/rust/src/transaction_response.rs
@@ -36,8 +36,9 @@ use crate::{
 /// To learn the consensus result, the client should later obtain a
 /// receipt (free), or can buy a more detailed record (not free).
 ///
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 pub struct TransactionResponse {
     /// The account ID of the node that the transaction was submitted to.
     pub node_account_id: AccountId,

--- a/sdk/rust/src/transfer_transaction.rs
+++ b/sdk/rust/src/transfer_transaction.rs
@@ -48,50 +48,54 @@ use crate::{
 ///
 pub type TransferTransaction = Transaction<TransferTransactionData>;
 
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(default, rename_all = "camelCase"))]
 pub struct TransferTransactionData {
     transfers: Vec<Transfer>,
     token_transfers: Vec<TokenTransfer>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 struct Transfer {
     account_id: AccountId,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     amount: i64,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     is_approval: bool,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 struct TokenTransfer {
     token_id: TokenId,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     transfers: Vec<Transfer>,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     nft_transfers: Vec<NftTransfer>,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     expected_decimals: Option<u32>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
 struct NftTransfer {
     sender_account_id: AccountId,
     receiver_account_id: AccountId,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     serial: u64,
 
-    #[serde(default)]
+    #[cfg_attr(feature = "ffi", serde(default))]
     is_approval: bool,
 }
 


### PR DESCRIPTION
**Description**:
The entire point of all the serde traits here is _specifically_ for the ffi feature, which we want to remove eventually:tm:.

Once CI is merged this will noticeably reduce the amount of time required for it to run, well, for the rust only CI jobs anyway, the Swift ones will get _some_ benefit because of other fat-trimming measures, but they won't be as pronounced.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
