### PR TITLE
private key from password protected pet

### DIFF
--- a/sdk/c/include/hedera.h
+++ b/sdk/c/include/hedera.h
@@ -750,6 +750,26 @@ enum HederaError hedera_private_key_from_string_ecdsa(const char *s, struct Hede
 enum HederaError hedera_private_key_from_pem(const char *pem, struct HederaPrivateKey **key);
 
 /**
+ * Parse a Hedera private key from the passed pem encoded string with the given password.
+ *
+ * # Safety
+ * - `pem` must be a valid string
+ * - `password` must be a valid string
+ * - `key` must be a valid for writes according to [*Rust* pointer rules].
+ *   The inner pointer need not point to a valid `PrivateKey`, however.
+ *
+ * # Errors
+ * - [`Error::KeyParse`] if `pem` is not valid PEM.
+ * - [`Error::KeyParse`] if the type label (`BEGIN XYZ`) is not `ENCRYPTED PRIVATE KEY`.
+ * - [`Error::KeyParse`] if decrypting the private key fails.
+ *
+ * [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+ */
+enum HederaError hedera_private_key_from_pem_with_password(const char *pem,
+                                                           const char *password,
+                                                           struct HederaPrivateKey **key);
+
+/**
  * Return `key`, serialized as der encoded bytes.
  *
  * Note: the returned `buf` must be freed via `hedera_bytes_free` in order to prevent a memory leak.

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "aes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +219,15 @@ name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cbindgen"
@@ -241,6 +270,16 @@ dependencies = [
  "num-traits",
  "serde",
  "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -930,6 +969,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,12 +1311,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs5"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d10d862c1f5c302df3c3dbfd837afbae0ad09551a6fa37b10311cb5890a80175"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "hmac",
+ "pbkdf2",
+ "scrypt",
+ "sha2 0.10.6",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
+ "pkcs5",
+ "rand_core 0.6.4",
  "spki",
 ]
 
@@ -1515,6 +1582,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1601,18 @@ name = "scratch"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
+name = "scrypt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
+dependencies = [
+ "hmac",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.6",
+]
 
 [[package]]
 name = "sec1"

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -15,7 +15,19 @@ bench = false
 crate-type = ["lib", "staticlib"]
 
 [features]
-ffi = ["anyhow", "cbindgen", "libc", "fraction/with-serde-support", "ed25519-dalek/serde", "hedera-proto/serde", "serde", "serde_with", "serde_json", "time/serde", "serde/derive"]
+ffi = [
+  "anyhow",
+  "cbindgen",
+  "libc",
+  "fraction/with-serde-support",
+  "ed25519-dalek/serde",
+  "hedera-proto/serde",
+  "serde",
+  "serde_with",
+  "serde_json",
+  "time/serde",
+  "serde/derive",
+]
 
 [dependencies]
 async-stream = "0.3.3"
@@ -40,7 +52,6 @@ once_cell = "1.10.0"
 parking_lot = "0.12.0"
 pbkdf2 = { version = "0.11.0", default-features = false }
 pem-rfc7468 = { version = "0.6.0", features = ["std"] }
-pkcs8 = "0.9.0"
 prost = "0.11.0"
 rand = "0.8.5"
 rust_decimal = "1.26.1"
@@ -55,6 +66,11 @@ tinystr = "0.7.0"
 # for ed25519-dalek
 rand_0_7 = { version = "0.7", package = "rand" }
 arc-swap = "1.6.0"
+
+[dependencies.pkcs8]
+version = "0.9.0"
+default_features = false
+features = ["encryption"]
 
 [dependencies.serde_json]
 version = "1.0.79"

--- a/sdk/rust/src/ffi/key/private/mod.rs
+++ b/sdk/rust/src/ffi/key/private/mod.rs
@@ -278,6 +278,44 @@ pub unsafe extern "C" fn hedera_private_key_from_pem(
     Error::Ok
 }
 
+/// Parse a Hedera private key from the passed pem encoded string with the given password.
+///
+/// # Safety
+/// - `pem` must be a valid string
+/// - `password` must be a valid string
+/// - `key` must be a valid for writes according to [*Rust* pointer rules].
+///   The inner pointer need not point to a valid `PrivateKey`, however.
+///
+/// # Errors
+/// - [`Error::KeyParse`] if `pem` is not valid PEM.
+/// - [`Error::KeyParse`] if the type label (`BEGIN XYZ`) is not `ENCRYPTED PRIVATE KEY`.
+/// - [`Error::KeyParse`] if decrypting the private key fails.
+///
+/// [*Rust* pointer rules]: https://doc.rust-lang.org/std/ptr/index.html#safety
+#[no_mangle]
+pub unsafe extern "C" fn hedera_private_key_from_pem_with_password(
+    pem: *const c_char,
+    password: *const c_char,
+    key: *mut *mut PrivateKey,
+) -> Error {
+    assert!(!key.is_null());
+
+    // safety: function contract requires that pem is a valid `CStr`.
+    let pem = unsafe { CStr::from_ptr(pem) };
+    // safety: function contract requires that password is a valid `CStr`.
+    let password = unsafe { CStr::from_ptr(password) };
+    let parsed = ffi_try!(PrivateKey::from_pem_with_password(pem.to_bytes(), password.to_bytes()));
+
+    let parsed = Box::into_raw(Box::new(parsed));
+    // safety:
+    // function contract requires that `key` points to a valid `*mut *mut PrivateKey`
+    // function contract requires us *not* to inspect the old value.
+    //  ^ and we don't, which is good.
+    unsafe { ptr::write(key, parsed) }
+
+    Error::Ok
+}
+
 /// Return `key`, serialized as der encoded bytes.
 ///
 /// Note: the returned `buf` must be freed via `hedera_bytes_free` in order to prevent a memory leak.

--- a/sdk/rust/src/key/private_key/tests.rs
+++ b/sdk/rust/src/key/private_key/tests.rs
@@ -162,6 +162,20 @@ MC4CAQAwBQYDK2VwBCIEINtIS4KOZLLY8SzjwKDpOguMznrxu485yXcyOUSCU44Q
 }
 
 #[test]
+fn ed25519_from_pem_with_password() {
+    const PEM: &[u8] = b"-----BEGIN ENCRYPTED PRIVATE KEY-----
+MIGbMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAjeB6TNNQX+1gICCAAw
+DAYIKoZIhvcNAgkFADAdBglghkgBZQMEAQIEENfMacg1/Txd/LhKkxZtJe0EQEVL
+mez3xb+sfUIF3TKEIDJtw7H0xBNlbAfLxTV11pofiar0z1/WRBHFFUuGIYSiKjlU
+V9RQhAnemO84zcZfTYs=
+-----END ENCRYPTED PRIVATE KEY-----";
+
+    let pk = PrivateKey::from_pem_with_password(PEM, "test").unwrap();
+
+    assert_eq!(pk.to_string(), "302e020100300506032b6570042204208d8df406a762e36dfbf6dda2239f38a266db369e09bca6a8569e9e79b4826152");
+}
+
+#[test]
 fn ecdsa_from_pem() {
     const PEM: &[u8] = br#"-----BEGIN PRIVATE KEY-----
 MDACAQAwBwYFK4EEAAoEIgQgh3bGuDGhthrBDawDBKKEPeRxb1SxkZu5GiaF0P4/

--- a/sdk/swift/Sources/Hedera/PrivateKey.swift
+++ b/sdk/swift/Sources/Hedera/PrivateKey.swift
@@ -119,10 +119,18 @@ public final class PrivateKey: LosslessStringConvertible, ExpressibleByStringLit
         return Self(key!)
     }
 
-    /// Parse a `PrivateKey` from [PEM](https://www.rfc-editor.org/rfc/rfc7468#section-10) encoded bytes.
+    /// Parse a `PrivateKey` from a [PEM](https://www.rfc-editor.org/rfc/rfc7468#section-10) encoded string.
     public static func fromPem(_ pem: String) throws -> Self {
         var key: OpaquePointer?
         try HError.throwing(error: hedera_private_key_from_pem(pem, &key))
+
+        return Self(key!)
+    }
+
+    /// Parse a `PrivateKey` from a password protected [PEM](https://www.rfc-editor.org/rfc/rfc7468#section-11) encoded string.
+    public static func fromPem(_ pem: String, _ password: String) throws -> Self {
+        var key: OpaquePointer?
+        try HError.throwing(error: hedera_private_key_from_pem_with_password(pem, password, &key))
 
         return Self(key!)
     }

--- a/sdk/swift/Tests/HederaTests/PrivateKeyTests.swift
+++ b/sdk/swift/Tests/HederaTests/PrivateKeyTests.swift
@@ -82,6 +82,25 @@ public final class PrivateKeyTests: XCTestCase {
             "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10")
     }
 
+    public func testEd25519FromPemWithPassword() throws {
+        let pemString =
+            """
+            -----BEGIN ENCRYPTED PRIVATE KEY-----
+            MIGbMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAjeB6TNNQX+1gICCAAw
+            DAYIKoZIhvcNAgkFADAdBglghkgBZQMEAQIEENfMacg1/Txd/LhKkxZtJe0EQEVL
+            mez3xb+sfUIF3TKEIDJtw7H0xBNlbAfLxTV11pofiar0z1/WRBHFFUuGIYSiKjlU
+            V9RQhAnemO84zcZfTYs=
+            -----END ENCRYPTED PRIVATE KEY-----
+            """
+
+        let privateKey = try PrivateKey.fromPem(pemString, "test")
+
+        XCTAssertEqual(
+            privateKey.description,
+            "302e020100300506032b6570042204208d8df406a762e36dfbf6dda2239f38a266db369e09bca6a8569e9e79b4826152"
+        )
+    }
+
     public func testEcdsaFromPem() throws {
         let pemString = """
             -----BEGIN PRIVATE KEY-----


### PR DESCRIPTION
**Description**:
- Add(swift): `PrivateKey.fromPem(_ pem: String, password: String) throws -> Self`
- Add(Rust): `PrivateKey::from_pem(pem: impl AsRef<[u8]>, password: impl AsRef<[u8]>) -> crate::Result<Self>`

**Related issue(s)**:
- #246 (second to last checkbox there, just the `sign_transaction` function left)


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
