### PR TITLE
feat(swift): Add various `clear*` methods

### DIFF
--- a/sdk/swift/Sources/Hedera/Contract/ContractUpdateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/Contract/ContractUpdateTransaction.swift
@@ -102,6 +102,13 @@ public final class ContractUpdateTransaction: Transaction {
         return self
     }
 
+    @discardableResult
+    public func clearMemo() -> Self {
+        contractMemo = nil
+
+        return self
+    }
+
     /// The maximum number of tokens that this contract can be automatically associated with.
     public var maxAutomaticTokenAssociations: UInt32?
 
@@ -126,6 +133,13 @@ public final class ContractUpdateTransaction: Transaction {
         return self
     }
 
+    @discardableResult
+    public func clearAutoRenewAccountId() -> Self {
+        autoRenewAccountId = nil
+
+        return self
+    }
+
     /// The ID of the account to which this contract is staking.
     /// This is mutually exclusive with `staked_node_id`.
     public var stakedAccountId: AccountId?
@@ -135,6 +149,13 @@ public final class ContractUpdateTransaction: Transaction {
     @discardableResult
     public func stakedAccountId(_ stakedAccountId: AccountId?) -> Self {
         self.stakedAccountId = stakedAccountId
+
+        return self
+    }
+
+    @discardableResult
+    public func clearStakedAccountId() -> Self {
+        stakedAccountId = nil
 
         return self
     }
@@ -152,6 +173,13 @@ public final class ContractUpdateTransaction: Transaction {
         return self
     }
 
+    @discardableResult
+    public func clearStakedNodeId() -> Self {
+        stakedNodeId = nil
+
+        return self
+    }
+
     /// If true, the contract declines receiving a staking reward. The default value is false.
     public var declineStakingReward: Bool?
 
@@ -159,6 +187,13 @@ public final class ContractUpdateTransaction: Transaction {
     @discardableResult
     public func declineStakingReward(_ declineStakingReward: Bool?) -> Self {
         self.declineStakingReward = declineStakingReward
+
+        return self
+    }
+
+    @discardableResult
+    public func clearDeclineStakingReward() -> Self {
+        declineStakingReward = nil
 
         return self
     }

--- a/sdk/swift/Sources/Hedera/ScheduleSignTransaction.swift
+++ b/sdk/swift/Sources/Hedera/ScheduleSignTransaction.swift
@@ -38,6 +38,13 @@ public final class ScheduleSignTransaction: Transaction {
         return self
     }
 
+    @discardableResult
+    public func clearScheduleId() -> Self {
+        scheduleId = nil
+
+        return self
+    }
+
     private enum CodingKeys: String, CodingKey {
         case scheduleId
     }

--- a/sdk/swift/Sources/Hedera/Token/TokenUpdateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/Token/TokenUpdateTransaction.swift
@@ -202,6 +202,13 @@ public final class TokenUpdateTransaction: Transaction {
         return self
     }
 
+    @discardableResult
+    public func clearMemo() -> Self {
+        tokenMemo = ""
+
+        return self
+    }
+
     /// The new key which can change the token's custom fee schedule.
     public var feeScheduleKey: Key?
 


### PR DESCRIPTION
**Description**:
- Add: `ContractUpdateTransaction.clearMemo`
- Add: `ContractUpdateTransaction.clearAutoRenewAccountId`
- Add: `ContractUpdateTransaction.clearStakedAccountId`
- Add: `ContractUpdateTransaction.clearStakedNodeId`
- Add: `ContractUpdateTransaction.clearDeclineStakingReward`
- Add: `ScheduleSignTransaction.clearScheduleId`
- Add: `TokenUpdateTransaction.clearMemo`

**Related issue(s)**:
- #233 
- closes #250 
- #258 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
