### PR TITLE
feat: Add remaining `TransactionRecord` fields

### DIFF
--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -84,6 +84,7 @@ mod transfer_transaction;
 #[cfg(feature = "ffi")]
 mod ffi;
 mod hbar;
+mod transfer;
 
 pub use account::{
     AccountAllowanceApproveTransaction,
@@ -203,6 +204,7 @@ pub use token::{
     TokenMintTransaction,
     TokenNftInfo,
     TokenNftInfoQuery,
+    TokenNftTransfer,
     TokenPauseTransaction,
     TokenRevokeKycTransaction,
     TokenSupplyType,
@@ -232,4 +234,5 @@ pub use transaction_record::TransactionRecord;
 pub use transaction_record_query::TransactionRecordQuery;
 pub(crate) use transaction_record_query::TransactionRecordQueryData;
 pub use transaction_response::TransactionResponse;
+pub use transfer::Transfer;
 pub use transfer_transaction::TransferTransaction;

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -188,6 +188,7 @@ pub use system::{
     SystemUndeleteTransaction,
 };
 pub use token::{
+    AssessedCustomFee,
     NftId,
     TokenAssociateTransaction,
     TokenAssociation,

--- a/sdk/rust/src/token/assessed_custom_fee.rs
+++ b/sdk/rust/src/token/assessed_custom_fee.rs
@@ -1,0 +1,72 @@
+use hedera_proto::services;
+
+use crate::protobuf::{
+    FromProtobuf,
+    ToProtobuf,
+};
+use crate::{
+    AccountId,
+    TokenId,
+};
+
+/// A custom transfer fee that was assessed during the handling of a CryptoTransfer.
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
+pub struct AssessedCustomFee {
+    /// The amount of currency charged to each payer.
+    pub amount: i64,
+
+    /// The currency `amount` is charged in, if `None` the fee is in HBar.
+    pub token_id: Option<TokenId>,
+
+    /// The account that receives the fees that were charged.
+    pub fee_collector_account_id: Option<AccountId>,
+
+    /// A list of all accounts that were charged this fee.
+    pub payer_account_id_list: Vec<AccountId>,
+}
+
+impl AssessedCustomFee {
+    /// Create a new `AssessedCustomFee` from protobuf-encoded `bytes`.
+    ///
+    /// # Errors
+    /// - [`Error::FromProtobuf`](crate::Error::FromProtobuf) if decoding the bytes fails to produce a valid protobuf.
+    /// - [`Error::FromProtobuf`](crate::Error::FromProtobuf) if decoding the protobuf fails.
+    pub fn from_bytes(bytes: &[u8]) -> crate::Result<Self> {
+        FromProtobuf::from_bytes(bytes)
+    }
+
+    /// Convert `self` to a protobuf-encoded [`Vec<u8>`].
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToProtobuf::to_bytes(self)
+    }
+}
+
+impl FromProtobuf<services::AssessedCustomFee> for AssessedCustomFee {
+    fn from_protobuf(pb: services::AssessedCustomFee) -> crate::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self {
+            amount: pb.amount,
+            token_id: pb.token_id.map(TokenId::from_protobuf).transpose()?,
+            fee_collector_account_id: FromProtobuf::from_protobuf(pb.fee_collector_account_id)?,
+            payer_account_id_list: FromProtobuf::from_protobuf(pb.effective_payer_account_id)?,
+        })
+    }
+}
+
+impl ToProtobuf for AssessedCustomFee {
+    type Protobuf = services::AssessedCustomFee;
+
+    fn to_protobuf(&self) -> Self::Protobuf {
+        services::AssessedCustomFee {
+            amount: self.amount,
+            token_id: self.token_id.to_protobuf(),
+            fee_collector_account_id: self.fee_collector_account_id.to_protobuf(),
+            effective_payer_account_id: self.payer_account_id_list.to_protobuf(),
+        }
+    }
+}

--- a/sdk/rust/src/token/mod.rs
+++ b/sdk/rust/src/token/mod.rs
@@ -18,6 +18,7 @@
  * ‍
  */
 
+mod assessed_custom_fee;
 mod custom_fees;
 mod nft_id;
 mod token_associate_transaction;
@@ -45,6 +46,7 @@ mod token_unpause_transaction;
 mod token_update_transaction;
 mod token_wipe_transaction;
 
+pub use assessed_custom_fee::AssessedCustomFee;
 pub use nft_id::NftId;
 pub use token_associate_transaction::{
     TokenAssociateTransaction,

--- a/sdk/rust/src/token/mod.rs
+++ b/sdk/rust/src/token/mod.rs
@@ -35,6 +35,7 @@ mod token_info_query;
 mod token_mint_transaction;
 mod token_nft_info;
 mod token_nft_info_query;
+mod token_nft_transfer;
 mod token_pause_transaction;
 mod token_revoke_kyc_transaction;
 mod token_supply_type;
@@ -93,6 +94,7 @@ pub use token_nft_info_query::{
     TokenNftInfoQuery,
     TokenNftInfoQueryData,
 };
+pub use token_nft_transfer::TokenNftTransfer;
 pub use token_pause_transaction::{
     TokenPauseTransaction,
     TokenPauseTransactionData,

--- a/sdk/rust/src/token/token_nft_transfer.rs
+++ b/sdk/rust/src/token/token_nft_transfer.rs
@@ -1,0 +1,44 @@
+use hedera_proto::services;
+
+use crate::protobuf::FromProtobuf;
+use crate::{
+    AccountId,
+    TokenId,
+};
+
+/// Represents a transfer of an NFT from one account to another.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
+pub struct TokenNftTransfer {
+    /// The ID of the NFT's token.
+    pub token_id: TokenId,
+
+    /// The account that the NFT is being transferred from.
+    pub sender: AccountId,
+
+    /// The account that the NFT is being transferred to.
+    pub receiver: AccountId,
+
+    /// The serial number for the NFT being transferred.
+    pub serial: u64,
+
+    /// If true then the transfer is expected to be an approved allowance and the
+    /// `sender` is expected to be the owner. The default is false.
+    pub is_approved: bool,
+}
+
+impl TokenNftTransfer {
+    pub(crate) fn from_protobuf(
+        pb: services::NftTransfer,
+        token_id: TokenId,
+    ) -> crate::Result<Self> {
+        Ok(Self {
+            token_id,
+            sender: AccountId::from_protobuf(pb_getf!(pb, sender_account_id)?)?,
+            receiver: AccountId::from_protobuf(pb_getf!(pb, receiver_account_id)?)?,
+            serial: pb.serial_number as u64,
+            is_approved: pb.is_approval,
+        })
+    }
+}

--- a/sdk/rust/src/transaction_record.rs
+++ b/sdk/rust/src/transaction_record.rs
@@ -89,7 +89,7 @@ pub struct TransactionRecord {
     /// Reference to the scheduled transaction ID that this transaction record represents.
     pub schedule_ref: Option<ScheduleId>,
 
-    /// All custom fees that were assessed during a CryptoTransfer, and must be paid if the
+    /// All custom fees that were assessed during a [`TransferTransaction`](crate::TransferTransaction), and must be paid if the
     /// transaction status resolved to SUCCESS.
     pub assessed_custom_fees: Vec<AssessedCustomFee>,
 

--- a/sdk/rust/src/transfer.rs
+++ b/sdk/rust/src/transfer.rs
@@ -1,0 +1,50 @@
+use hedera_proto::services;
+
+use crate::protobuf::{
+    FromProtobuf,
+    ToProtobuf,
+};
+use crate::{
+    AccountId,
+    Hbar,
+};
+
+/// A transfer of [`Hbar`] that occured within a [`Transaction`](crate::Transaction)
+///
+/// Returned as part of a [`TransactionRecord`](crate::TransactionRecord)
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "ffi", derive(serde::Serialize))]
+#[cfg_attr(feature = "ffi", serde(rename_all = "camelCase"))]
+pub struct Transfer {
+    /// The account ID that this transfer is to/from.
+    pub account_id: AccountId,
+
+    /// The value of this transfer.
+    ///
+    /// Negative if the account sends/withdraws hbar, positive if it receives hbar.
+    pub amount: Hbar,
+}
+
+impl FromProtobuf<services::AccountAmount> for Transfer {
+    fn from_protobuf(pb: services::AccountAmount) -> crate::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self {
+            account_id: AccountId::from_protobuf(pb_getf!(pb, account_id)?)?,
+            amount: Hbar::from_tinybars(pb.amount),
+        })
+    }
+}
+
+impl ToProtobuf for Transfer {
+    type Protobuf = services::AccountAmount;
+
+    fn to_protobuf(&self) -> Self::Protobuf {
+        services::AccountAmount {
+            account_id: Some(self.account_id.to_protobuf()),
+            amount: self.amount.to_tinybars(),
+            is_approval: false,
+        }
+    }
+}

--- a/sdk/swift/Sources/Hedera/Account/AccountId.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountId.swift
@@ -23,6 +23,11 @@ import Foundation
 
 /// The unique identifier for a cryptocurrency account on Hedera.
 public final class AccountId: EntityId {
+    public override func hash(into hasher: inout Hasher) {
+        super.hash(into: &hasher)
+        hasher.combine(alias)
+    }
+
     public let alias: PublicKey?
 
     public init(shard: UInt64 = 0, realm: UInt64 = 0, alias: PublicKey) {
@@ -113,9 +118,11 @@ public final class AccountId: EntityId {
             return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
         }
     }
+
+    public static func == (lhs: AccountId, rhs: AccountId) -> Bool {
+        lhs.shard == rhs.shard && lhs.realm == rhs.realm && lhs.num == lhs.num && lhs.alias == rhs.alias
+    }
 }
 
 // TODO: checksum
 // TODO: to evm address
-// TODO: hash
-// TODO: equals

--- a/sdk/swift/Sources/Hedera/AssessedCustomFee.swift
+++ b/sdk/swift/Sources/Hedera/AssessedCustomFee.swift
@@ -1,0 +1,17 @@
+/// A custom transfer fee that was assessed during the handling of a ``TransferTransaction``.
+public struct AssessedCustomFee: Equatable, Codable {
+    /// The amount of currency charged to each payer.
+    public let amount: Int64
+
+    /// The currency `amount` is charged in, if `None` the fee is in HBar.
+    public let tokenId: TokenId?
+
+    /// The account that receives the fees that were charged.
+    public let feeCollectorAccountId: AccountId?
+
+    /// A list of all accounts that were charged this fee.
+    public let payerAccountIdList: [AccountId]
+
+    // todo: fromBytes
+    // todo: toBytes
+}

--- a/sdk/swift/Sources/Hedera/EntityId.swift
+++ b/sdk/swift/Sources/Hedera/EntityId.swift
@@ -22,7 +22,7 @@ import CHedera
 import Foundation
 
 public class EntityId: LosslessStringConvertible, ExpressibleByIntegerLiteral, Equatable, Codable,
-    ExpressibleByStringLiteral
+    ExpressibleByStringLiteral, Hashable
 {
     /// The shard number (non-negative).
     public let shard: UInt64
@@ -77,6 +77,12 @@ public class EntityId: LosslessStringConvertible, ExpressibleByIntegerLiteral, E
 
     public static func == (lhs: EntityId, rhs: EntityId) -> Bool {
         lhs.num == rhs.num && lhs.shard == rhs.shard && lhs.realm == rhs.realm
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(shard)
+        hasher.combine(realm)
+        hasher.combine(num)
     }
 }
 

--- a/sdk/swift/Sources/Hedera/PublicKey.swift
+++ b/sdk/swift/Sources/Hedera/PublicKey.swift
@@ -28,7 +28,7 @@ private typealias UnsafeFromBytesFunc = @convention(c) (
 ) -> HederaError
 
 /// A public key on the Hedera network.
-public final class PublicKey: LosslessStringConvertible, ExpressibleByStringLiteral, Codable {
+public final class PublicKey: LosslessStringConvertible, ExpressibleByStringLiteral, Codable, Equatable, Hashable {
     internal let ptr: OpaquePointer
 
     // sadly, we can't avoid a leaky abstraction here.
@@ -190,6 +190,16 @@ public final class PublicKey: LosslessStringConvertible, ExpressibleByStringLite
         var container = encoder.singleValueContainer()
 
         try container.encode(String(describing: self))
+    }
+
+    public static func == (lhs: PublicKey, rhs: PublicKey) -> Bool {
+        // this will always be true for public keys, DER is a stable format with canonicalization.
+        // ideally we'd do this a different way, but that needs to wait until ffi is gone.
+        lhs.toBytesDer() == rhs.toBytesDer()
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(toBytesDer())
     }
 
     deinit {

--- a/sdk/swift/Sources/Hedera/Token/TokenNftTransfer.swift
+++ b/sdk/swift/Sources/Hedera/Token/TokenNftTransfer.swift
@@ -1,0 +1,19 @@
+/// Represents a transfer of an NFT from one account to another.
+
+public struct TokenNftTransfer: Equatable, Codable {
+    /// The ID of the NFT's token.
+    public let tokenId: TokenId
+
+    /// The account that the NFT is being transferred from.
+    public let sender: AccountId
+
+    /// The account that the NFT is being transferred to.
+    public let receiver: AccountId
+
+    /// The serial number for the NFT being transferred.
+    public let serial: UInt64
+
+    /// If true then the transfer is expected to be an approved allowance and the
+    /// `sender` is expected to be the owner. The default is false.
+    public let isApproved: Bool
+}

--- a/sdk/swift/Sources/Hedera/TransactionRecord.swift
+++ b/sdk/swift/Sources/Hedera/TransactionRecord.swift
@@ -35,6 +35,20 @@ public struct TransactionRecord: Codable {
     /// The consensus timestamp.
     public let consensusTimestamp: Timestamp
 
+    /// Record of the value returned by the smart contract function or constructor.
+    public let contractFunctionResult: ContractFunctionResult?
+
+    /// All hbar transfers as a result of this transaction, such as fees, or
+    /// transfers performed by the transaction, or by a smart contract it calls,
+    /// or by the creation of threshold records that it triggers.
+    public let transfers: [Transfer]
+
+    /// All fungible token transfers as a result of this transaction.
+    public let tokenTransfers: [TokenId: [AccountId: Int64]]
+
+    /// All NFT Token transfers as a result of this transaction.
+    public let tokenNftTransfers: [TokenId: [TokenNftTransfer]]
+
     /// The ID of the transaction this record represents.
     public let transactionId: TransactionId
 
@@ -46,6 +60,10 @@ public struct TransactionRecord: Codable {
 
     /// Reference to the scheduled transaction ID that this transaction record represents.
     public let scheduleRef: ScheduleId?
+
+    /// All custom fees that were assessed during a ``TransferTransaction``, and must be paid if the
+    /// transaction status resolved to SUCCESS.
+    public let assessedCustomFees: [AssessedCustomFee]
 
     /// All token associations implicitly created while handling this transaction
     public let automaticTokenAssociations: [TokenAssociation]
@@ -76,10 +94,16 @@ public struct TransactionRecord: Codable {
         receipt = try container.decode(TransactionReceipt.self, forKey: .receipt)
         transactionHash = Data(base64Encoded: try container.decode(String.self, forKey: .transactionHash))!
         consensusTimestamp = try container.decode(Timestamp.self, forKey: .consensusTimestamp)
+        contractFunctionResult = try container.decodeIfPresent(
+            ContractFunctionResult.self, forKey: .contractFunctionResult)
+        transfers = try container.decode([Transfer].self, forKey: .transfers)
+        tokenTransfers = try container.decode(Dictionary.self, forKey: .tokenTransfers)
+        tokenNftTransfers = try container.decode(Dictionary.self, forKey: .tokenNftTransfers)
         transactionId = try container.decode(TransactionId.self, forKey: .transactionId)
         transactionMemo = try container.decode(String.self, forKey: .transactionMemo)
         transactionFee = try container.decode(Hbar.self, forKey: .transactionFee)
         scheduleRef = try container.decodeIfPresent(ScheduleId.self, forKey: .scheduleRef)
+        assessedCustomFees = try container.decode([AssessedCustomFee].self, forKey: .assessedCustomFees)
         automaticTokenAssociations = try container.decode([TokenAssociation].self, forKey: .automaticTokenAssociations)
 
         parentConsensusTimestamp = try container.decodeIfPresent(Timestamp.self, forKey: .parentConsensusTimestamp)

--- a/sdk/swift/Sources/Hedera/Transfer.swift
+++ b/sdk/swift/Sources/Hedera/Transfer.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A transfer of ``Hbar`` that occured within a ``Transaction``
+///
+/// Returned as part of a ``TransactionRecord``
+public struct Transfer: Codable {
+    /// The account ID that this transfer is to/from.
+    public let accountId: AccountId
+
+    /// The value of this transfer.
+    ///
+    /// Negative if the account sends/withdraws hbar, positive if it receives hbar.
+    public let amount: Hbar
+}

--- a/sdk/swift/Sources/Hedera/TransferTransaction.swift
+++ b/sdk/swift/Sources/Hedera/TransferTransaction.swift
@@ -26,8 +26,29 @@
 /// account (a receiver). The amounts list must sum to zero.
 ///
 public final class TransferTransaction: Transaction {
-    private var transfers: [Transfer] = []
-    private var tokenTransfers: [TokenTransfer] = []
+    // avoid scope collisions by nesting :/
+    private struct Transfer: Encodable {
+        let accountId: AccountId
+        let amount: Int64
+        let isApproval: Bool
+    }
+
+    private struct TokenTransfer: Encodable {
+        let tokenId: TokenId
+        var transfers: [TransferTransaction.Transfer]
+        var nftTransfers: [TransferTransaction.NftTransfer]
+        var expectedDecimals: UInt32?
+    }
+
+    private struct NftTransfer: Encodable {
+        let senderAccountId: AccountId
+        let receiverAccountId: AccountId
+        let serial: UInt64
+        let isApproval: Bool
+    }
+
+    private var transfers: [TransferTransaction.Transfer] = []
+    private var tokenTransfers: [TransferTransaction.TokenTransfer] = []
 
     /// Create a new `TransferTransaction`.
     public override init() {
@@ -165,24 +186,4 @@ public final class TransferTransaction: Transaction {
 
         try super.encode(to: encoder)
     }
-}
-
-private struct Transfer: Encodable {
-    let accountId: AccountId
-    let amount: Int64
-    let isApproval: Bool
-}
-
-private struct TokenTransfer: Encodable {
-    let tokenId: TokenId
-    var transfers: [Transfer]
-    var nftTransfers: [NftTransfer]
-    var expectedDecimals: UInt32?
-}
-
-private struct NftTransfer: Encodable {
-    let senderAccountId: AccountId
-    let receiverAccountId: AccountId
-    let serial: UInt64
-    let isApproval: Bool
 }


### PR DESCRIPTION
**Description**:

- Add: `TransactionRecord.contract_function_result` (Rust)
- Add: `TransactionRecord.contractFunctionResult` (Swift)
- Add: `TransactionRecord.assessed_custom_fees` (Rust)
- Add: `AssessedCustomFee` (Rust, theoretically completed)
- Add: `TransactionRecord.assessedCustomFees` (Swift)
- Add: `AssessedCustomFee` (Swift, missing `{to, from}Bytes`)
- Add: `TransactionRecord.transfers` (Rust)
- Add: `Transfer` (Rust, theoretically completed)
- Add: `TransactionRecord.transfers` (Swift)
- Add: `Transfer` (Swift, theoretically completed)
- Add: `TransactionRecord.token_transfers` (Rust)
- Add: `TransactionRecord.tokenTransfers` (Swift)
- **Skip** Adding `TransactionRecord.token_transfer_list` (it... Exists in other languages, but none of the fields are public anyway)
- Add: `TransactionRecord.token_nft_transfers` (Rust)
- Add: `TokenNftTransfer` (Rust, theoretically completed)
- Add: `TransactionRecord.tokenNftTransfers` (Swift)
- Add: `TokenNftTransfer` (Swift, theoretically completed)

**Related issue(s)**:

- Fixes #265 
- Several boxes in #268 
- *post* merge: create an issue for `AssessedCustomFee` to/from bytes for swift.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
