### PR TITLE
feat!: FeeAssessmentMethod

### DIFF
--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -199,6 +199,7 @@ pub use system::{
 };
 pub use token::{
     AssessedCustomFee,
+    FeeAssessmentMethod,
     NftId,
     TokenAssociateTransaction,
     TokenAssociation,

--- a/sdk/rust/src/token/custom_fees/tests.rs
+++ b/sdk/rust/src/token/custom_fees/tests.rs
@@ -125,13 +125,14 @@ fn fractional_fee_can_convert_to_protobuf() -> anyhow::Result<()> {
     let minimum_amount = 500;
     let maximum_amount = 1000;
     let net_of_transfers = true;
+    let assessment_method = super::FeeAssessmentMethod::Exclusive;
 
     let fractional_fee = FractionalFeeData {
         denominator: 1,
         numerator: 2,
         minimum_amount,
         maximum_amount,
-        net_of_transfers,
+        assessment_method,
     };
 
     let fractional_fee_proto = fractional_fee.to_protobuf();
@@ -148,6 +149,7 @@ fn fractional_fee_can_be_created_from_protobuf() -> anyhow::Result<()> {
     let minimum_amount = 500;
     let maximum_amount = 1000;
     let net_of_transfers = true;
+    let assessment_method = super::FeeAssessmentMethod::Exclusive;
 
     let fractional_fee_protobuf = services::FractionalFee {
         fractional_amount: Some(services::Fraction { numerator: 1, denominator: 2 }),
@@ -160,7 +162,7 @@ fn fractional_fee_can_be_created_from_protobuf() -> anyhow::Result<()> {
 
     assert_eq!(fractional_fee.minimum_amount, minimum_amount);
     assert_eq!(fractional_fee.maximum_amount, maximum_amount);
-    assert_eq!(fractional_fee.net_of_transfers, net_of_transfers);
+    assert_eq!(fractional_fee.assessment_method, assessment_method);
 
     Ok(())
 }

--- a/sdk/rust/src/token/mod.rs
+++ b/sdk/rust/src/token/mod.rs
@@ -47,6 +47,7 @@ mod token_update_transaction;
 mod token_wipe_transaction;
 
 pub use assessed_custom_fee::AssessedCustomFee;
+pub use custom_fees::FeeAssessmentMethod;
 pub use nft_id::NftId;
 pub use token_associate_transaction::{
     TokenAssociateTransaction,


### PR DESCRIPTION
I don't know *why* this exists, but it does

It's a bit less confusing than `net_of_transfers` though.

**Description**:

This is a breaking change because it modifies a field on a public struct (Rust/Swift), and it adds a new field to a struct that is publicly constructible (Rust)
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #451 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
