### PR TITLE
refactor(swift/entity-id)!: use swift-native parsing

### DIFF
--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -260,11 +260,6 @@ size_t hedera_account_balance_to_bytes(struct HederaAccountBalance id,
                                        uint8_t **buf);
 
 /**
- * Parse a Hedera `AccountId` from the passed string.
- */
-enum HederaError hedera_account_id_from_string(const char *s, struct HederaAccountId *id);
-
-/**
  * Parse a Hedera `AccountId` from the passed bytes.
  */
 enum HederaError hedera_account_id_from_bytes(const uint8_t *bytes,
@@ -370,12 +365,6 @@ size_t hedera_client_get_nodes(struct HederaClient *client,
                                struct HederaAccountId **ids);
 
 /**
- * Parse a Hedera `ContractId` from the passed string.
- */
-enum HederaError hedera_contract_id_from_string(const char *s,
-                                                struct HederaContractId *contract_id);
-
-/**
  * Parse a Hedera `ContractId` from the passed bytes.
  *
  * # Safety
@@ -434,14 +423,6 @@ enum HederaError hedera_contract_id_to_solidity_address(struct HederaContractId 
 enum HederaError hedera_contract_info_from_bytes(const uint8_t *bytes, size_t bytes_size, char **s);
 
 enum HederaError hedera_contract_info_to_bytes(const char *s, uint8_t **buf, size_t *buf_size);
-
-/**
- * Parse a Hedera `EntityId` from the passed string.
- */
-enum HederaError hedera_entity_id_from_string(const char *s,
-                                              uint64_t *id_shard,
-                                              uint64_t *id_realm,
-                                              uint64_t *id_num);
 
 /**
  * Parse a Hedera `FileId` from the passed bytes.

--- a/sdk/rust/src/ffi/account_id.rs
+++ b/sdk/rust/src/ffi/account_id.rs
@@ -21,12 +21,10 @@
 use core::slice;
 use std::os::raw::c_char;
 use std::ptr;
-use std::str::FromStr;
 
 use libc::size_t;
 
 use crate::ffi::error::Error;
-use crate::ffi::util::cstr_from_ptr;
 use crate::protobuf::ToProtobuf;
 use crate::PublicKey;
 
@@ -94,24 +92,6 @@ impl<'a> ToProtobuf for RefAccountId<'a> {
             }),
         }
     }
-}
-
-/// Parse a Hedera `AccountId` from the passed string.
-#[no_mangle]
-pub unsafe extern "C" fn hedera_account_id_from_string(
-    s: *const c_char,
-    id: *mut AccountId,
-) -> Error {
-    assert!(!id.is_null());
-
-    let s = unsafe { cstr_from_ptr(s) };
-    let parsed = ffi_try!(crate::AccountId::from_str(&s)).into();
-
-    unsafe {
-        ptr::write(id, parsed);
-    }
-
-    Error::Ok
 }
 
 /// Parse a Hedera `AccountId` from the passed bytes.

--- a/sdk/rust/src/ffi/contract_id.rs
+++ b/sdk/rust/src/ffi/contract_id.rs
@@ -7,7 +7,6 @@ use std::ptr::{
     NonNull,
 };
 use std::slice;
-use std::str::FromStr;
 
 use libc::size_t;
 
@@ -47,26 +46,6 @@ impl ContractId {
         // fixme: swift checksum support
         crate::ContractId { shard, realm, num, evm_address, checksum: None }
     }
-}
-
-/// Parse a Hedera `ContractId` from the passed string.
-#[no_mangle]
-pub extern "C" fn hedera_contract_id_from_string(
-    s: *const c_char,
-    contract_id: *mut ContractId,
-) -> Error {
-    assert!(!contract_id.is_null());
-
-    let s = unsafe { cstr_from_ptr(s) };
-    let parsed = ffi_try!(crate::ContractId::from_str(&s));
-
-    let parsed = ContractId::from_rust(parsed);
-
-    unsafe {
-        ptr::write(contract_id, parsed);
-    }
-
-    Error::Ok
 }
 
 /// Parse a Hedera `ContractId` from the passed bytes.

--- a/sdk/rust/src/ffi/entity_id.rs
+++ b/sdk/rust/src/ffi/entity_id.rs
@@ -18,8 +18,6 @@
  * ‍
  */
 
-use std::os::raw::c_char;
-use std::str::FromStr;
 use std::{
     ptr,
     slice,
@@ -28,7 +26,6 @@ use std::{
 use libc::size_t;
 
 use crate::ffi::error::Error;
-use crate::ffi::util::cstr_from_ptr;
 use crate::{
     EntityId,
     FileId,
@@ -36,30 +33,6 @@ use crate::{
     TokenId,
     TopicId,
 };
-
-/// Parse a Hedera `EntityId` from the passed string.
-#[no_mangle]
-pub extern "C" fn hedera_entity_id_from_string(
-    s: *const c_char,
-    id_shard: *mut u64,
-    id_realm: *mut u64,
-    id_num: *mut u64,
-) -> Error {
-    assert!(!id_shard.is_null());
-    assert!(!id_realm.is_null());
-    assert!(!id_num.is_null());
-
-    let s = unsafe { cstr_from_ptr(s) };
-    let parsed = ffi_try!(EntityId::from_str(&s));
-
-    unsafe {
-        ptr::write(id_shard, parsed.shard);
-        ptr::write(id_realm, parsed.realm);
-        ptr::write(id_num, parsed.num);
-    }
-
-    Error::Ok
-}
 
 // note(sr): This abstraction is worthwhile because it reduces the amount of duplicated non-trival unsafe code.
 // generics (on `FromProtobuf`/`ToProtobuf`) make it very hard to do this without this hack.

--- a/sdk/rust/src/ffi/execute.rs
+++ b/sdk/rust/src/ffi/execute.rs
@@ -107,7 +107,7 @@ pub unsafe extern "C" fn hedera_execute(
                     .map(|response| serde_json::to_string(&response).unwrap())
             }
 
-            AnyRequest::MirrorQuery(mut mirror_query) => mirror_query
+            AnyRequest::MirrorQuery(mirror_query) => mirror_query
                 .execute_with_optional_timeout(client, timeout)
                 .await
                 .map(|response| serde_json::to_string(&response).unwrap()),

--- a/sdk/swift/Sources/Hedera/Data+Extensions.swift
+++ b/sdk/swift/Sources/Hedera/Data+Extensions.swift
@@ -60,7 +60,7 @@ extension Data {
     }
 
     // (sr): swift compiler wins the "useless acl vs explicit acl debate
-    internal init?(hexEncoded: String) {
+    internal init?<S: StringProtocol>(hexEncoded: S) {
         let chars = Array(hexEncoded.utf8)
         // note: hex check is done character by character
         let count = chars.count

--- a/sdk/swift/Sources/Hedera/String+Extensions.swift
+++ b/sdk/swift/Sources/Hedera/String+Extensions.swift
@@ -19,7 +19,6 @@
  */
 
 import CHedera
-import Foundation
 
 extension String {
     /// Creates a new string by copying from a CHedera owned string.

--- a/sdk/swift/Sources/Hedera/StringProtocol+Extensions.swift
+++ b/sdk/swift/Sources/Hedera/StringProtocol+Extensions.swift
@@ -1,0 +1,45 @@
+/*
+ * ‌
+ * Hedera Swift SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+extension StringProtocol {
+    fileprivate func splitAt(index: Index) -> (SubSequence, SubSequence) {
+        (self[..<index], self[self.index(after: index)...])
+    }
+
+    internal func splitOnce(on separator: Element) -> (SubSequence, SubSequence)? {
+        firstIndex(of: separator).map { index in
+            self.splitAt(index: index)
+        }
+    }
+
+    internal func rsplitOnce(on separator: Element) -> (SubSequence, SubSequence)? {
+        lastIndex(of: separator).map { index in
+            self.splitAt(index: index)
+        }
+    }
+
+    internal func stripPrefix<S: StringProtocol>(_ prefix: S) -> SubSequence? {
+        if self.starts(with: prefix) {
+            return self[self.index(self.startIndex, offsetBy: prefix.count)...]
+        }
+
+        return nil
+    }
+}

--- a/sdk/swift/Sources/Hedera/UInt64+Extensions.swift
+++ b/sdk/swift/Sources/Hedera/UInt64+Extensions.swift
@@ -1,0 +1,29 @@
+/*
+ * ‌
+ * Hedera Swift SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+extension UInt64 {
+    internal init<S: StringProtocol>(parsing description: S) throws {
+        guard let value = Self(description) else {
+            throw HError(kind: .basicParse, description: "Invalid numeric string `\(description)`")
+        }
+
+        self = value
+    }
+}


### PR DESCRIPTION
**Description**:
this is to replace the rust string parsing (in swift), and pave the way for checksums

I can change it back to a class and such if need be

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
