### PR TITLE
feat(rust): Add all the `get_*` methods to `ContractFunctionResult`

### DIFF
--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -429,6 +429,18 @@ enum HederaError hedera_contract_info_from_bytes(const uint8_t *bytes, size_t by
 enum HederaError hedera_contract_info_to_bytes(const char *s, uint8_t **buf, size_t *buf_size);
 
 /**
+ * # Safety
+ * - `bytes` must be valid for reads of up to `bytes_size` bytes.
+ * - `s` must only be freed with `hedera_string_free`,
+ *   notably this means it must not be freed with `free`.
+ */
+enum HederaError hedera_contract_log_info_from_bytes(const uint8_t *bytes,
+                                                     size_t bytes_size,
+                                                     char **s);
+
+enum HederaError hedera_contract_log_info_to_bytes(const char *s, uint8_t **buf, size_t *buf_size);
+
+/**
  * Parse a Hedera `FileId` from the passed bytes.
  *
  * # Safety

--- a/sdk/rust/src/contract/contract_function_result.rs
+++ b/sdk/rust/src/contract/contract_function_result.rs
@@ -18,7 +18,14 @@
  * ‍
  */
 
+use std::borrow::Cow;
+use std::str;
+
 use hedera_proto::services;
+use num_bigint::{
+    BigInt,
+    BigUint,
+};
 
 use crate::{
     AccountId,
@@ -28,7 +35,6 @@ use crate::{
 
 // TODO: log info
 /// The result returned by a call to a smart contract function.
-
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
@@ -67,6 +73,132 @@ pub struct ContractFunctionResult {
     pub sender_account_id: Option<AccountId>,
 }
 
+impl ContractFunctionResult {
+    const SLOT_SIZE: usize = 32;
+
+    fn get_fixed_bytes<const N: usize>(&self, slot: usize) -> Option<&[u8; N]> {
+        self.get_fixed_bytes_at(slot * Self::SLOT_SIZE + (Self::SLOT_SIZE - N))
+    }
+
+    // fixme(sr): name is weird, but I can't think of a better one.
+    // basically, there's `get_fixed_bytes` which works off of "slots" (multiples of 32 bytes), and this version, which can be from anywhere.
+    fn get_fixed_bytes_at<const N: usize>(&self, offset: usize) -> Option<&[u8; N]> {
+        self.bytes.get(offset..).and_then(|it| it.get(..N)).map(|it| it.try_into().unwrap())
+    }
+
+    // fixme(sr): name is weird, but I can't think of a better one.
+    fn get_u32_at(&self, offset: usize) -> Option<u32> {
+        self.get_fixed_bytes_at(28 + offset).map(|it| u32::from_be_bytes(*it))
+    }
+
+    fn offset_len_pair(&self, offset: usize) -> Option<(usize, usize)> {
+        let offset = self.get_u32(offset)? as usize;
+        let len = self.get_u32_at(offset)? as usize;
+        Some((offset, len))
+    }
+
+    /// Get the whole raw function result.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    // note: This would be best named `get_str_lossy` but consistency :/
+    /// Get the value at `index` as a solidity `string`.
+    ///
+    /// Theoretically, all strings here should be utf8, but this function does _lossy_ conversion.
+    pub fn get_str(&self, index: usize) -> Option<Cow<str>> {
+        self.get_bytes(index).map(String::from_utf8_lossy)
+    }
+    /// Get the value at `index` as a solidity `string[]`.
+    ///
+    /// Theoretically, all strings here should be utf8, but this function does _lossy_ conversion.
+    pub fn get_str_array(&self, index: usize) -> Option<Vec<Cow<str>>> {
+        let (offset, len) = dbg!(self.offset_len_pair(index)?);
+
+        let mut v = Vec::with_capacity(len);
+        for i in 0..len {
+            let str_offset =
+                self.get_u32_at(offset + Self::SLOT_SIZE + (i * Self::SLOT_SIZE))? as usize;
+            let str_offset = offset + str_offset + Self::SLOT_SIZE;
+            let len = self.get_u32_at(str_offset)? as usize;
+
+            let bytes =
+                self.bytes.get((str_offset + Self::SLOT_SIZE)..).and_then(|it| it.get(..len))?;
+
+            v.push(String::from_utf8_lossy(bytes))
+        }
+
+        Some(v)
+    }
+
+    /// Get the value at `index` as solidity `bytes`.
+    pub fn get_bytes(&self, index: usize) -> Option<&[u8]> {
+        let (offset, len) = self.offset_len_pair(index)?;
+        self.bytes.get((offset + Self::SLOT_SIZE)..).and_then(|it| it.get(..len))
+    }
+
+    /// Get the value at `index` as solidity `bytes32`.
+    ///
+    /// This is the native word size for the solidity ABI.
+    pub fn get_bytes32(&self, index: usize) -> Option<&[u8; 32]> {
+        self.get_fixed_bytes(index)
+    }
+
+    /// Get the value at `index` as a solidity `address` and then hex-encode the result.
+    pub fn get_address(&self, index: usize) -> Option<String> {
+        self.get_fixed_bytes::<20>(index).map(hex::encode)
+    }
+
+    /// Get the value at `index` as a solidity `bool`.
+    pub fn get_bool(&self, index: usize) -> Option<bool> {
+        self.get_u8(index).map(|it| it != 0)
+    }
+
+    /// Get the value at `index` as a solidity `u8`.
+    pub fn get_u8(&self, index: usize) -> Option<u8> {
+        self.get_fixed_bytes(index).map(|it| u8::from_be_bytes(*it))
+    }
+
+    /// Get the value at `index` as a solidity `i8`.
+    pub fn get_i8(&self, index: usize) -> Option<i8> {
+        self.get_fixed_bytes(index).map(|it| i8::from_be_bytes(*it))
+    }
+
+    /// Get the value at `index` as a solidity `u32`.
+    pub fn get_u32(&self, index: usize) -> Option<u32> {
+        self.get_fixed_bytes(index).map(|it| u32::from_be_bytes(*it))
+    }
+
+    /// Get the value at `index` as a solidity `i32`.
+    pub fn get_i32(&self, index: usize) -> Option<i32> {
+        self.get_fixed_bytes(index).map(|it| i32::from_be_bytes(*it))
+    }
+
+    /// Get the value at `index` as a solidity `u64`.
+    pub fn get_u64(&self, index: usize) -> Option<u64> {
+        self.get_fixed_bytes(index).map(|it| u64::from_be_bytes(*it))
+    }
+
+    /// Get the value at `index` as a solidity `i64`.
+    pub fn get_i64(&self, index: usize) -> Option<i64> {
+        self.get_fixed_bytes(index).map(|it| i64::from_be_bytes(*it))
+    }
+
+    /// Get the value at `index` as a solidity `u256` (`uint`).
+    ///
+    /// This is the native unsigned integer size for the solidity ABI.
+    pub fn get_u256(&self, index: usize) -> Option<BigUint> {
+        self.get_bytes32(index).map(|it| BigUint::from_bytes_be(it))
+    }
+
+    /// Get the value at `index` as a solidity `i256` (`int`).
+    ///
+    /// This is the native unsigned integer size for the solidity ABI.
+    pub fn get_i256(&self, index: usize) -> Option<BigInt> {
+        self.get_bytes32(index).map(|it| BigInt::from_signed_bytes_be(it))
+    }
+}
+
 impl FromProtobuf<services::ContractFunctionResult> for ContractFunctionResult {
     fn from_protobuf(pb: services::ContractFunctionResult) -> crate::Result<Self>
     where
@@ -77,15 +209,29 @@ impl FromProtobuf<services::ContractFunctionResult> for ContractFunctionResult {
 
         let sender_account_id = Option::from_protobuf(pb.sender_id)?;
 
-        let evm_address = pb
-            .evm_address
-            .and_then(|address| <[u8; 20]>::try_from(address).ok())
-            .map(ContractId::from);
+        let evm_address =
+            pb.evm_address.and_then(|address| <[u8; 20]>::try_from(address).ok()).map(|address| {
+                ContractId::from_evm_address_bytes(contract_id.shard, contract_id.realm, address)
+            });
+
+        let error_message = if pb.error_message.is_empty() { None } else { Some(pb.error_message) };
+
+        // if an exception was thrown, the call result is encoded like the params
+        // for a function `Error(string)`
+        // https://solidity.readthedocs.io/en/v0.6.2/control-structures.html#revert
+        let bytes = if error_message.is_some() {
+            pb.contract_call_result
+                .strip_prefix(&[0x08, 0xc3, 0x79, 0xa0])
+                .map(|it| it.to_vec())
+                .unwrap_or(pb.contract_call_result)
+        } else {
+            pb.contract_call_result
+        };
 
         Ok(Self {
             contract_id,
-            bytes: pb.contract_call_result,
-            error_message: if pb.error_message.is_empty() { None } else { Some(pb.error_message) },
+            bytes,
+            error_message,
             bloom: pb.bloom,
             gas_used: pb.gas_used,
             gas: pb.gas as u64,
@@ -108,5 +254,172 @@ impl FromProtobuf<services::response::Response> for ContractFunctionResult {
         let result = ContractFunctionResult::from_protobuf(result)?;
 
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fraction::{
+        BigInt,
+        BigUint,
+    };
+    use hedera_proto::services;
+    use hex_literal::hex;
+
+    use crate::protobuf::{
+        FromProtobuf,
+        ToProtobuf,
+    };
+    use crate::{
+        AccountId,
+        ContractFunctionResult,
+        ContractId,
+    };
+
+    const CALL_RESULT: [u8; 320] = hex!(
+        "00000000000000000000000000000000000000000000000000000000ffffffff"
+        "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        "00000000000000000000000011223344556677889900aabbccddeeff00112233"
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        "00000000000000000000000000000000000000000000000000000000000000c0"
+        "0000000000000000000000000000000000000000000000000000000000000100"
+        "000000000000000000000000000000000000000000000000000000000000000d"
+        "48656c6c6f2c20776f726c642100000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000014"
+        "48656c6c6f2c20776f726c642c20616761696e21000000000000000000000000"
+    );
+
+    const STRING_ARRAY_RESULT: [u8; 256] = hex!(
+        "0000000000000000000000000000000000000000000000000000000000000020"
+        "0000000000000000000000000000000000000000000000000000000000000002"
+        "0000000000000000000000000000000000000000000000000000000000000040"
+        "0000000000000000000000000000000000000000000000000000000000000080"
+        "000000000000000000000000000000000000000000000000000000000000000C"
+        "72616E646F6D2062797465730000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000E"
+        "72616E646F6D2062797465732032000000000000000000000000000000000000"
+    );
+
+    // previous one, just offset by a bit, to ensure the logic works.
+    // notes below, where `slot` is just an offset at a multiple of 32 bytes.
+    const STRING_ARRAY_RESULT_2: [u8; 320] = hex!(
+        // empty value at slot 0
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        // reference to slot 3 at slot 1
+        // this is interpreted as a string[]
+        "0000000000000000000000000000000000000000000000000000000000000060"
+        // empty value at slot 2
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        // length of string (2 items) at slot 3
+        "0000000000000000000000000000000000000000000000000000000000000002"
+        // relative offset of strings[0] (2 slots) at slot 4
+        "0000000000000000000000000000000000000000000000000000000000000040"
+        // relative offset of strings[1] (4 slots) at slot 5
+        "0000000000000000000000000000000000000000000000000000000000000080"
+        // length of strings[0] (12 bytes) at slot 6
+        "000000000000000000000000000000000000000000000000000000000000000c"
+        // first 12 bytes: value of strings[0], rest is filler, at slot 7
+        "72616e646f6d206279746573000000000000000000000000c0ffee0000000000"
+        // length of strings[1] (14 bytes) at slot 8
+        "000000000000000000000000000000000000000000000000000000000000000e"
+        // first 14 bytes: value of strings[0], rest is filler, at slot 7
+        "72616E646F6D2062797465732032000000000000decaff000000000000000000"
+    );
+
+    #[test]
+    fn evm_address() {
+        const EVM_ADDRESS: [u8; 20] = hex!("98329e006610472e6b372c080833f6d79ed833cf");
+        let result = services::ContractFunctionResult {
+            contract_id: Some(ContractId::new(3, 7, 13).to_protobuf()),
+            evm_address: Some(EVM_ADDRESS.to_vec()),
+            ..Default::default()
+        };
+
+        let result = ContractFunctionResult::from_protobuf(result).unwrap();
+
+        assert_eq!(result.contract_id, ContractId::new(3, 7, 13));
+
+        // ensure that we follow *Java* behavior (every SDK has different behavior here)
+        assert_eq!(result.evm_address, Some(ContractId::from_evm_address_bytes(3, 7, EVM_ADDRESS)));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn provides_results() {
+        let result = services::ContractFunctionResult {
+            contract_id: Some(ContractId::from(3).to_protobuf()),
+            contract_call_result: CALL_RESULT.to_vec(),
+            sender_id: Some(
+                AccountId {
+                    shard: 31,
+                    realm: 41,
+                    num: 65,
+                    alias: None,
+                    evm_address: None,
+                    checksum: None,
+                }
+                .to_protobuf(),
+            ),
+            ..Default::default()
+        };
+
+        let result = ContractFunctionResult::from_protobuf(result).unwrap();
+
+        assert_eq!(result.get_bool(0).unwrap(), true);
+        assert_eq!(result.get_i32(0).unwrap(), -1);
+        assert_eq!(result.get_i64(0).unwrap(), u32::MAX as u64 as i64);
+        assert_eq!(result.get_i256(0).unwrap(), BigInt::from(u32::MAX));
+        assert_eq!(result.get_i256(1).unwrap(), (BigInt::from(1) << 255) - 1);
+        assert_eq!(&result.get_address(2).unwrap(), "11223344556677889900aabbccddeeff00112233");
+        assert_eq!(result.get_u32(3).unwrap(), u32::MAX);
+        assert_eq!(result.get_u64(3).unwrap(), u64::MAX);
+        // BigInteger can represent the full range and so should be 2^256 - 1
+        assert_eq!(result.get_u256(3).unwrap(), (BigUint::from(1_u8) << 256) - 1_u32);
+
+        assert_eq!(result.get_str(4).unwrap(), "Hello, world!");
+        assert_eq!(result.get_str(5).unwrap(), "Hello, world, again!");
+
+        assert_eq!(
+            result.sender_account_id,
+            Some(AccountId {
+                shard: 31,
+                realm: 41,
+                num: 65,
+                alias: None,
+                evm_address: None,
+                checksum: None,
+            })
+        );
+    }
+
+    #[test]
+    fn str_array_results() {
+        let result = services::ContractFunctionResult {
+            contract_id: Some(ContractId::from(3).to_protobuf()),
+            contract_call_result: STRING_ARRAY_RESULT.to_vec(),
+            ..Default::default()
+        };
+
+        let result = ContractFunctionResult::from_protobuf(result).unwrap();
+
+        let strings = result.get_str_array(0).unwrap();
+        assert_eq!(strings[0], "random bytes");
+        assert_eq!(strings[1], "random bytes 2")
+    }
+
+    // previous one, just offset by a bit, to ensure the logic works.
+    #[test]
+    fn str_array_results2() {
+        let result = services::ContractFunctionResult {
+            contract_id: Some(ContractId::from(3).to_protobuf()),
+            contract_call_result: STRING_ARRAY_RESULT_2.to_vec(),
+            ..Default::default()
+        };
+
+        let result = ContractFunctionResult::from_protobuf(result).unwrap();
+
+        let strings = result.get_str_array(1).unwrap();
+        assert_eq!(strings[0], "random bytes");
+        assert_eq!(strings[1], "random bytes 2")
     }
 }

--- a/sdk/rust/src/contract/contract_function_result.rs
+++ b/sdk/rust/src/contract/contract_function_result.rs
@@ -30,10 +30,10 @@ use num_bigint::{
 use crate::{
     AccountId,
     ContractId,
+    ContractLogInfo,
     FromProtobuf,
 };
 
-// TODO: log info
 /// The result returned by a call to a smart contract function.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
@@ -71,6 +71,9 @@ pub struct ContractFunctionResult {
 
     /// The account that is the "sender." If not present it is the accountId from the transactionId.
     pub sender_account_id: Option<AccountId>,
+
+    /// Logs that this call and any called functions produced.
+    pub logs: Vec<ContractLogInfo>,
 }
 
 impl ContractFunctionResult {
@@ -239,6 +242,7 @@ impl FromProtobuf<services::ContractFunctionResult> for ContractFunctionResult {
             contract_function_parameters_bytes: pb.function_parameters,
             sender_account_id,
             evm_address,
+            logs: Vec::from_protobuf(pb.log_info)?,
         })
     }
 }

--- a/sdk/rust/src/contract/contract_log_info.rs
+++ b/sdk/rust/src/contract/contract_log_info.rs
@@ -1,0 +1,37 @@
+use hedera_proto::services;
+
+use crate::protobuf::FromProtobuf;
+use crate::ContractId;
+
+/// The log information for an event returned by a smart contract function call.
+/// One function call may return several such events.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
+pub struct ContractLogInfo {
+    /// Address of the contract that emitted the event.
+    pub contract_id: ContractId,
+
+    /// Bloom filter for this log.
+    pub bloom: Vec<u8>,
+
+    /// A list of topics this log is relevent to.
+    pub topics: Vec<Vec<u8>>,
+
+    /// The log's data payload.
+    pub data: Vec<u8>,
+}
+
+impl FromProtobuf<services::ContractLoginfo> for ContractLogInfo {
+    fn from_protobuf(pb: services::ContractLoginfo) -> crate::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self {
+            contract_id: ContractId::from_protobuf(pb_getf!(pb, contract_id)?)?,
+            bloom: pb.bloom,
+            topics: pb.topic,
+            data: pb.data,
+        })
+    }
+}

--- a/sdk/rust/src/contract/contract_log_info.rs
+++ b/sdk/rust/src/contract/contract_log_info.rs
@@ -13,12 +13,15 @@ pub struct ContractLogInfo {
     pub contract_id: ContractId,
 
     /// Bloom filter for this log.
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub bloom: Vec<u8>,
 
     /// A list of topics this log is relevent to.
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<Vec<serde_with::base64::Base64>>"))]
     pub topics: Vec<Vec<u8>>,
 
     /// The log's data payload.
+    #[cfg_attr(feature = "ffi", serde(with = "serde_with::As::<serde_with::base64::Base64>"))]
     pub data: Vec<u8>,
 }
 

--- a/sdk/rust/src/contract/contract_log_info.rs
+++ b/sdk/rust/src/contract/contract_log_info.rs
@@ -1,6 +1,9 @@
 use hedera_proto::services;
 
-use crate::protobuf::FromProtobuf;
+use crate::protobuf::{
+    FromProtobuf,
+    ToProtobuf,
+};
 use crate::ContractId;
 
 /// The log information for an event returned by a smart contract function call.
@@ -25,6 +28,23 @@ pub struct ContractLogInfo {
     pub data: Vec<u8>,
 }
 
+impl ContractLogInfo {
+    /// Create a new `ContractLogInfo` from protobuf-encoded `bytes`.
+    ///
+    /// # Errors
+    /// - [`Error::FromProtobuf`](crate::Error::FromProtobuf) if decoding the bytes fails to produce a valid protobuf.
+    /// - [`Error::FromProtobuf`](crate::Error::FromProtobuf) if decoding the protobuf fails.
+    pub fn from_bytes(bytes: &[u8]) -> crate::Result<Self> {
+        FromProtobuf::from_bytes(bytes)
+    }
+
+    /// Convert `self` to a protobuf-encoded [`Vec<u8>`].
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToProtobuf::to_bytes(self)
+    }
+}
+
 impl FromProtobuf<services::ContractLoginfo> for ContractLogInfo {
     fn from_protobuf(pb: services::ContractLoginfo) -> crate::Result<Self>
     where
@@ -36,5 +56,18 @@ impl FromProtobuf<services::ContractLoginfo> for ContractLogInfo {
             topics: pb.topic,
             data: pb.data,
         })
+    }
+}
+
+impl ToProtobuf for ContractLogInfo {
+    type Protobuf = services::ContractLoginfo;
+
+    fn to_protobuf(&self) -> Self::Protobuf {
+        Self::Protobuf {
+            contract_id: Some(self.contract_id.to_protobuf()),
+            bloom: self.bloom.clone(),
+            topic: self.topics.clone(),
+            data: self.data.clone(),
+        }
     }
 }

--- a/sdk/rust/src/contract/mod.rs
+++ b/sdk/rust/src/contract/mod.rs
@@ -27,6 +27,7 @@ mod contract_function_result;
 mod contract_id;
 mod contract_info;
 mod contract_info_query;
+mod contract_log_info;
 mod contract_update_transaction;
 
 pub use contract_bytecode_query::ContractBytecodeQuery;
@@ -44,5 +45,6 @@ pub use contract_id::ContractId;
 pub use contract_info::ContractInfo;
 pub use contract_info_query::ContractInfoQuery;
 pub(crate) use contract_info_query::ContractInfoQueryData;
+pub use contract_log_info::ContractLogInfo;
 pub use contract_update_transaction::ContractUpdateTransaction;
 pub(crate) use contract_update_transaction::ContractUpdateTransactionData;

--- a/sdk/rust/src/ffi/contract_id.rs
+++ b/sdk/rust/src/ffi/contract_id.rs
@@ -1,4 +1,3 @@
-use std::ffi::c_char;
 use std::ptr::{
     self,
     NonNull,
@@ -8,7 +7,6 @@ use std::slice;
 use libc::size_t;
 
 use super::error::Error;
-use crate::ffi::util::cstr_from_ptr;
 
 #[derive(Copy, Clone)]
 #[repr(C)]

--- a/sdk/rust/src/ffi/contract_log_info.rs
+++ b/sdk/rust/src/ffi/contract_log_info.rs
@@ -1,0 +1,47 @@
+/*
+ * ‌
+ * Hedera Rust SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+use std::ffi::c_char;
+
+use super::error::Error;
+use crate::ffi::util;
+use crate::ContractLogInfo;
+
+/// # Safety
+/// - `bytes` must be valid for reads of up to `bytes_size` bytes.
+/// - `s` must only be freed with `hedera_string_free`,
+///   notably this means it must not be freed with `free`.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_contract_log_info_from_bytes(
+    bytes: *const u8,
+    bytes_size: libc::size_t,
+    s: *mut *mut c_char,
+) -> Error {
+    unsafe { util::json_from_bytes(bytes, bytes_size, s, ContractLogInfo::from_bytes) }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn hedera_contract_log_info_to_bytes(
+    s: *const c_char,
+    buf: *mut *mut u8,
+    buf_size: *mut libc::size_t,
+) -> Error {
+    unsafe { util::json_to_bytes(s, buf, buf_size, ContractLogInfo::to_bytes) }
+}

--- a/sdk/rust/src/ffi/mod.rs
+++ b/sdk/rust/src/ffi/mod.rs
@@ -30,6 +30,7 @@ mod callback;
 mod client;
 mod contract_id;
 mod contract_info;
+mod contract_log_info;
 mod entity_id;
 mod execute;
 mod file_info;

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -114,6 +114,7 @@ pub use contract::{
     ContractId,
     ContractInfo,
     ContractInfoQuery,
+    ContractLogInfo,
     ContractUpdateTransaction,
 };
 pub use entity_id::EntityId;

--- a/sdk/swift/Sources/Hedera/Contract/ContractFunctionResult.swift
+++ b/sdk/swift/Sources/Hedera/Contract/ContractFunctionResult.swift
@@ -99,7 +99,8 @@ extension ContractFunctionResult: Codable {
         try container.encode(gas, forKey: .gas)
         try container.encode(logs, forKey: .logs)
         try container.encode(hbarAmount, forKey: .hbarAmount)
-        try container.encode(contractFunctionParametersBytes.base64EncodedString(), forKey: .contractFunctionParametersBytes)
+        try container.encode(
+            contractFunctionParametersBytes.base64EncodedString(), forKey: .contractFunctionParametersBytes)
         try container.encode(bytes.base64EncodedString(), forKey: .bytes)
         try container.encodeIfPresent(senderAccountId, forKey: .senderAccountId)
     }

--- a/sdk/swift/Sources/Hedera/Contract/ContractFunctionResult.swift
+++ b/sdk/swift/Sources/Hedera/Contract/ContractFunctionResult.swift
@@ -22,7 +22,7 @@ import Foundation
 
 /// Result of invoking a contract via `ContractCallQuery`, `ContractExecuteTransaction`,
 /// or `ContractCreateTransaction`.
-public struct ContractFunctionResult: Codable {
+public struct ContractFunctionResult {
     /// The smart contract instance whose function was called.
     public let contractId: ContractId
 
@@ -38,10 +38,11 @@ public struct ContractFunctionResult: Codable {
     /// Units of gas used to execute contract.
     public let gasUsed: UInt64
 
-    // TODO: public let logs: [ContractLogInfo]
-
     /// The amount of gas available for the call.
     public let gas: UInt64
+
+    /// Logs that this call and any called functions produced.
+    public let logs: [ContractLogInfo]
 
     /// Number of HBAR sent (the function must be payable if this is nonzero).
     public let hbarAmount: Hbar
@@ -54,23 +55,56 @@ public struct ContractFunctionResult: Codable {
 
     /// The account that is the "sender." If not present it is the accountId from the transactionId.
     public let senderAccountId: AccountId?
+}
+
+extension ContractFunctionResult: Codable {
+    private enum CodingKeys: CodingKey {
+        case contractId
+        case evmAddress
+        case errorMessage
+        case bloom
+        case gasUsed
+        case gas
+        case logs
+        case hbarAmount
+        case contractFunctionParametersBytes
+        case bytes
+        case senderAccountId
+    }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         contractId = try container.decode(ContractId.self, forKey: .contractId)
-        evmAddress = try container.decode(ContractId.self, forKey: .evmAddress)
+        evmAddress = try container.decodeIfPresent(ContractId.self, forKey: .evmAddress)
         errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
         bloom = Data(base64Encoded: try container.decode(String.self, forKey: .bloom))!
         gasUsed = try container.decode(UInt64.self, forKey: .gasUsed)
         gas = try container.decode(UInt64.self, forKey: .gas)
+        logs = try container.decode([ContractLogInfo].self, forKey: .logs)
         hbarAmount = try container.decode(Hbar.self, forKey: .hbarAmount)
         contractFunctionParametersBytes = Data(
             base64Encoded: try container.decode(String.self, forKey: .contractFunctionParametersBytes))!
         bytes = Data(base64Encoded: try container.decode(String.self, forKey: .bytes))!
         senderAccountId = try container.decodeIfPresent(AccountId.self, forKey: .senderAccountId)
     }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(contractId, forKey: .contractId)
+        try container.encodeIfPresent(evmAddress, forKey: .evmAddress)
+        try container.encodeIfPresent(errorMessage, forKey: .errorMessage)
+        try container.encode(bloom.base64EncodedString(), forKey: .bloom)
+        try container.encode(gasUsed, forKey: .gasUsed)
+        try container.encode(gas, forKey: .gas)
+        try container.encode(logs, forKey: .logs)
+        try container.encode(hbarAmount, forKey: .hbarAmount)
+        try container.encode(contractFunctionParametersBytes.base64EncodedString(), forKey: .contractFunctionParametersBytes)
+        try container.encode(bytes.base64EncodedString(), forKey: .bytes)
+        try container.encodeIfPresent(senderAccountId, forKey: .senderAccountId)
+    }
 }
+
 // TODO: func getString(_ index: UInt) -> String
 // TODO: func getStringArray(_ index: UInt) -> [String]
 // TODO: func getBytes(_ index: UInt) -> Data

--- a/sdk/swift/Sources/Hedera/Contract/ContractLogInfo.swift
+++ b/sdk/swift/Sources/Hedera/Contract/ContractLogInfo.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// The log information for an event returned by a smart contract function call.
+/// One function call may return several such events.
+public struct ContractLogInfo: Equatable {
+    /// Address of the contract that emitted the event.
+    public let contractId: ContractId
+
+    /// Bloom filter for this log.
+    public let bloom: Data
+
+    /// A list of topics this log is relevent to.
+    public let topics: [Data]
+
+    /// The log's data payload.
+    public let data: Data
+}
+
+extension ContractLogInfo: Codable {
+    private enum CodingKeys: CodingKey {
+        case contractId
+        case bloom
+        case topics
+        case data
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        contractId = try container.decode(ContractId.self, forKey: .contractId)
+        bloom = try Data(base64Encoded: container.decode(String.self, forKey: .bloom))!
+        topics = try container.decode([String].self, forKey: .topics).map { Data(base64Encoded: $0)! }
+        data = try Data(base64Encoded: container.decode(String.self, forKey: .data))!
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(contractId, forKey: .contractId)
+        try container.encode(bloom.base64EncodedString(), forKey: .bloom)
+        try container.encode(topics.map { $0.base64EncodedString() }, forKey: .topics)
+        try container.encode(data.base64EncodedString(), forKey: .data)
+    }
+}

--- a/sdk/swift/Sources/Hedera/Contract/ContractLogInfo.swift
+++ b/sdk/swift/Sources/Hedera/Contract/ContractLogInfo.swift
@@ -1,3 +1,4 @@
+import CHedera
 import Foundation
 
 /// The log information for an event returned by a smart contract function call.
@@ -14,6 +15,16 @@ public struct ContractLogInfo: Equatable {
 
     /// The log's data payload.
     public let data: Data
+
+    public static func fromBytes(_ bytes: Data) throws -> Self {
+        try Self.fromJsonBytes(bytes)
+    }
+
+    public func toBytes() -> Data {
+        // can't have `throws` because that's the wrong function signature.
+        // swiftlint:disable force_try
+        try! toJsonBytes()
+    }
 }
 
 extension ContractLogInfo: Codable {
@@ -41,4 +52,9 @@ extension ContractLogInfo: Codable {
         try container.encode(topics.map { $0.base64EncodedString() }, forKey: .topics)
         try container.encode(data.base64EncodedString(), forKey: .data)
     }
+}
+
+extension ContractLogInfo: ToFromJsonBytes {
+    internal static var cFromBytes: FromJsonBytesFunc { hedera_contract_log_info_from_bytes }
+    internal static var cToBytes: ToJsonBytesFunc { hedera_contract_log_info_to_bytes }
 }


### PR DESCRIPTION
**Description**:
~still missing `logs`~
~Leaving this here and open; I did this and then priorities got shifted around, it needs _many_ tests (iirc there's a "bug" with the `get_u32_at` function, it needs to add 28 to the offset)~

All outstanding issues *resolved*.

Could still use *far* more tests, but this is all that exists in the Java SDK and then some.

**Related issue(s)**:

- no issue, but this is the Rust equivalent of #298

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
