### PR TITLE
feat(swift): `AccountBalance` to/from bytes, rename, and `toString`

### DIFF
--- a/sdk/rust/src/account/account_balance_query.rs
+++ b/sdk/rust/src/account/account_balance_query.rs
@@ -76,8 +76,7 @@ enum AccountBalanceSource {
 impl AccountBalanceQuery {
     /// Sets the account ID for which information is requested.
     ///
-    /// This is mutually exclusive with [`contract_id`](#method.contract_id).
-    ///
+    /// This is mutually exclusive with [`contract_id`](Self::contract_id).
     pub fn account_id(&mut self, id: AccountId) -> &mut Self {
         self.data.source = AccountBalanceSource::AccountId(id);
         self
@@ -85,8 +84,7 @@ impl AccountBalanceQuery {
 
     /// Sets the contract ID for which information is requested.
     ///
-    /// This is mutually exclusive with [`account_id`](#method.account_id).
-    ///
+    /// This is mutually exclusive with [`account_id`](Self::account_id).
     pub fn contract_id(&mut self, id: ContractId) -> &mut Self {
         self.data.source = AccountBalanceSource::ContractId(id);
         self

--- a/sdk/rust/src/client/mod.rs
+++ b/sdk/rust/src/client/mod.rs
@@ -21,7 +21,6 @@
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
-use parking_lot::RwLock;
 use tokio::sync::RwLock as AsyncRwLock;
 use tokio::task::block_in_place;
 

--- a/sdk/rust/src/ffi/account_balance.rs
+++ b/sdk/rust/src/ffi/account_balance.rs
@@ -1,0 +1,98 @@
+use std::ptr;
+
+use libc::size_t;
+
+use crate::ffi;
+use crate::ffi::error::Error;
+use crate::protobuf::ToProtobuf;
+
+#[repr(C)]
+pub struct AccountBalance {
+    id: ffi::AccountId,
+    hbars: i64,
+}
+
+impl AccountBalance {
+    fn borrow_ref<'a>(&'a self) -> RefAccountBalance<'a> {
+        RefAccountBalance { id: self.id.borrow_ref(), hbars: self.hbars }
+    }
+}
+
+impl From<crate::AccountBalance> for AccountBalance {
+    fn from(it: crate::AccountBalance) -> Self {
+        Self { id: it.account_id.into(), hbars: it.hbars.to_tinybars() }
+    }
+}
+
+struct RefAccountBalance<'a> {
+    id: ffi::RefAccountId<'a>,
+    hbars: i64,
+}
+
+impl<'a> ToProtobuf for RefAccountBalance<'a> {
+    type Protobuf = hedera_proto::services::CryptoGetAccountBalanceResponse;
+
+    fn to_protobuf(&self) -> Self::Protobuf {
+        use hedera_proto::services;
+
+        services::CryptoGetAccountBalanceResponse {
+            header: None,
+            account_id: Some(self.id.to_protobuf()),
+            balance: self.hbars as u64,
+            token_balances: Vec::new(),
+        }
+    }
+}
+
+impl<'a> RefAccountBalance<'a> {
+    fn into_bytes(self) -> Vec<u8> {
+        use prost::Message;
+        self.to_protobuf().encode_to_vec()
+    }
+}
+
+/// Parse a Hedera `AccountBalance` from the passed bytes.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_account_balance_from_bytes(
+    bytes: *const u8,
+    bytes_size: size_t,
+    id: *mut AccountBalance,
+) -> Error {
+    assert!(!bytes.is_null());
+    assert!(!id.is_null());
+
+    let bytes = unsafe { std::slice::from_raw_parts(bytes, bytes_size) };
+
+    let parsed = ffi_try!(crate::AccountBalance::from_bytes(&bytes)).into();
+
+    unsafe {
+        ptr::write(id, parsed);
+    }
+
+    Error::Ok
+}
+
+/// Serialize the passed `AccountBalance` as bytes
+///
+/// # Safety
+/// - `id` must uphold the safety requirements of `AccountBalance`.
+/// - `buf` must be valid for writes.
+/// - `buf` must only be freed with `hedera_bytes_free`, notably this means that it must not be freed with `free`.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_account_balance_to_bytes(
+    id: AccountBalance,
+    buf: *mut *mut u8,
+) -> size_t {
+    let bytes = id.borrow_ref().into_bytes().into_boxed_slice();
+
+    let bytes = Box::leak(bytes);
+    let len = bytes.len();
+    let bytes = bytes.as_mut_ptr();
+
+    // safety: invariants promise that `buf` must be valid for writes.
+    unsafe {
+        ptr::write(buf, bytes);
+    }
+
+    len
+}

--- a/sdk/rust/src/ffi/mod.rs
+++ b/sdk/rust/src/ffi/mod.rs
@@ -21,6 +21,7 @@
 #[macro_use]
 mod error;
 
+mod account_balance;
 mod account_id;
 mod account_info;
 mod c_util;
@@ -43,4 +44,8 @@ mod token_association;
 mod transaction_receipt;
 mod util;
 
+use account_id::{
+    AccountId,
+    RefAccountId,
+};
 use semantic_version::SemanticVersion;

--- a/sdk/rust/src/protobuf/mod.rs
+++ b/sdk/rust/src/protobuf/mod.rs
@@ -24,7 +24,7 @@ mod time;
 #[macro_use]
 pub(crate) mod get;
 
-pub use convert::{
+pub(crate) use convert::{
     FromProtobuf,
     ToProtobuf,
 };

--- a/sdk/rust/src/semantic_version/mod.rs
+++ b/sdk/rust/src/semantic_version/mod.rs
@@ -47,13 +47,13 @@ pub struct SemanticVersion {
     /// Increases with backwards-compatible bug fixes]
     pub patch: u32,
 
-    /// A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers (https://semver.org/#spec-item-9);
+    /// A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers (<https://semver.org/#spec-item-9>);
     /// so given a semver 0.14.0-alpha.1+21AF26D3, this field would contain ‘alpha.1’
     #[cfg_attr(feature = "ffi", serde(skip_serializing_if = "String::is_empty"))]
     pub prerelease: String,
 
     /// Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers
-    /// immediately following the patch or pre-release version (https://semver.org/#spec-item-10);
+    /// immediately following the patch or pre-release version (<https://semver.org/#spec-item-10>);
     /// so given a semver 0.14.0-alpha.1+21AF26D3, this field would contain ‘21AF26D3’
     #[cfg_attr(feature = "ffi", serde(skip_serializing_if = "String::is_empty"))]
     pub build: String,

--- a/sdk/swift/Sources/Hedera/Account/AccountBalance.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountBalance.swift
@@ -18,11 +18,58 @@
  * ‍
  */
 
+import CHedera
+import Foundation
+
 /// Response from ``AccountBalanceQuery``.
-public final class AccountBalanceResponse: Codable {
+public final class AccountBalance: Codable {
     /// The account that is being referenced.
     public let accountId: AccountId
 
     /// Current balance of the referenced account.
     public let hbars: Hbar
+
+    internal init(unsafeFromCHedera hedera: HederaAccountBalance) {
+        accountId = AccountId(unsafeFromCHedera: hedera.id)
+        hbars = Hbar.fromTinybars(hedera.hbars)
+    }
+
+    internal func unsafeWithCHedera<Result>(_ body: (HederaAccountBalance) throws -> Result) rethrows -> Result {
+        try accountId.unsafeWithCHedera {
+            (hederaAccountId) in
+            try body(HederaAccountBalance(id: hederaAccountId, hbars: hbars.toTinybars()))
+        }
+    }
+
+    public static func fromBytes(_ bytes: Data) throws -> Self {
+        try bytes.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) in
+            var balance = HederaAccountBalance()
+
+            let err = hedera_account_balance_from_bytes(
+                pointer.baseAddress,
+                pointer.count,
+                &balance
+            )
+
+            if err != HEDERA_ERROR_OK {
+                throw HError(err)!
+            }
+
+            return Self(unsafeFromCHedera: balance)
+        }
+    }
+
+    public func toBytes() -> Data {
+        self.unsafeWithCHedera {
+            (hedera) in
+            var buf: UnsafeMutablePointer<UInt8>?
+            let size = hedera_account_balance_to_bytes(hedera, &buf)
+
+            return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+        }
+    }
+
+    public func toString() -> String {
+        String(describing: self)
+    }
 }

--- a/sdk/swift/Sources/Hedera/Account/AccountBalanceQuery.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountBalanceQuery.swift
@@ -23,8 +23,7 @@
 /// This returns only the balance, so it is a smaller reply
 /// than `AccountInfoQuery`, which returns the balance plus
 /// additional information.
-///
-public final class AccountBalanceQuery: Query<AccountBalanceResponse> {
+public final class AccountBalanceQuery: Query<AccountBalance> {
     /// Create a new `AccountBalanceQuery`.
     public init(
         accountId: AccountId? = nil,
@@ -40,7 +39,6 @@ public final class AccountBalanceQuery: Query<AccountBalanceResponse> {
     /// Sets the account ID for which information is requested.
     ///
     /// This is mutually exclusive with `contractId`.
-    ///
     @discardableResult
     public func accountId(_ accountId: AccountId) -> Self {
         self.accountId = accountId
@@ -55,7 +53,6 @@ public final class AccountBalanceQuery: Query<AccountBalanceResponse> {
     /// Sets the contract ID for which information is requested.
     ///
     /// This is mutually exclusive with `accountId`.
-    ///
     @discardableResult
     public func contractId(_ contractId: ContractId) -> Self {
         self.contractId = contractId


### PR DESCRIPTION
**Description**:
- Add: `AccountBalance.fromBytes`
- Add: `AccountBalance.toBytes`
- Add: `AccountBalance.toString`
- Change: rename `AccountBalanceResponse` to just `AccountBalance`

**Related issue(s)**:

Fixes #221

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
