### PR TITLE
refactor(swift): move `*Allowance` to more discoverable spots in the source

### DIFF
--- a/sdk/swift/Sources/Hedera/Account/AccountAllowanceApproveTransaction.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountAllowanceApproveTransaction.swift
@@ -146,25 +146,3 @@ public final class AccountAllowanceApproveTransaction: Transaction {
         try super.encode(to: encoder)
     }
 }
-
-public struct HbarAllowance: Codable {
-    public let ownerAccountId: AccountId
-    public let spenderAccountId: AccountId
-    public let amount: Hbar
-}
-
-public struct TokenAllowance: Codable {
-    public let tokenId: TokenId
-    public let ownerAccountId: AccountId
-    public let spenderAccountId: AccountId
-    public let amount: UInt64
-}
-
-public struct TokenNftAllowance: Codable {
-    public let tokenId: TokenId
-    public let ownerAccountId: AccountId
-    public let spenderAccountId: AccountId
-    public var serials: [UInt64]
-    public let approvedForAll: Bool?
-    public let delegatingSpenderAccountId: AccountId?
-}

--- a/sdk/swift/Sources/Hedera/Account/AccountAllowanceDeleteTransaction.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountAllowanceDeleteTransaction.swift
@@ -65,9 +65,3 @@ public final class AccountAllowanceDeleteTransaction: Transaction {
         try super.encode(to: encoder)
     }
 }
-
-public struct NftRemoveAllowance: Encodable {
-    public let tokenId: TokenId
-    public let ownerAccountId: AccountId
-    public var serials: [UInt64]
-}

--- a/sdk/swift/Sources/Hedera/HbarAllowance.swift
+++ b/sdk/swift/Sources/Hedera/HbarAllowance.swift
@@ -1,0 +1,5 @@
+public struct HbarAllowance: Codable {
+    public let ownerAccountId: AccountId
+    public let spenderAccountId: AccountId
+    public let amount: Hbar
+}

--- a/sdk/swift/Sources/Hedera/Token/TokenAllowance.swift
+++ b/sdk/swift/Sources/Hedera/Token/TokenAllowance.swift
@@ -1,0 +1,6 @@
+public struct TokenAllowance: Codable {
+    public let tokenId: TokenId
+    public let ownerAccountId: AccountId
+    public let spenderAccountId: AccountId
+    public let amount: UInt64
+}

--- a/sdk/swift/Sources/Hedera/Token/TokenNftAllowance.swift
+++ b/sdk/swift/Sources/Hedera/Token/TokenNftAllowance.swift
@@ -1,0 +1,14 @@
+public struct TokenNftAllowance: Codable {
+    public let tokenId: TokenId
+    public let ownerAccountId: AccountId
+    public let spenderAccountId: AccountId
+    public var serials: [UInt64]
+    public let approvedForAll: Bool?
+    public let delegatingSpenderAccountId: AccountId?
+}
+
+public struct NftRemoveAllowance: Encodable {
+    public let tokenId: TokenId
+    public let ownerAccountId: AccountId
+    public var serials: [UInt64]
+}


### PR DESCRIPTION
**Description**:

**Related issue(s)**:

- #268 (tick off `HbarAllowance`, `TokenAllowance`, and `TokenNftAllowance`

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
