### PR TITLE
feat(swift): `AccountAllowanceDeleteTransaction.getTokenNftAllowanceDeletions`

### DIFF
--- a/sdk/swift/Sources/Hedera/Account/AccountAllowanceDeleteTransaction.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountAllowanceDeleteTransaction.swift
@@ -49,6 +49,10 @@ public final class AccountAllowanceDeleteTransaction: Transaction {
         return self
     }
 
+    public func getTokenNftAllowanceDeletions() -> [NftRemoveAllowance] {
+        self.nftAllowances
+    }
+
     private enum CodingKeys: String, CodingKey {
         case nftAllowances
     }
@@ -62,8 +66,8 @@ public final class AccountAllowanceDeleteTransaction: Transaction {
     }
 }
 
-private struct NftRemoveAllowance: Encodable {
-    let tokenId: TokenId
-    let ownerAccountId: AccountId
-    var serials: [UInt64]
+public struct NftRemoveAllowance: Encodable {
+    public let tokenId: TokenId
+    public let ownerAccountId: AccountId
+    public var serials: [UInt64]
 }


### PR DESCRIPTION
**Description**:

this works differently than other SDKs because in other SDKs the stuff is nullable

**Related issue(s)**:

Fixes #220 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
