### PR TITLE
feat: Add a bunch of easy (to add) methods to `Client`

### DIFF
--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -283,6 +283,16 @@ size_t hedera_account_id_to_bytes(struct HederaAccountId id,
                                   uint8_t **buf);
 
 /**
+ * Free an array of account IDs.
+ *
+ * # Safety
+ * - `ids` must point to an allocation made by `hedera`.
+ * - `ids` must not already have been freed.
+ * - `ids` must be valid for `size` elements.
+ */
+void hedera_account_id_array_free(struct HederaAccountId *ids, size_t size);
+
+/**
  * # Safety
  * - `bytes` must be valid for reads of up to `bytes_size` bytes.
  * - `s` must only be freed with `hedera_string_free`,
@@ -345,6 +355,19 @@ void hedera_client_set_operator(struct HederaClient *client,
                                 uint64_t id_realm,
                                 uint64_t id_num,
                                 struct HederaPrivateKey *key);
+
+/**
+ * Get all the nodes for the `Client`
+ *
+ * For internal use _only_.
+ *
+ * # Safety:
+ * - `Client` must be valid for reads.
+ * - `ids` must be freed by using `hedera_account_id_array_free`, notably this means that it must *not* be freed with `free`.
+ * - the length of `ids` must not be changed.
+ */
+size_t hedera_client_get_nodes(struct HederaClient *client,
+                               struct HederaAccountId **ids);
 
 /**
  * Parse a Hedera `ContractId` from the passed string.

--- a/sdk/rust/src/client/mirror_network.rs
+++ b/sdk/rust/src/client/mirror_network.rs
@@ -39,6 +39,18 @@ pub(crate) struct MirrorNetwork {
 }
 
 impl MirrorNetwork {
+    pub(super) fn mainnet() -> Self {
+        Self::from_static(&[MAINNET])
+    }
+
+    pub(super) fn testnet() -> Self {
+        Self::from_static(&[TESTNET])
+    }
+
+    pub(super) fn previewnet() -> Self {
+        Self::from_static(&[PREVIEWNET])
+    }
+
     pub(crate) fn from_static(network: &[&'static str]) -> Self {
         let mut addresses = Vec::with_capacity(network.len());
 

--- a/sdk/rust/src/client/mod.rs
+++ b/sdk/rust/src/client/mod.rs
@@ -29,12 +29,7 @@ use tokio::sync::RwLock as AsyncRwLock;
 use tokio::task::block_in_place;
 
 use self::mirror_network::MirrorNetwork;
-use crate::client::network::{
-    Network,
-    MAINNET,
-    PREVIEWNET,
-    TESTNET,
-};
+use crate::client::network::Network;
 use crate::error::BoxStdError;
 use crate::{
     AccountId,
@@ -52,73 +47,73 @@ struct Operator {
     signer: PrivateKey,
 }
 
-/// Managed client for use on the Hedera network.
-#[derive(Clone)]
-pub struct Client {
-    network: Arc<Network>,
-    mirror_network: Arc<MirrorNetwork>,
-    operator: Arc<AsyncRwLock<Option<Operator>>>,
-    max_transaction_fee_tinybar: Arc<AtomicU64>,
-    ledger_id: Arc<AsyncRwLock<Option<LedgerId>>>,
-    auto_validate_checksums: Arc<AtomicBool>,
+struct ClientInner {
+    network: Network,
+    mirror_network: MirrorNetwork,
+    operator: AsyncRwLock<Option<Operator>>,
+    max_transaction_fee_tinybar: AtomicU64,
+    ledger_id: AsyncRwLock<Option<LedgerId>>,
+    auto_validate_checksums: AtomicBool,
 }
 
+/// Managed client for use on the Hedera network.
+#[derive(Clone)]
+pub struct Client(Arc<ClientInner>);
+
 impl Client {
+    fn with_network(
+        network: Network,
+        mirror_network: MirrorNetwork,
+        ledger_id: impl Into<Option<LedgerId>>,
+    ) -> Self {
+        Self(Arc::new(ClientInner {
+            network,
+            mirror_network,
+            operator: AsyncRwLock::new(None),
+            max_transaction_fee_tinybar: AtomicU64::new(0),
+            ledger_id: AsyncRwLock::new(ledger_id.into()),
+            auto_validate_checksums: AtomicBool::new(false),
+        }))
+    }
+
     /// Construct a Hedera client pre-configured for mainnet access.
     #[must_use]
     pub fn for_mainnet() -> Self {
-        Self {
-            network: Arc::new(Network::from_static(MAINNET)),
-            mirror_network: Arc::new(MirrorNetwork::from_static(&[mirror_network::MAINNET])),
-            operator: Arc::new(AsyncRwLock::new(None)),
-            max_transaction_fee_tinybar: Arc::new(AtomicU64::new(0)),
-            ledger_id: Arc::new(AsyncRwLock::new(Some(LedgerId::mainnet()))),
-            auto_validate_checksums: Arc::new(AtomicBool::new(false)),
-        }
+        Self::with_network(Network::mainnet(), MirrorNetwork::mainnet(), LedgerId::mainnet())
     }
 
     /// Construct a Hedera client pre-configured for testnet access.
     #[must_use]
     pub fn for_testnet() -> Self {
-        Self {
-            network: Arc::new(Network::from_static(TESTNET)),
-            mirror_network: Arc::new(MirrorNetwork::from_static(&[mirror_network::TESTNET])),
-            operator: Arc::new(AsyncRwLock::new(None)),
-            max_transaction_fee_tinybar: Arc::new(AtomicU64::new(0)),
-            ledger_id: Arc::new(AsyncRwLock::new(Some(LedgerId::testnet()))),
-            auto_validate_checksums: Arc::new(AtomicBool::new(false)),
-        }
+        Self::with_network(Network::testnet(), MirrorNetwork::testnet(), LedgerId::testnet())
     }
 
     /// Construct a Hedera client pre-configured for previewnet access.
     #[must_use]
     pub fn for_previewnet() -> Self {
-        Self {
-            network: Arc::new(Network::from_static(PREVIEWNET)),
-            mirror_network: Arc::new(MirrorNetwork::from_static(&[mirror_network::PREVIEWNET])),
-            operator: Arc::new(AsyncRwLock::new(None)),
-            max_transaction_fee_tinybar: Arc::new(AtomicU64::new(0)),
-            ledger_id: Arc::new(AsyncRwLock::new(Some(LedgerId::previewnet()))),
-            auto_validate_checksums: Arc::new(AtomicBool::new(false)),
-        }
+        Self::with_network(
+            Network::previewnet(),
+            MirrorNetwork::previewnet(),
+            LedgerId::previewnet(),
+        )
     }
 
     pub(crate) async fn ledger_id(&self) -> Option<LedgerId> {
-        self.ledger_id.read().await.clone()
+        self.0.ledger_id.read().await.clone()
     }
 
     /// Sets the ledger ID for the Client's network.
     pub fn set_ledger_id(&self, ledger_id: Option<LedgerId>) {
-        block_in_place(|| *self.ledger_id.blocking_write() = ledger_id);
+        block_in_place(|| *self.0.ledger_id.blocking_write() = ledger_id);
     }
 
     pub(crate) fn auto_validate_checksums(&self) -> bool {
-        self.auto_validate_checksums.load(Ordering::Relaxed)
+        self.0.auto_validate_checksums.load(Ordering::Relaxed)
     }
 
     /// Enable or disable automatic entity ID checksum validation.
     pub fn set_auto_validate_checksums(&self, value: bool) {
-        self.auto_validate_checksums.store(value, Ordering::Relaxed)
+        self.0.auto_validate_checksums.store(value, Ordering::Relaxed)
     }
 
     /// Sets the account that will, by default, be paying for transactions and queries built with
@@ -131,20 +126,20 @@ impl Client {
     ///
     pub fn set_operator(&self, id: AccountId, key: PrivateKey) {
         block_in_place(|| {
-            *self.operator.blocking_write() = Some(Operator { account_id: id, signer: key });
+            *self.0.operator.blocking_write() = Some(Operator { account_id: id, signer: key });
         });
     }
 
     /// Generate a new transaction ID from the stored operator account ID, if present.
     pub(crate) async fn generate_transaction_id(&self) -> Option<TransactionId> {
-        self.operator.read().await.as_ref().map(|it| it.account_id).map(TransactionId::generate)
+        self.0.operator.read().await.as_ref().map(|it| it.account_id).map(TransactionId::generate)
     }
 
     pub(crate) async fn sign_with_operator(
         &self,
         body_bytes: &[u8],
     ) -> Result<(PublicKey, Vec<u8>), BoxStdError> {
-        if let Some(operator) = &*self.operator.read().await {
+        if let Some(operator) = &*self.0.operator.read().await {
             Ok((operator.signer.public_key(), operator.signer.sign(body_bytes)))
         } else {
             unreachable!()
@@ -153,17 +148,17 @@ impl Client {
 
     /// Gets a reference to the configured network.
     pub(crate) fn network(&self) -> &Network {
-        &self.network
+        &self.0.network
     }
 
     /// Gets a reference to the configured mirror network.
     pub(crate) fn mirror_network(&self) -> &MirrorNetwork {
-        &self.mirror_network
+        &self.0.mirror_network
     }
 
     /// Gets the maximum transaction fee the paying account is willing to pay.
     pub(crate) fn max_transaction_fee(&self) -> &AtomicU64 {
-        &self.max_transaction_fee_tinybar
+        &self.0.max_transaction_fee_tinybar
     }
 
     #[allow(clippy::unused_self)]

--- a/sdk/rust/src/client/network.rs
+++ b/sdk/rust/src/client/network.rs
@@ -146,6 +146,18 @@ pub(crate) struct Network {
 }
 
 impl Network {
+    pub(super) fn mainnet() -> Self {
+        Self::from_static(MAINNET)
+    }
+
+    pub(super) fn testnet() -> Self {
+        Self::from_static(TESTNET)
+    }
+
+    pub(super) fn previewnet() -> Self {
+        Self::from_static(PREVIEWNET)
+    }
+
     pub(crate) fn from_static(network: &'static [(u64, &'static [&'static str])]) -> Self {
         let mut map = HashMap::with_capacity(network.len());
         let mut nodes = Vec::with_capacity(network.len());

--- a/sdk/rust/src/client/network.rs
+++ b/sdk/rust/src/client/network.rs
@@ -178,6 +178,10 @@ impl Network {
         Self { map, nodes, addresses, channels, healthy }
     }
 
+    pub(crate) fn node_ids(&self) -> &[AccountId] {
+        &self.nodes
+    }
+
     pub(crate) fn node_indexes_for_ids(&self, ids: &[AccountId]) -> crate::Result<Vec<usize>> {
         let mut indexes = Vec::new();
         for id in ids {

--- a/sdk/rust/src/ffi/account_id.rs
+++ b/sdk/rust/src/ffi/account_id.rs
@@ -18,6 +18,7 @@
  * ‍
  */
 
+use core::slice;
 use std::os::raw::c_char;
 use std::ptr;
 use std::str::FromStr;
@@ -154,4 +155,23 @@ pub unsafe extern "C" fn hedera_account_id_to_bytes(id: AccountId, buf: *mut *mu
     }
 
     len
+}
+
+/// Free an array of account IDs.
+///
+/// # Safety
+/// - `ids` must point to an allocation made by `hedera`.
+/// - `ids` must not already have been freed.
+/// - `ids` must be valid for `size` elements.
+#[no_mangle]
+pub unsafe extern "C" fn hedera_account_id_array_free(ids: *mut AccountId, size: size_t) {
+    assert!(!ids.is_null());
+
+    // safety: function contract promises that we own this `Box<[AccountId]>`.
+    let buf = unsafe {
+        let ids = slice::from_raw_parts_mut(ids, size);
+        Box::from_raw(ids)
+    };
+
+    drop(buf);
 }

--- a/sdk/swift/Sources/Hedera/Client.swift
+++ b/sdk/swift/Sources/Hedera/Client.swift
@@ -19,6 +19,7 @@
  */
 
 import CHedera
+import Foundation
 
 /// Managed client for use on the Hedera network.
 public final class Client {
@@ -28,23 +29,49 @@ public final class Client {
         self.ptr = ptr
     }
 
-    deinit {
-        hedera_client_free(ptr)
+    /// Note: this operation is O(n)
+    private var nodes: [AccountId] {
+        var ids: UnsafeMutablePointer<HederaAccountId>?
+
+        let len = hedera_client_get_nodes(ptr, &ids)
+
+        let nodes = UnsafeMutableBufferPointer(start: ids, count: len).map { AccountId(unsafeFromCHedera: $0) }
+
+        hedera_account_id_array_free(ids, len)
+
+        return nodes
     }
 
     /// Construct a Hedera client pre-configured for mainnet access.
-    public static func forMainnet() -> Client {
-        Client(hedera_client_for_testnet())
+    public static func forMainnet() -> Self {
+        Self(hedera_client_for_testnet())
     }
 
     /// Construct a Hedera client pre-configured for testnet access.
-    public static func forTestnet() -> Client {
-        Client(hedera_client_for_testnet())
+    public static func forTestnet() -> Self {
+        Self(hedera_client_for_testnet())
     }
 
     /// Construct a Hedera client pre-configured for previewnet access.
-    public static func forPreviewnet() -> Client {
-        Client(hedera_client_for_previewnet())
+    public static func forPreviewnet() -> Self {
+        Self(hedera_client_for_previewnet())
+    }
+
+    // wish I could write `init(for name: String)`
+    public static func forName(_ name: String) throws -> Self {
+        switch name {
+        case "mainnet":
+            return Self.forMainnet()
+
+        case "testnet":
+            return Self.forTestnet()
+
+        case "previewnet":
+            return Self.forPreviewnet()
+
+        default:
+            throw HError(kind: .basicParse, description: "Unknown network name \(name)")
+        }
     }
 
     /// Sets the account that will, by default, be paying for transactions and queries built with
@@ -52,5 +79,42 @@ public final class Client {
     public func setOperator(_ accountId: AccountId, _ privateKey: PrivateKey) {
         hedera_client_set_operator(
             ptr, accountId.shard, accountId.realm, accountId.num, privateKey.ptr)
+    }
+
+    public func ping(_ nodeAccountId: AccountId) async throws {
+        _ = try await AccountBalanceQuery(accountId: nodeAccountId).nodeAccountIds([nodeAccountId]).execute(self)
+    }
+
+    public func ping(_ nodeAccountId: AccountId, _ timeout: TimeInterval) async throws {
+        _ = try await AccountBalanceQuery(accountId: nodeAccountId).nodeAccountIds([nodeAccountId]).execute(
+            self, timeout)
+    }
+
+    public func pingAll() async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for node in self.nodes {
+                group.addTask {
+                    try await self.ping(node)
+                }
+
+                try await group.waitForAll()
+            }
+        }
+    }
+
+    public func pingAll(_ timeout: TimeInterval) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for node in self.nodes {
+                group.addTask {
+                    try await self.ping(node, timeout)
+                }
+
+                try await group.waitForAll()
+            }
+        }
+    }
+
+    deinit {
+        hedera_client_free(ptr)
     }
 }


### PR DESCRIPTION
**Description**:
- Add: Client::for_name (rust)
- Add: Client::ping (rust)
- Add: Client::ping_with_timeout (rust)
- Add: Client::ping_all (rust)
- Add: Client::ping_all_with_timeout (rust)
- Add: Client.forName (Swift)
- Add: Client.ping(_ nodeAccountId: AccountId) (Swift)
- Add: Client.ping(_ nodeAccountId: AccountId, _ timeout: TimeInterval) (swift)
- Add: Client.pingAll() (swift)
- Add: Client.pingAll(_ timeout: TimeInterval) (swift)


**Related issue(s)**:

- #226 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
