### PR TITLE
fix: `toJsonBytes` should use `Self.cToBytes` not `schedule_id`'s

### DIFF
--- a/sdk/swift/Sources/Hedera/ToFromJsonBytes.swift
+++ b/sdk/swift/Sources/Hedera/ToFromJsonBytes.swift
@@ -43,7 +43,7 @@ extension ToJsonBytes {
         var buf: UnsafeMutablePointer<UInt8>?
         var bufSize: Int = 0
 
-        try HError.throwing(error: hedera_schedule_info_to_bytes(json, &buf, &bufSize))
+        try HError.throwing(error: Self.cToBytes(json, &buf, &bufSize))
 
         return Data(bytesNoCopy: buf!, count: bufSize, deallocator: Data.unsafeCHederaBytesFree)
     }


### PR DESCRIPTION
Signed-off-by: Skyler Ross <skyler@launchbadge.com>

**Description**:
Something like this was bound to happen eventually... Stringly typed and all
**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
