### PR TITLE
fix(swift): remove unsafe flags from build

### DIFF
--- a/sdk/swift/Package.swift
+++ b/sdk/swift/Package.swift
@@ -84,10 +84,11 @@ let package = Package(
                 .product(name: "NumberKit", package: "swift-numberkit"),
                 .product(name: "GRPC", package: "grpc-swift"),
                 .product(name: "Atomics", package: "swift-atomics"),
-            ],
-            swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-warn-concurrency", "-Xfrontend", "-enable-actor-data-race-checks"])
             ]
+            // todo: find some way to enable these locally.
+            // swiftSettings: [
+            //     .unsafeFlags(["-Xfrontend", "-warn-concurrency", "-Xfrontend", "-enable-actor-data-race-checks"])
+            // ]
         ),
         .testTarget(name: "HederaTests", dependencies: ["Hedera"]),
     ] + exampleTargets


### PR DESCRIPTION
**Description**:
Turns out unsafeFlags prevent downstream users from building

This wasn't caught by CI because CI has no way to test that.
**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
