### PR TITLE
feat!: Transaction response features (and accidentally some general `Executable` features)

### DIFF
--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -479,6 +479,8 @@ enum HederaError hedera_execute(const struct HederaClient *client,
                                 const char *request,
                                 const void *context,
                                 struct HederaSigners signers,
+                                bool has_timeout,
+                                uint64_t timeout_nanos,
                                 void (*callback)(const void *context, enum HederaError err, const char *response));
 
 /**

--- a/sdk/rust/src/client/mod.rs
+++ b/sdk/rust/src/client/mod.rs
@@ -134,4 +134,9 @@ impl Client {
     pub(crate) fn max_transaction_fee(&self) -> &AtomicU64 {
         &self.max_transaction_fee_tinybar
     }
+
+    pub(crate) fn get_request_timeout(&self) -> Option<std::time::Duration> {
+        // todo: implement this.
+        None
+    }
 }

--- a/sdk/rust/src/execute.rs
+++ b/sdk/rust/src/execute.rs
@@ -107,13 +107,23 @@ pub(crate) trait Execute {
     fn response_pre_check_status(response: &Self::GrpcResponse) -> crate::Result<i32>;
 }
 
-pub(crate) async fn execute<E>(client: &Client, executable: &E) -> crate::Result<E::Response>
+pub(crate) async fn execute<E>(
+    client: &Client,
+    executable: &E,
+    timeout: impl Into<Option<std::time::Duration>>,
+) -> crate::Result<E::Response>
 where
     E: Execute + Sync,
 {
-    // the overall timeout for the backoff starts measuring from here
+    let timeout: Option<std::time::Duration> = timeout.into();
+    
+    let timeout = timeout.or_else(|| client.get_request_timeout()).unwrap_or_else(|| {
+        std::time::Duration::from_millis(backoff::default::MAX_ELAPSED_TIME_MILLIS)
+    });
 
-    let mut backoff = ExponentialBackoff::default();
+    // the overall timeout for the backoff starts measuring from here
+    let mut backoff =
+        ExponentialBackoff { max_elapsed_time: Some(timeout), ..ExponentialBackoff::default() };
     let mut last_error: Option<Error> = None;
 
     // TODO: cache requests to avoid signing a new request for every node in a delayed back-off
@@ -140,7 +150,6 @@ where
     // the outer loop continues until we timeout or reach the maximum number of "attempts"
     // an attempt is counted when we have a successful response from a node that must either
     // be retried immediately (on a new node) or retried after a backoff.
-
     loop {
         // if no explicit set of node account IDs, we randomly sample 1/3 of all
         // healthy nodes on the client. this set of healthy nodes can change on

--- a/sdk/rust/src/execute.rs
+++ b/sdk/rust/src/execute.rs
@@ -110,13 +110,13 @@ pub(crate) trait Execute {
 pub(crate) async fn execute<E>(
     client: &Client,
     executable: &E,
-    timeout: impl Into<Option<std::time::Duration>>,
+    timeout: impl Into<Option<std::time::Duration>> + Send,
 ) -> crate::Result<E::Response>
 where
     E: Execute + Sync,
 {
     let timeout: Option<std::time::Duration> = timeout.into();
-    
+
     let timeout = timeout.or_else(|| client.get_request_timeout()).unwrap_or_else(|| {
         std::time::Duration::from_millis(backoff::default::MAX_ELAPSED_TIME_MILLIS)
     });

--- a/sdk/rust/src/query/cost.rs
+++ b/sdk/rust/src/query/cost.rs
@@ -134,7 +134,11 @@ where
     D: QueryExecute,
 {
     /// Execute this query against the provided client of the Hedera network.
-    pub async fn execute(&mut self, client: &Client) -> crate::Result<Hbar> {
-        execute(client, self).await
+    pub(crate) async fn execute(
+        &mut self,
+        client: &Client,
+        timeout: Option<std::time::Duration>,
+    ) -> crate::Result<Hbar> {
+        execute(client, self, timeout).await
     }
 }

--- a/sdk/rust/src/transaction/execute.rs
+++ b/sdk/rust/src/transaction/execute.rs
@@ -185,6 +185,7 @@ where
             node_account_id,
             transaction_id: transaction_id.unwrap(),
             transaction_hash,
+            validate_status: true,
         })
     }
 

--- a/sdk/rust/src/transaction/mod.rs
+++ b/sdk/rust/src/transaction/mod.rs
@@ -212,6 +212,27 @@ where
     // todo:
     #[allow(clippy::missing_errors_doc)]
     pub async fn execute(&mut self, client: &Client) -> crate::Result<TransactionResponse> {
-        execute(client, self).await
+        execute(client, self, None).await
+    }
+
+    #[cfg(feature = "ffi")]
+    pub(crate) async fn execute_with_optional_timeout(
+        &mut self,
+        client: &Client,
+        timeout: Option<std::time::Duration>,
+    ) -> crate::Result<TransactionResponse> {
+        execute(client, self, timeout).await
+    }
+
+    /// Execute this transaction against the provided client of the Hedera network.
+    // todo:
+    #[allow(clippy::missing_errors_doc)]
+    pub async fn execute_with_timeout(
+        &mut self,
+        client: &Client,
+        // fixme: be consistent with `time::Duration`? Except `tokio::time` is `std::time`, and we depend on tokio.
+        timeout: std::time::Duration,
+    ) -> crate::Result<TransactionResponse> {
+        execute(client, self, timeout).await
     }
 }

--- a/sdk/swift/Sources/Hedera/Transaction.swift
+++ b/sdk/swift/Sources/Hedera/Transaction.swift
@@ -42,13 +42,13 @@ public class Transaction: Request {
         return self
     }
 
-    public func execute(_ client: Client) async throws -> TransactionResponse {
+    public func execute(_ client: Client, _ timeoutNanos: UInt64? = nil) async throws -> TransactionResponse {
         // encode self as a JSON request to pass to Rust
         let requestBytes = try JSONEncoder().encode(self)
 
         let request = String(data: requestBytes, encoding: .utf8)!
 
-        return try await self.executeEncoded(client, request: request, signers: self.signers)
+        return try await executeEncoded(client, request: request, signers: signers, timeoutNanos: timeoutNanos)
     }
 
     public func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
**Description**:
- Add: `*.execute_with_timeout` (Rust) - this includes `MirrorQuery`s which use it as a connect timeout.
    This was added to keep the logic around ffi sane.
- Add: `TransactionResponse.validate_status` (Rust) & `TransactionResponse.validateStatus` (Swift)
- Add: `TransactionResponse.get_record` (Rust)
- Add: `TransactionResponse.get_{record,receipt}_query` (Rust)
- Add: `TransactionResponse.get_{record,receipt}_with_timeout` (Rust)
- Add: `TransactionResponse.getRecord` (Swift)
- Add: `TransactionResponse.get{Record,Receipt}Query` (Swift)
- Change: `TransactionResponse.getReceipt` now takes an extra, optional `timeoutNanos` argument
- Change: `Request.execute` now takes an extra, optional `timeoutNanos` argument (Swift)

**Related issue(s)**:
- closes #267

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
