### PR TITLE
fix: set a default `expirationTime` for `FileCreateTransaction`

### DIFF
--- a/sdk/swift/Sources/Hedera/File/FileCreateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/File/FileCreateTransaction.swift
@@ -66,7 +66,8 @@ public final class FileCreateTransaction: Transaction {
     }
 
     /// The time at which this file should expire.
-    public var expirationTime: Timestamp?
+    public var expirationTime: Timestamp? = Timestamp(
+        from: Calendar.current.date(byAdding: .day, value: 90, to: Date())!)
 
     /// Sets the time at which this file should expire.
     @discardableResult


### PR DESCRIPTION
**Description**:

**Related issue(s)**:

Fixes #236 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
