### PR TITLE
feat: various (all swift)

### DIFF
--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -411,18 +411,6 @@ enum HederaError hedera_contract_id_from_bytes(const uint8_t *bytes,
                                                struct HederaContractId *contract_id);
 
 /**
- * Create a `ContractId` from a `shard.realm.evm_address` set.
- *
- * # Safety
- * - `contract_id` must be valid for writes.
- * - `address` must be valid for reads up until the first `\0` character.
- */
-enum HederaError hedera_contract_id_from_evm_address(uint64_t shard,
-                                                     uint64_t realm,
-                                                     const char *evm_address,
-                                                     struct HederaContractId *contract_id);
-
-/**
  * Serialize the passed `ContractId` as bytes
  *
  * # Safety

--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -423,31 +423,12 @@ enum HederaError hedera_contract_id_from_evm_address(uint64_t shard,
                                                      struct HederaContractId *contract_id);
 
 /**
- * create a `ContractId` from a solidity address.
- *
- * # Safety
- * - `contract_id` must be valid for writes.
- * - `address` must be valid for reads up until the first `\0` character.
- */
-enum HederaError hedera_contract_id_from_solidity_address(const char *address,
-                                                          struct HederaContractId *contract_id);
-
-/**
  * Serialize the passed `ContractId` as bytes
  *
  * # Safety
  * - `buf` must be valid for writes.
  */
 size_t hedera_contract_id_to_bytes(struct HederaContractId contract_id, uint8_t **buf);
-
-/**
- * Serialize the passed `ContractId` as a solidity `address`
- *
- * # Safety
- * - `s` must be valid for writes
- */
-enum HederaError hedera_contract_id_to_solidity_address(struct HederaContractId contract_id,
-                                                        char **s);
 
 /**
  * # Safety

--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -73,6 +73,14 @@ typedef struct HederaAccountId {
    *   - point to a valid instance of `PublicKey` (any `PublicKey` that `hedera` provides which hasn't been freed yet)
    */
   struct HederaPublicKey *alias;
+  /**
+   * Safety:
+   * - if `evm_address` is not null, it must:
+   * - be properly aligned
+   * - be dereferencable
+   * - point to an array of 20 bytes
+   */
+  uint8_t *evm_address;
 } HederaAccountId;
 
 typedef struct HederaAccountBalance {
@@ -1182,6 +1190,20 @@ bool hedera_public_key_is_ed25519(struct HederaPublicKey *key);
  * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
  */
 bool hedera_public_key_is_ecdsa(struct HederaPublicKey *key);
+
+/**
+ * Convert this public key into an evm address. The evm address is This is the rightmost 20 bytes of the 32 byte Keccak-256 hash of the ECDSA public key.
+ *
+ * # Safety
+ * - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
+ * - `evm_address` must be valid for writes according to the [*Rust* pointer rules].
+ * - the length of `evm_address` string must not be modified.
+ * - `evm_address` must NOT be freed with `free`.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_public_key_to_evm_address(struct HederaPublicKey *key,
+                                                  char **evm_address);
 
 /**
  * Releases memory associated with the public key.

--- a/sdk/rust/src/entity_id.rs
+++ b/sdk/rust/src/entity_id.rs
@@ -312,7 +312,11 @@ impl FromStr for EntityId {
 
 #[cfg(test)]
 mod tests {
-    use crate::EntityId;
+    use crate::{
+        EntityId,
+        LedgerId,
+        TopicId,
+    };
 
     #[test]
     fn from_solidity_address() {
@@ -337,15 +341,6 @@ mod tests {
             .unwrap()
             .eq_ignore_ascii_case("000000000000000000000000000000000000138D"));
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{
-        EntityId,
-        LedgerId,
-        TopicId,
-    };
 
     #[test]
     fn generate_checksum_mainnet() {

--- a/sdk/rust/src/ffi/contract_id.rs
+++ b/sdk/rust/src/ffi/contract_id.rs
@@ -1,7 +1,4 @@
-use std::ffi::{
-    c_char,
-    CString,
-};
+use std::ffi::c_char;
 use std::ptr::{
     self,
     NonNull,
@@ -63,32 +60,6 @@ pub unsafe extern "C" fn hedera_contract_id_from_bytes(
     let bytes = unsafe { slice::from_raw_parts(bytes, bytes_size) };
 
     let parsed = ffi_try!(crate::ContractId::from_bytes(bytes));
-
-    let parsed = ContractId::from_rust(parsed);
-
-    unsafe {
-        ptr::write(contract_id, parsed);
-    }
-
-    Error::Ok
-}
-
-/// Create a `ContractId` from a `shard.realm.evm_address` set.
-///
-/// # Safety
-/// - `contract_id` must be valid for writes.
-/// - `address` must be valid for reads up until the first `\0` character.
-#[no_mangle]
-pub unsafe extern "C" fn hedera_contract_id_from_evm_address(
-    shard: u64,
-    realm: u64,
-    evm_address: *const c_char,
-    contract_id: *mut ContractId,
-) -> Error {
-    assert!(!contract_id.is_null());
-
-    let evm_address = unsafe { cstr_from_ptr(evm_address) };
-    let parsed = ffi_try!(crate::ContractId::from_evm_address(shard, realm, &evm_address));
 
     let parsed = ContractId::from_rust(parsed);
 

--- a/sdk/rust/src/ffi/contract_id.rs
+++ b/sdk/rust/src/ffi/contract_id.rs
@@ -99,30 +99,6 @@ pub unsafe extern "C" fn hedera_contract_id_from_evm_address(
     Error::Ok
 }
 
-/// create a `ContractId` from a solidity address.
-///
-/// # Safety
-/// - `contract_id` must be valid for writes.
-/// - `address` must be valid for reads up until the first `\0` character.
-#[no_mangle]
-pub unsafe extern "C" fn hedera_contract_id_from_solidity_address(
-    address: *const c_char,
-    contract_id: *mut ContractId,
-) -> Error {
-    assert!(!contract_id.is_null());
-
-    let evm_address = unsafe { cstr_from_ptr(address) };
-    let parsed = ffi_try!(crate::ContractId::from_solidity_address(&evm_address));
-
-    let parsed = ContractId::from_rust(parsed);
-
-    unsafe {
-        ptr::write(contract_id, parsed);
-    }
-
-    Error::Ok
-}
-
 /// Serialize the passed `ContractId` as bytes
 ///
 /// # Safety
@@ -147,27 +123,4 @@ pub unsafe extern "C" fn hedera_contract_id_to_bytes(
     }
 
     len
-}
-
-/// Serialize the passed `ContractId` as a solidity `address`
-///
-/// # Safety
-/// - `s` must be valid for writes
-#[no_mangle]
-pub unsafe extern "C" fn hedera_contract_id_to_solidity_address(
-    contract_id: ContractId,
-    s: *mut *mut c_char,
-) -> Error {
-    // todo: use `as_maybe_uninit_ref` once that's stable.
-    assert!(!s.is_null());
-
-    let out = ffi_try!(contract_id.to_rust().to_solidity_address());
-    let out = CString::new(out).unwrap().into_raw();
-
-    // safety: invariants promise that `buf` must be valid for writes.
-    unsafe {
-        ptr::write(s, out);
-    }
-
-    Error::Ok
 }

--- a/sdk/rust/src/ffi/key/public/mod.rs
+++ b/sdk/rust/src/ffi/key/public/mod.rs
@@ -394,6 +394,32 @@ pub unsafe extern "C" fn hedera_public_key_is_ecdsa(key: *mut PublicKey) -> bool
     key.is_ecdsa()
 }
 
+/// Convert this public key into an evm address. The evm address is This is the rightmost 20 bytes of the 32 byte Keccak-256 hash of the ECDSA public key.
+///
+/// # Safety
+/// - `key` must be a pointer that is valid for reads according to the [*Rust* pointer rules].
+/// - `evm_address` must be valid for writes according to the [*Rust* pointer rules].
+/// - the length of `evm_address` string must not be modified.
+/// - `evm_address` must NOT be freed with `free`.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_public_key_to_evm_address(
+    key: *mut PublicKey,
+    evm_address: *mut *mut c_char,
+) -> Error {
+    let key = unsafe { key.as_ref() }.unwrap();
+
+    assert!(!evm_address.is_null());
+
+    let out = ffi_try!(key.to_evm_address());
+    let out = CString::new(out).unwrap();
+
+    unsafe { evm_address.write(out.into_raw()) }
+
+    Error::Ok
+}
+
 /// Releases memory associated with the public key.
 #[no_mangle]
 pub unsafe extern "C" fn hedera_public_key_free(key: *mut PublicKey) {

--- a/sdk/rust/src/file/file_info.rs
+++ b/sdk/rust/src/file/file_info.rs
@@ -52,11 +52,11 @@ pub struct FileInfo {
     )]
     pub expiration_time: Option<OffsetDateTime>,
 
-    /// The auto renew period for this account.
+    /// The auto renew period for this file.
     pub auto_renew_period: Option<Duration>,
 
-    /// The account to be used at this account's expiration time to extend the
-    /// life of the account.  If `None`, this account pays for its own auto renewal fee.
+    /// The account to be used at this ffile's expiration time to extend the
+    /// life of the file.
     pub auto_renew_account_id: Option<AccountId>,
 
     /// True if deleted but not yet expired.

--- a/sdk/swift/Sources/Hedera/Account/AccountBalance.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountBalance.swift
@@ -55,7 +55,7 @@ public final class AccountBalance: Codable {
             var buf: UnsafeMutablePointer<UInt8>?
             let size = hedera_account_balance_to_bytes(hedera, &buf)
 
-            return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+            return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
         }
     }
 

--- a/sdk/swift/Sources/Hedera/Account/AccountCreateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountCreateTransaction.swift
@@ -28,8 +28,11 @@ public final class AccountCreateTransaction: Transaction {
         initialBalance: Hbar = 0,
         receiverSignatureRequired: Bool = false,
         autoRenewPeriod: Duration? = nil,
+        autoRenewAccountId: AccountId? = nil,
         accountMemo: String = "",
         maxAutomaticTokenAssociations: UInt32 = 0,
+        alias: PublicKey? = nil,
+        evmAddress: EvmAddress? = nil,
         stakedAccountId: AccountId? = nil,
         stakedNodeId: UInt64? = nil,
         declineStakingReward: Bool = false
@@ -89,6 +92,19 @@ public final class AccountCreateTransaction: Transaction {
         return self
     }
 
+    /// The account to be used at this account's expiration time to extend the
+    /// life of the account.  If `nil`, this account pays for its own auto renewal fee.
+    public var autoRenewAccountId: AccountId? = nil
+
+    /// Sets the account to be used at this account's expiration time to extend the
+    /// life of the account.  If `nil`, this account pays for its own auto renewal fee.
+    @discardableResult
+    public func autoRenewAccountId(_ autoRenewAccountId: AccountId) -> Self {
+        self.autoRenewAccountId = autoRenewAccountId
+
+        return self
+    }
+
     /// The memo associated with the account.
     public var accountMemo: String
 
@@ -107,6 +123,27 @@ public final class AccountCreateTransaction: Transaction {
     @discardableResult
     public func maxAutomaticTokenAssociations(_ maxAutomaticTokenAssociations: UInt32) -> Self {
         self.maxAutomaticTokenAssociations = maxAutomaticTokenAssociations
+
+        return self
+    }
+
+    /// A key to be used as the account's alias.
+    public var alias: PublicKey?
+
+    /// Sets the key to be used as the account's alias.
+    @discardableResult
+    public func alias(_ alias: PublicKey) -> Self {
+        self.alias = alias
+
+        return self
+    }
+
+    /// A 20-byte EVM address to be used as the account's evm address.
+    public var evmAddress: EvmAddress?
+
+    @discardableResult
+    public func evmAddress(_ evmAddress: EvmAddress) -> Self {
+        self.evmAddress = evmAddress
 
         return self
     }
@@ -157,6 +194,9 @@ public final class AccountCreateTransaction: Transaction {
         case stakedAccountId
         case stakedNodeId
         case declineStakingReward
+        case alias
+        case evmAddress
+        case autoRenewAccountId
     }
 
     public override func encode(to encoder: Encoder) throws {
@@ -170,12 +210,15 @@ public final class AccountCreateTransaction: Transaction {
         try container.encodeIfPresent(stakedAccountId, forKey: .stakedAccountId)
         try container.encodeIfPresent(stakedNodeId, forKey: .stakedNodeId)
         try container.encode(declineStakingReward, forKey: .declineStakingReward)
+        try container.encodeIfPresent(alias, forKey: .alias)
+        try container.encodeIfPresent(evmAddress, forKey: .evmAddress)
 
         try super.encode(to: encoder)
     }
 
     internal override func validateChecksums(on ledgerId: LedgerId) throws {
         try stakedAccountId?.validateChecksums(on: ledgerId)
+        try autoRenewAccountId?.validateChecksums(on: ledgerId)
         try super.validateChecksums(on: ledgerId)
     }
 }

--- a/sdk/swift/Sources/Hedera/Account/AccountId.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountId.swift
@@ -119,7 +119,7 @@ public struct AccountId: EntityId, ValidateChecksums {
             return "\(shard).\(realm).\(alias)"
         }
 
-        return defaultDescription
+        return helper.description
     }
 
     public static func fromBytes(_ bytes: Data) throws -> Self {
@@ -145,7 +145,7 @@ public struct AccountId: EntityId, ValidateChecksums {
         precondition(alias == nil, "cannot create a checksum for an `AccountId` with an alias")
         precondition(evmAddress == nil, "cannot create a checksum for an `AccountId` with an evmAddress")
 
-        return defaultToStringWithChecksum(client)
+        return helper.toStringWithChecksum(client)
     }
 
     public func validateChecksum(_ client: Client) throws {
@@ -157,7 +157,7 @@ public struct AccountId: EntityId, ValidateChecksums {
             return
         }
 
-        try defaultValidateChecksum(on: ledgerId)
+        try helper.validateChecksum(on: ledgerId)
     }
 
     /// Create an `AccountId` from an evm address.

--- a/sdk/swift/Sources/Hedera/Account/AccountId.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountId.swift
@@ -168,10 +168,6 @@ public struct AccountId: EntityId, ValidateChecksums {
     }
 
     // todo: public func `toEvmAddress`/`getEvmAddress`
-
-    public static func == (lhs: AccountId, rhs: AccountId) -> Bool {
-        lhs.shard == rhs.shard && lhs.realm == rhs.realm && lhs.num == lhs.num && lhs.alias == rhs.alias
-    }
 }
 
 // TODO: to evm address

--- a/sdk/swift/Sources/Hedera/Account/AccountUpdateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountUpdateTransaction.swift
@@ -75,6 +75,19 @@ public final class AccountUpdateTransaction: Transaction {
         return self
     }
 
+    /// The account to be used at this account's expiration time to extend the
+    /// life of the account.  If `nil`, this account pays for its own auto renewal fee.
+    public var autoRenewAccountId: AccountId? = nil
+
+    /// Sets the account to be used at this account's expiration time to extend the
+    /// life of the account.  If `nil`, this account pays for its own auto renewal fee.
+    @discardableResult
+    public func autoRenewAccountId(_ autoRenewAccountId: AccountId) -> Self {
+        self.autoRenewAccountId = autoRenewAccountId
+
+        return self
+    }
+
     /// The new expiration time to extend to (ignored if equal to or before the current one).
     public var expirationTime: Timestamp?
 
@@ -155,6 +168,7 @@ public final class AccountUpdateTransaction: Transaction {
         case stakedAccountId
         case stakedNodeId
         case declineStakingReward
+        case autoRenewAccountId
     }
 
     public override func encode(to encoder: Encoder) throws {
@@ -168,6 +182,7 @@ public final class AccountUpdateTransaction: Transaction {
         try container.encodeIfPresent(stakedAccountId, forKey: .stakedAccountId)
         try container.encodeIfPresent(stakedNodeId, forKey: .stakedNodeId)
         try container.encodeIfPresent(declineStakingReward, forKey: .declineStakingReward)
+        try container.encodeIfPresent(autoRenewAccountId, forKey: .autoRenewAccountId)
 
         try super.encode(to: encoder)
     }
@@ -175,6 +190,7 @@ public final class AccountUpdateTransaction: Transaction {
     internal override func validateChecksums(on ledgerId: LedgerId) throws {
         try accountId?.validateChecksums(on: ledgerId)
         try stakedAccountId?.validateChecksums(on: ledgerId)
+        try autoRenewAccountId?.validateChecksums(on: ledgerId)
         try super.validateChecksums(on: ledgerId)
     }
 }

--- a/sdk/swift/Sources/Hedera/Account/AccountUpdateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountUpdateTransaction.swift
@@ -88,6 +88,27 @@ public final class AccountUpdateTransaction: Transaction {
         return self
     }
 
+    /// The ID of the account to which this account is proxy staked.
+    ///
+    /// If `proxy_account_id` is `None`, or is an invalid account, or is an account
+    /// that isn't a node, then this account is automatically proxy staked to
+    /// a node chosen by the network, but without earning payments.
+    ///
+    /// If the `proxy_account_id` account refuses to accept proxy staking, or
+    /// if it is not currently running a node, then it
+    /// will behave as if `proxy_account_id` was `None`.
+    @available(*, deprecated)
+    public var proxyAccountId: AccountId?
+
+    ///  Set the proxy account ID for this account
+    @available(*, deprecated)
+    public func proxyAccountId(_ proxyAccountId: AccountId) -> Self {
+        self.proxyAccountId = proxyAccountId
+
+        return self
+    }
+
+
     /// The new expiration time to extend to (ignored if equal to or before the current one).
     public var expirationTime: Timestamp?
 

--- a/sdk/swift/Sources/Hedera/Account/AccountUpdateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/Account/AccountUpdateTransaction.swift
@@ -108,7 +108,6 @@ public final class AccountUpdateTransaction: Transaction {
         return self
     }
 
-
     /// The new expiration time to extend to (ignored if equal to or before the current one).
     public var expirationTime: Timestamp?
 

--- a/sdk/swift/Sources/Hedera/Client.swift
+++ b/sdk/swift/Sources/Hedera/Client.swift
@@ -130,7 +130,7 @@ public final class Client {
             var bytes: UnsafeMutablePointer<UInt8>?
             let count = hedera_client_get_ledger_id(ptr, &bytes)
 
-            return bytes.map { LedgerId(Data(bytesNoCopy: $0, count: count, deallocator: Data.unsafeCHederaBytesFree)) }
+            return bytes.map { LedgerId(Data(bytesNoCopy: $0, count: count, deallocator: .unsafeCHederaBytesFree)) }
         }
 
         set(value) {

--- a/sdk/swift/Sources/Hedera/Collection+Extensions.swift
+++ b/sdk/swift/Sources/Hedera/Collection+Extensions.swift
@@ -1,0 +1,13 @@
+extension Collection {
+    internal subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+
+    internal subscript(safe range: Range<Index>) -> SubSequence? {
+        contains(range: range) ? self[range] : nil
+    }
+
+    internal func contains(range: Range<Index>) -> Bool {
+        indices.contains(range.lowerBound) && indices.contains(range.upperBound)
+    }
+}

--- a/sdk/swift/Sources/Hedera/Contract/ContractId.swift
+++ b/sdk/swift/Sources/Hedera/Contract/ContractId.swift
@@ -112,11 +112,7 @@ public struct ContractId: EntityId {
     }
 
     public static func fromEvmAddress(_ shard: UInt64, _ realm: UInt64, _ address: String) throws -> Self {
-        var hedera = HederaContractId()
-
-        try HError.throwing(error: hedera_contract_id_from_evm_address(shard, realm, address, &hedera))
-
-        return Self(unsafeFromCHedera: hedera)
+        Self(shard: shard, realm: realm, evmAddress: try SolidityAddress(parsing: address).data)
     }
 
     public func toSolidityAddress() throws -> String {
@@ -124,7 +120,8 @@ public struct ContractId: EntityId {
             return evmAddress.hexStringEncoded()
         }
 
-        return try helper.toSolidityAddress()
+        return String(describing: try SolidityAddress(self))
+
     }
 
     public func toBytes() -> Data {

--- a/sdk/swift/Sources/Hedera/Contract/ContractId.swift
+++ b/sdk/swift/Sources/Hedera/Contract/ContractId.swift
@@ -74,7 +74,7 @@ public struct ContractId: EntityId {
 
         if let evmAddress = hedera.evm_address {
             self.num = 0
-            self.evmAddress = Data(bytesNoCopy: evmAddress, count: 20, deallocator: Data.unsafeCHederaBytesFree)
+            self.evmAddress = Data(bytesNoCopy: evmAddress, count: 20, deallocator: .unsafeCHederaBytesFree)
         } else {
             self.num = hedera.num
             self.evmAddress = nil
@@ -142,7 +142,7 @@ public struct ContractId: EntityId {
             var buf: UnsafeMutablePointer<UInt8>?
             let size = hedera_contract_id_to_bytes(hedera, &buf)
 
-            return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+            return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
         }
     }
 

--- a/sdk/swift/Sources/Hedera/Data+Extensions.swift
+++ b/sdk/swift/Sources/Hedera/Data+Extensions.swift
@@ -42,12 +42,6 @@ private func hexVal(_ char: UInt8) -> UInt8? {
 }
 
 extension Data {
-    // safety: `hedera_bytes_free` needs to be called so...
-    // perf: might as well enable use of the no copy constructor.
-    internal static let unsafeCHederaBytesFree: Data.Deallocator = .custom { (buf, size) in
-        hedera_bytes_free(buf.bindMemory(to: UInt8.self, capacity: size), size)
-    }
-
     private static let hexAlphabet = Array("0123456789abcdef".unicodeScalars)
 
     // (sr): swift compiler wins the "useless acl vs explicit acl debate
@@ -95,5 +89,13 @@ extension Data {
         try self.withUnsafeBytes { pointer in
             try body(pointer.bindMemory(to: UInt8.self))
         }
+    }
+}
+
+extension Data.Deallocator {
+    // safety: `hedera_bytes_free` needs to be called so...
+    // perf: might as well enable use of the no copy constructor.
+    internal static let unsafeCHederaBytesFree: Data.Deallocator = .custom { (buf, size) in
+        hedera_bytes_free(buf.bindMemory(to: UInt8.self, capacity: size), size)
     }
 }

--- a/sdk/swift/Sources/Hedera/EvmAddress.swift
+++ b/sdk/swift/Sources/Hedera/EvmAddress.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public struct EvmAddress: CustomStringConvertible, LosslessStringConvertible, ExpressibleByStringLiteral, Hashable {
+    internal let data: Data
+
+    internal init(_ data: Data) throws {
+        guard data.count == 20 else {
+            throw HError(kind: .basicParse, description: "expected evm address to have 20 bytes, it had \(data.count)")
+        }
+
+        self.data = data
+    }
+
+    internal init<S: StringProtocol>(parsing description: S) throws {
+        guard let description = description.stripPrefix("0x") else {
+            throw HError(kind: .basicParse, description: "expected evm address to have `0x` prefix")
+        }
+
+        guard let bytes = Data(hexEncoded: description) else {
+            // todo: better error message
+            throw HError(kind: .basicParse, description: "invalid evm address")
+        }
+
+        try self.init(bytes)
+    }
+
+    public init?(_ description: String) {
+        try? self.init(parsing: description)
+    }
+
+    public init(stringLiteral value: StringLiteralType) {
+        // swiftlint:disable:next force_try
+        try! self.init(parsing: value)
+    }
+
+    public static func fromString(_ description: String) throws -> Self {
+        try Self(parsing: description)
+    }
+
+    public static func fromBytes(_ data: Data) throws -> Self {
+        try Self(data)
+    }
+
+    public var description: String {
+        "0x\(data.hexStringEncoded())"
+    }
+
+    public func toString() -> String {
+        description
+    }
+
+    public func toBytes() -> Data {
+        data
+    }
+}
+
+extension EvmAddress: Codable {
+    public init(from decoder: Decoder) throws {
+        try self.init(parsing: decoder.singleValueContainer().decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        try container.encode(String(describing: self))
+    }
+}

--- a/sdk/swift/Sources/Hedera/EvmAddress.swift
+++ b/sdk/swift/Sources/Hedera/EvmAddress.swift
@@ -65,3 +65,15 @@ extension EvmAddress: Codable {
         try container.encode(String(describing: self))
     }
 }
+
+extension EvmAddress: Codable {
+    public init(from decoder: Decoder) throws {
+        try self.init(parsing: decoder.singleValueContainer().decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        try container.encode(String(describing: self))
+    }
+}

--- a/sdk/swift/Sources/Hedera/EvmAddress.swift
+++ b/sdk/swift/Sources/Hedera/EvmAddress.swift
@@ -65,15 +65,3 @@ extension EvmAddress: Codable {
         try container.encode(String(describing: self))
     }
 }
-
-extension EvmAddress: Codable {
-    public init(from decoder: Decoder) throws {
-        try self.init(parsing: decoder.singleValueContainer().decode(String.self))
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-
-        try container.encode(String(describing: self))
-    }
-}

--- a/sdk/swift/Sources/Hedera/File/FileCreateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/File/FileCreateTransaction.swift
@@ -65,6 +65,28 @@ public final class FileCreateTransaction: Transaction {
         return self
     }
 
+    /// The auto renew period for this file.
+    public var autoRenewPeriod: Duration?
+
+    /// Set the auto renew period for this file.
+    public func autoRenewPeriod(_ autoRenewPeriod: Duration) -> Self {
+        self.autoRenewPeriod = autoRenewPeriod
+
+        return self
+    }
+
+    /// The account to be used at the files's expiration time to extend the
+    /// life of the file.
+    public var autoRenewAccountId: AccountId?
+
+    /// Sets the account to be used at the files's expiration time to extend the
+    /// life of the file.
+    public func autoRenewAccountId(_ autoRenewAccountId: AccountId) -> Self {
+        self.autoRenewAccountId = autoRenewAccountId
+
+        return self
+    }
+
     /// The time at which this file should expire.
     public var expirationTime: Timestamp? = Timestamp(
         from: Calendar.current.date(byAdding: .day, value: 90, to: Date())!)
@@ -82,6 +104,7 @@ public final class FileCreateTransaction: Transaction {
         case keys
         case contents
         case expirationTime
+        case autoRenewAccountId
     }
 
     public override func encode(to encoder: Encoder) throws {
@@ -90,8 +113,13 @@ public final class FileCreateTransaction: Transaction {
         try container.encode(fileMemo, forKey: .fileMemo)
         try container.encode(keys, forKey: .keys)
         try container.encode(contents.base64EncodedString(), forKey: .contents)
+        try container.encodeIfPresent(autoRenewAccountId, forKey: .autoRenewAccountId)
         try container.encodeIfPresent(expirationTime, forKey: .expirationTime)
 
         try super.encode(to: encoder)
+    }
+
+    override func validateChecksums(on ledgerId: LedgerId) throws {
+        try self.autoRenewAccountId?.validateChecksums(on: ledgerId)
     }
 }

--- a/sdk/swift/Sources/Hedera/File/FileInfo.swift
+++ b/sdk/swift/Sources/Hedera/File/FileInfo.swift
@@ -45,6 +45,13 @@ public final class FileInfo: Codable {
 
     public let ledgerId: LedgerId
 
+    /// The auto renew period for this file.
+    public let autoRenewPeriod: Duration?
+
+    /// The account to be used at this file's expiration time to extend the
+    /// life of the file.
+    public let autoRenewAccountId: AccountId?
+
     public static func fromBytes(_ bytes: Data) throws -> Self {
         try Self.fromJsonBytes(bytes)
     }

--- a/sdk/swift/Sources/Hedera/File/FileUpdateTransaction.swift
+++ b/sdk/swift/Sources/Hedera/File/FileUpdateTransaction.swift
@@ -80,6 +80,28 @@ public final class FileUpdateTransaction: Transaction {
         return self
     }
 
+    /// The auto renew period for this file.
+    public var autoRenewPeriod: Duration?
+
+    /// Set the auto renew period for this file.
+    public func autoRenewPeriod(_ autoRenewPeriod: Duration) -> Self {
+        self.autoRenewPeriod = autoRenewPeriod
+
+        return self
+    }
+
+    /// The account to be used at the files's expiration time to extend the
+    /// life of the file.
+    public var autoRenewAccountId: AccountId?
+
+    /// Sets the account to be used at the files's expiration time to extend the
+    /// life of the file.
+    public func autoRenewAccountId(_ autoRenewAccountId: AccountId) -> Self {
+        self.autoRenewAccountId = autoRenewAccountId
+
+        return self
+    }
+
     /// The time at which this file should expire.
     private var expirationTime: Timestamp?
 
@@ -97,6 +119,7 @@ public final class FileUpdateTransaction: Transaction {
         case keys
         case contents
         case expirationTime
+        case autoRenewAccountId
     }
 
     public override func encode(to encoder: Encoder) throws {
@@ -107,12 +130,14 @@ public final class FileUpdateTransaction: Transaction {
         try container.encodeIfPresent(keys, forKey: .keys)
         try container.encode(contents.base64EncodedString(), forKey: .contents)
         try container.encodeIfPresent(expirationTime, forKey: .expirationTime)
+        try container.encodeIfPresent(autoRenewAccountId, forKey: .autoRenewAccountId)
 
         try super.encode(to: encoder)
     }
 
     internal override func validateChecksums(on ledgerId: LedgerId) throws {
         try fileId?.validateChecksums(on: ledgerId)
+        try autoRenewAccountId?.validateChecksums(on: ledgerId)
         try super.validateChecksums(on: ledgerId)
     }
 }

--- a/sdk/swift/Sources/Hedera/FixedWidthInteger+Extensions.swift
+++ b/sdk/swift/Sources/Hedera/FixedWidthInteger+Extensions.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+extension FixedWidthInteger {
+    internal init?(littleEndianBytes bytes: Data) {
+        let size = MemoryLayout<Self>.size
+
+        guard bytes.contains(range: 0..<size) else { return nil }
+
+        self = 0
+
+        let _ = withUnsafeMutableBytes(of: &self, { bytes.copyBytes(to: $0) })
+
+        self = littleEndian
+
+    }
+
+    internal init?(nativeEndianBytes bytes: Data) {
+        let size = MemoryLayout<Self>.size
+
+        guard bytes.contains(range: 0..<size) else { return nil }
+
+        self = 0
+
+        let _ = withUnsafeMutableBytes(of: &self, { bytes.copyBytes(to: $0) })
+    }
+
+    internal init?(bigEndianBytes bytes: Data) {
+        let size = MemoryLayout<Self>.size
+
+        guard bytes.contains(range: 0..<size) else { return nil }
+
+        self = 0
+
+        let _ = withUnsafeMutableBytes(of: &self, { bytes.copyBytes(to: $0) })
+
+        self = bigEndian
+
+    }
+
+    internal var nativeEndianBytes: Data {
+        var num: Self = self
+        return Data(bytes: &num, count: MemoryLayout.size(ofValue: num))
+    }
+
+    internal var littleEndianBytes: Data {
+        var num: Self = self.littleEndian
+        return Data(bytes: &num, count: MemoryLayout.size(ofValue: num))
+    }
+
+    internal var bigEndianBytes: Data {
+        var num: Self = self.bigEndian
+        return Data(bytes: &num, count: MemoryLayout.size(ofValue: num))
+    }
+}

--- a/sdk/swift/Sources/Hedera/HError.swift
+++ b/sdk/swift/Sources/Hedera/HError.swift
@@ -58,6 +58,7 @@ public struct HError: Error, CustomStringConvertible {
         case badEntityId
         case cannotToStringWithChecksum
         case cannotPerformTaskWithoutLedgerId
+        case wrongKeyType
     }
 
     public let description: String
@@ -142,6 +143,9 @@ public struct HError: Error, CustomStringConvertible {
 
         case HEDERA_ERROR_CANNOT_PERFORM_TASK_WITHOUT_LEDGER_ID:
             kind = .cannotPerformTaskWithoutLedgerId
+
+        case HEDERA_ERROR_WRONG_KEY_TYPE:
+            kind = .wrongKeyType
 
         case HEDERA_ERROR_OK:
             return nil

--- a/sdk/swift/Sources/Hedera/Mnemonic.swift
+++ b/sdk/swift/Sources/Hedera/Mnemonic.swift
@@ -93,7 +93,7 @@ public final class Mnemonic: LosslessStringConvertible, ExpressibleByStringLiter
 
     public var description: String {
         let descriptionBytes = hedera_mnemonic_to_string(ptr)
-        return String(hString: descriptionBytes!)!
+        return String(hString: descriptionBytes!)
     }
 
     deinit {

--- a/sdk/swift/Sources/Hedera/NetworkVersionInfo.swift
+++ b/sdk/swift/Sources/Hedera/NetworkVersionInfo.swift
@@ -59,7 +59,7 @@ public struct NetworkVersionInfo: Codable {
             var buf: UnsafeMutablePointer<UInt8>?
             let size = hedera_network_version_info_to_bytes(info, &buf)
 
-            return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+            return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
         }
     }
 }

--- a/sdk/swift/Sources/Hedera/NftId.swift
+++ b/sdk/swift/Sources/Hedera/NftId.swift
@@ -87,7 +87,7 @@ public final class NftId: Codable, LosslessStringConvertible, ExpressibleByStrin
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_nft_id_to_bytes(tokenId.shard, tokenId.realm, tokenId.num, serial, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
     }
 
     public static func == (lhs: NftId, rhs: NftId) -> Bool {

--- a/sdk/swift/Sources/Hedera/PrivateKey.swift
+++ b/sdk/swift/Sources/Hedera/PrivateKey.swift
@@ -131,26 +131,26 @@ public final class PrivateKey: LosslessStringConvertible, ExpressibleByStringLit
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_private_key_to_bytes_der(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
     }
 
     public func toBytes() -> Data {
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_private_key_to_bytes(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
     }
 
     public func toBytesRaw() -> Data {
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_private_key_to_bytes_raw(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
     }
 
     public var description: String {
         let descriptionBytes = hedera_private_key_to_string(ptr)
-        return String(hString: descriptionBytes!)!
+        return String(hString: descriptionBytes!)
     }
 
     public func toString() -> String {
@@ -159,12 +159,12 @@ public final class PrivateKey: LosslessStringConvertible, ExpressibleByStringLit
 
     public func toStringDer() -> String {
         let stringBytes = hedera_private_key_to_string_der(ptr)
-        return String(hString: stringBytes!)!
+        return String(hString: stringBytes!)
     }
 
     public func toStringRaw() -> String {
         let stringBytes = hedera_private_key_to_string_raw(ptr)
-        return String(hString: stringBytes!)!
+        return String(hString: stringBytes!)
     }
 
     public func toAccountId(shard: UInt64, realm: UInt64) -> AccountId {
@@ -183,7 +183,7 @@ public final class PrivateKey: LosslessStringConvertible, ExpressibleByStringLit
         message.withUnsafeTypedBytes { pointer in
             var buf: UnsafeMutablePointer<UInt8>?
             let size = hedera_private_key_sign(ptr, pointer.baseAddress, pointer.count, &buf)
-            return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+            return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
         }
     }
 

--- a/sdk/swift/Sources/Hedera/PublicKey.swift
+++ b/sdk/swift/Sources/Hedera/PublicKey.swift
@@ -117,26 +117,26 @@ public final class PublicKey: LosslessStringConvertible, ExpressibleByStringLite
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_public_key_to_bytes_der(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
     }
 
     public func toBytes() -> Data {
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_public_key_to_bytes(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
     }
 
     public func toBytesRaw() -> Data {
         var buf: UnsafeMutablePointer<UInt8>?
         let size = hedera_public_key_to_bytes_raw(ptr, &buf)
 
-        return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
     }
 
     public var description: String {
         let descriptionBytes = hedera_public_key_to_string(ptr)
-        return String(hString: descriptionBytes!)!
+        return String(hString: descriptionBytes!)
     }
 
     public func toString() -> String {
@@ -145,16 +145,16 @@ public final class PublicKey: LosslessStringConvertible, ExpressibleByStringLite
 
     public func toStringDer() -> String {
         let stringBytes = hedera_public_key_to_string_der(ptr)
-        return String(hString: stringBytes!)!
+        return String(hString: stringBytes!)
     }
 
     public func toStringRaw() -> String {
         let stringBytes = hedera_public_key_to_string_raw(ptr)
-        return String(hString: stringBytes!)!
+        return String(hString: stringBytes!)
     }
 
     public func toAccountId(shard: UInt64, realm: UInt64) -> AccountId {
-        AccountId.init(shard: shard, realm: realm, alias: self)
+        AccountId(shard: shard, realm: realm, alias: self)
     }
 
     public func verify(_ message: Data, _ signature: Data) throws {
@@ -191,6 +191,14 @@ public final class PublicKey: LosslessStringConvertible, ExpressibleByStringLite
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(toBytesDer())
+    }
+
+    /// Convert this public key into an evm address. The EVM address is This is the rightmost 20 bytes of the 32 byte Keccak-256 hash of the ECDSA public key.
+    public func toEvmAddress() throws -> String {
+        var stringPtr: UnsafeMutablePointer<CChar>?
+        try HError.throwing(error: hedera_public_key_to_evm_address(ptr, &stringPtr))
+
+        return String(hString: stringPtr!)
     }
 
     deinit {

--- a/sdk/swift/Sources/Hedera/SemanticVersion.swift
+++ b/sdk/swift/Sources/Hedera/SemanticVersion.swift
@@ -112,7 +112,7 @@ public struct SemanticVersion: Codable, ExpressibleByStringLiteral, LosslessStri
             var buf: UnsafeMutablePointer<UInt8>?
             let size = hedera_semantic_version_to_bytes(info, &buf)
 
-            return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+            return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
         }
     }
 

--- a/sdk/swift/Sources/Hedera/SolidityAddress.swift
+++ b/sdk/swift/Sources/Hedera/SolidityAddress.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+internal struct SolidityAddress: CustomStringConvertible {
+    internal let data: Data
+
+    internal init(_ data: Data) throws {
+        guard data.count == 20 else {
+            throw HError(kind: .basicParse, description: "expected evm address to have 20 bytes, it had \(data.count)")
+        }
+
+        self.data = data
+    }
+
+    internal init<E: EntityId>(_ id: E) throws {
+        guard let shard = UInt32(exactly: id.shard) else {
+            // todo: use a proper error kind
+            throw HError(kind: .basicParse, description: "Shard too big for `toSolidityAddress`")
+        }
+
+        self.data = (shard.bigEndianBytes + id.realm.bigEndianBytes + id.num.bigEndianBytes)
+    }
+
+    internal init<S: StringProtocol>(parsing description: S) throws {
+        let description = description.stripPrefix("0x") ?? description[...]
+
+        guard let bytes = Data(hexEncoded: description) else {
+            // todo: better error message
+            throw HError(kind: .basicParse, description: "invalid solidity address")
+        }
+
+        try self.init(bytes)
+    }
+
+    internal func toEntityId<E: EntityId>() -> E {
+        let shard = UInt32(bigEndianBytes: data[..<4])!
+        // eww copies, but, what can we do?
+        let realm = UInt64(bigEndianBytes: Data(data[4..<12]))!
+        let num = UInt64(bigEndianBytes: Data(data[12...]))!
+
+        return E(shard: UInt64(shard), realm: realm, num: num)
+    }
+
+    internal var description: String {
+        data.hexStringEncoded()
+    }
+}

--- a/sdk/swift/Sources/Hedera/String+Extensions.swift
+++ b/sdk/swift/Sources/Hedera/String+Extensions.swift
@@ -28,12 +28,12 @@ extension String {
     ///
     /// - Parameter hString: A pointer to a CString
     ///
-    internal init!(hString: UnsafeMutablePointer<CChar>) {
+    internal init(hString: UnsafeMutablePointer<CChar>) {
         // `String.init(validatingUTF8)` copies the string:
         // https://developer.apple.com/documentation/swift/string/init(validatingutf8:)-208fn
         // > Creates a new string by copying and validating
         //   the null-terminated UTF-8 data referenced by the given pointer.
-        self.init(validatingUTF8: hString)
+        self.init(validatingUTF8: hString)!
 
         hedera_string_free(hString)
     }

--- a/sdk/swift/Sources/Hedera/ToFromJsonBytes.swift
+++ b/sdk/swift/Sources/Hedera/ToFromJsonBytes.swift
@@ -45,6 +45,6 @@ extension ToJsonBytes {
 
         try HError.throwing(error: Self.cToBytes(json, &buf, &bufSize))
 
-        return Data(bytesNoCopy: buf!, count: bufSize, deallocator: Data.unsafeCHederaBytesFree)
+        return Data(bytesNoCopy: buf!, count: bufSize, deallocator: .unsafeCHederaBytesFree)
     }
 }

--- a/sdk/swift/Sources/Hedera/TransactionId.swift
+++ b/sdk/swift/Sources/Hedera/TransactionId.swift
@@ -75,7 +75,7 @@ public struct TransactionId: Codable, Equatable, ExpressibleByStringLiteral, Los
             var buf: UnsafeMutablePointer<UInt8>?
             let size = hedera_transaction_id_to_bytes(hedera, &buf)
 
-            return Data(bytesNoCopy: buf!, count: size, deallocator: Data.unsafeCHederaBytesFree)
+            return Data(bytesNoCopy: buf!, count: size, deallocator: .unsafeCHederaBytesFree)
         }
     }
 

--- a/sdk/swift/Sources/Hedera/TransactionRecord.swift
+++ b/sdk/swift/Sources/Hedera/TransactionRecord.swift
@@ -88,6 +88,9 @@ public struct TransactionRecord: Codable {
     /// `EthereumTransaction`.
     public let ethereumHash: Data?
 
+    /// The last 20 bytes of the keccak-256 hash of a ECDSA_SECP256K1 primitive key.
+    public let evmAddress: EvmAddress?
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
@@ -105,6 +108,7 @@ public struct TransactionRecord: Codable {
         scheduleRef = try container.decodeIfPresent(ScheduleId.self, forKey: .scheduleRef)
         assessedCustomFees = try container.decode([AssessedCustomFee].self, forKey: .assessedCustomFees)
         automaticTokenAssociations = try container.decode([TokenAssociation].self, forKey: .automaticTokenAssociations)
+        evmAddress = try container.decode(EvmAddress.self, forKey: .evmAddress)
 
         parentConsensusTimestamp = try container.decodeIfPresent(Timestamp.self, forKey: .parentConsensusTimestamp)
 


### PR DESCRIPTION
Signed-off-by: Skyler Ross <skyler@launchbadge.com>

**Description**:
- Add: EntityId.{to,from}SolidityAddress
- Add: `EvmAddress`
- Add; `AccountId.evmAddress`
- Add: `AccountId.fromEvmAddress`
- Add: `AccountCreateTransaction` `autoRenewAccountId`, `alias`, `evmAddress`
- Add: `AccountUpdateTransaction.autoRenewAccountId`
- Add: `FileCreateTransaction.autoRenewPeriod` & `autoRenewAccountId`
- Add: `FileInfo.autoRenewPeriod` & `autoRenewAccountId`
- Add: `FileUpdateTransactionauto.autoRenewPeriod` & `autoRenewAccountId`
- Change: make `AccountId.fromString` support `0x{evmAddress}

Conflicts with #354 (not unresolvable, but they touch the same things)

**Related issue(s)**:

closed issues depends on if #354 gets merged before or after this.
- closes #222 
- closes #223 
- closes #225 
- closes #237
- closes #344 
- closes #346 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
