### PR TITLE
fix(rust): Don't free client ledger id when passing to swift

### DIFF
--- a/sdk/rust/src/ffi/client.rs
+++ b/sdk/rust/src/ffi/client.rs
@@ -22,6 +22,7 @@ use std::ptr;
 
 use libc::size_t;
 
+use super::util;
 use crate::{
     Client,
     LedgerId,
@@ -188,14 +189,7 @@ pub unsafe extern "C" fn hedera_client_get_ledger_id(
         }
     };
 
-    let mut ledger_id = ledger_id.to_bytes().into_boxed_slice();
-
-    let len = ledger_id.len();
-    let ptr = ledger_id.as_mut_ptr();
-
-    unsafe { ptr::write(ledger_id_bytes, ptr) };
-
-    len
+    unsafe { util::make_bytes(ledger_id.to_bytes(), ledger_id_bytes) }
 }
 
 #[no_mangle]

--- a/sdk/swift/Tests/HederaTests/EntityIdTests.swift
+++ b/sdk/swift/Tests/HederaTests/EntityIdTests.swift
@@ -89,6 +89,12 @@ public final class EntityIdTests: XCTestCase {
         }
     }
 
+    internal func testAccountIdChecksum() {
+        let checksumAddress = AccountId("0.0.1126123").toStringWithChecksum(.forMainnet())
+
+        XCTAssertEqual(checksumAddress, "0.0.1126123-ycfte")
+    }
+
     internal func testChecksumOnPreviewnet() {
         let expected: [String] = [
             "nwkes", "wghmj", "eqeua", "nacbr", "vjzji", "dtwqz", "mdtyq", "unrgh",


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
