### PR TITLE
[rust] Fix `TransactionId::from_str`, Add `TransactionId::{to,from}_bytes`

### DIFF
--- a/sdk/rust/src/transaction_id.rs
+++ b/sdk/rust/src/transaction_id.rs
@@ -78,6 +78,21 @@ impl TransactionId {
 
         Self { account_id, valid_start, scheduled: false, nonce: None }
     }
+
+    /// Create a new `TransactionId` from protobuf-encoded `bytes`.
+    ///
+    /// # Errors
+    /// - [`Error::FromProtobuf`](crate::Error::FromProtobuf) if decoding the bytes fails to produce a valid protobuf.
+    /// - [`Error::FromProtobuf`](crate::Error::FromProtobuf) if decoding the protobuf fails.
+    pub fn from_bytes(bytes: &[u8]) -> crate::Result<Self> {
+        FromProtobuf::from_bytes(bytes)
+    }
+
+    /// Convert `self` to a protobuf-encoded [`Vec<u8>`].
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToProtobuf::to_bytes(self)
+    }
 }
 
 impl Debug for TransactionId {
@@ -113,6 +128,19 @@ impl FromProtobuf<services::TransactionId> for TransactionId {
             nonce: (pb.nonce != 0).then_some(pb.nonce),
             scheduled: pb.scheduled,
         })
+    }
+}
+
+impl ToProtobuf for TransactionId {
+    type Protobuf = services::TransactionId;
+
+    fn to_protobuf(&self) -> Self::Protobuf {
+        services::TransactionId {
+            account_id: Some(self.account_id.to_protobuf()),
+            scheduled: self.scheduled,
+            nonce: self.nonce.unwrap_or_default(),
+            transaction_valid_start: Some(self.valid_start.into()),
+        }
     }
 }
 
@@ -157,19 +185,6 @@ impl FromStr for TransactionId {
         };
 
         Ok(Self { account_id, valid_start, nonce, scheduled })
-    }
-}
-
-impl ToProtobuf for TransactionId {
-    type Protobuf = services::TransactionId;
-
-    fn to_protobuf(&self) -> Self::Protobuf {
-        services::TransactionId {
-            account_id: Some(self.account_id.to_protobuf()),
-            scheduled: self.scheduled,
-            nonce: self.nonce.unwrap_or_default(),
-            transaction_valid_start: Some(self.valid_start.into()),
-        }
     }
 }
 

--- a/sdk/rust/src/transaction_response.rs
+++ b/sdk/rust/src/transaction_response.rs
@@ -58,7 +58,7 @@ pub struct TransactionResponse {
 // TODO: get_record
 // TODO: get_successful_record
 impl TransactionResponse {
-    /// Get the receipt of this transaction.
+    /// Get the receipt for this transaction.
     /// Will wait for consensus.
     ///
     /// # Errors


### PR DESCRIPTION
**Description**:
I tend to use Rust as the reference for the swift SDK, noticed some things while trying to work on that

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
