### PR TITLE
Various internal refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,8 @@ dependencies = [
  "tinystr",
  "tokio",
  "tonic",
+ "triomphe",
+ "unsize",
 ]
 
 [[package]]
@@ -1813,6 +1815,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ee9bd9239c339d714d657fac840c6d2a4f9c45f4f9ec7b0975113458be78db"
+dependencies = [
+ "arc-swap",
+ "unsize",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,6 +1841,15 @@ name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unsize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa7a7a734c1a5664a662ddcea0b6c9472a21da8888c957c7f1eaa09dba7a939"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6342bd4f5a1205d7f41e94a41a901f5647c938cdfa96036338e8533c9d6c2450"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "arc-swap"
@@ -127,9 +127,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b70caf9f1b0c045f7da350636435b775a9733adf2df56e8aa2a29210fbc335d4"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.4"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.4"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -384,13 +384,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
@@ -927,9 +927,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libm"
@@ -939,9 +939,9 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -1302,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -1410,9 +1410,9 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustix"
-version = "0.37.14"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -1470,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
 
 [[package]]
 name = "sha2"
@@ -1487,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest",
  "keccak",
@@ -1532,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
  "der",
@@ -1624,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "serde",
  "time-core",
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "tinystr"
@@ -1687,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cd2598a37719e3cd4c28af93f978506a97a2920ef4d96e4b12e38b8cbc8940"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1785,10 +1785,11 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.38"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ arc-swap = "1.6.0"
 rlp = "0.5.2"
 bytes = { version = "1.2.1", default-features = false }
 pin-project-lite = "0.2.9"
+unsize = "1.1.0"
 
 [dependencies.futures-util]
 version = "0.3.21"
@@ -70,6 +71,11 @@ features = ["ecdsa", "precomputed-tables", "std"]
 version = "0.10.0"
 default_features = false
 features = ["encryption"]
+
+[dependencies.triomphe]
+version = "0.1.8"
+default-features = false
+features = ["std", "arc-swap", "unsize"]
 
 [dev-dependencies]
 anyhow = "1.0.57"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,3 @@
-disallowed-types = ["std::sync::Arc"]
+disallowed-types = [
+    { path = "std::sync::Arc", reason = "Use `triomphe::Arc` internally" }
+]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+disallowed-types = ["std::sync::Arc"]

--- a/examples/consensus_pub_sub_chunked.rs
+++ b/examples/consensus_pub_sub_chunked.rs
@@ -80,11 +80,9 @@ async fn main() -> anyhow::Result<()> {
             let mut tx = TopicMessageSubmitTransaction::new();
 
             // note: this used to set `max_chunks(15)` with a comment saying that the default is 10, but it's 20.
-            // todo: sign with operator (once that's merged)
             tx.topic_id(topic_id)
                 .message(resources::BIG_CONTENTS)
-                .freeze_with(&client)?
-                .sign(args.operator_key.clone());
+                .sign_with_operator(&client)?;
 
             // serialize to bytes so we can be signed "somewhere else" by the submit key
             let transaction_bytes = tx.to_bytes()?;

--- a/src/account/account_allowance_approve_transaction.rs
+++ b/src/account/account_allowance_approve_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
 use crate::transaction::{
     AnyTransactionData,
@@ -36,7 +37,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     Hbar,
-    LedgerId,
     NftId,
     ToProtobuf,
     TokenId,
@@ -215,7 +215,7 @@ impl TransactionExecute for AccountAllowanceApproveTransactionData {
 }
 
 impl ValidateChecksums for AccountAllowanceApproveTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         for hbar_allowance in &self.hbar_allowances {
             hbar_allowance.owner_account_id.validate_checksums(ledger_id)?;
             hbar_allowance.spender_account_id.validate_checksums(ledger_id)?;

--- a/src/account/account_allowance_delete_transaction.rs
+++ b/src/account/account_allowance_delete_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -38,7 +39,6 @@ use crate::{
     AccountId,
     BoxGrpcFuture,
     Error,
-    LedgerId,
     NftId,
     TokenId,
     Transaction,
@@ -114,7 +114,7 @@ impl TransactionExecute for AccountAllowanceDeleteTransactionData {
 }
 
 impl ValidateChecksums for AccountAllowanceDeleteTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         for allowance in &self.nft_allowances {
             allowance.token_id.validate_checksums(ledger_id)?;
             allowance.owner_account_id.validate_checksums(ledger_id)?;

--- a/src/account/account_balance_query.rs
+++ b/src/account/account_balance_query.rs
@@ -23,6 +23,7 @@ use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use services::crypto_get_account_balance_query::BalanceSource;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     Query,
@@ -35,7 +36,6 @@ use crate::{
     BoxGrpcFuture,
     ContractId,
     Error,
-    LedgerId,
     ToProtobuf,
     ValidateChecksums,
 };
@@ -142,7 +142,7 @@ impl QueryExecute for AccountBalanceQueryData {
 }
 
 impl ValidateChecksums for AccountBalanceQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         match self.source {
             AccountBalanceSource::AccountId(account_id) => account_id.validate_checksums(ledger_id),
             AccountBalanceSource::ContractId(contract_id) => {

--- a/src/account/account_create_transaction.rs
+++ b/src/account/account_create_transaction.rs
@@ -23,6 +23,7 @@ use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use time::Duration;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -42,7 +43,6 @@ use crate::{
     Error,
     Hbar,
     Key,
-    LedgerId,
     PublicKey,
     Transaction,
     ValidateChecksums,
@@ -310,7 +310,7 @@ impl TransactionExecute for AccountCreateTransactionData {
 }
 
 impl ValidateChecksums for AccountCreateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.staked_id.validate_checksums(ledger_id)
     }
 }

--- a/src/account/account_delete_transaction.rs
+++ b/src/account/account_delete_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -38,7 +39,6 @@ use crate::{
     AccountId,
     BoxGrpcFuture,
     Error,
-    LedgerId,
     Transaction,
     ValidateChecksums,
 };
@@ -98,7 +98,7 @@ impl TransactionExecute for AccountDeleteTransactionData {
 }
 
 impl ValidateChecksums for AccountDeleteTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.transfer_account_id.validate_checksums(ledger_id)?;
         self.account_id.validate_checksums(ledger_id)
     }

--- a/src/account/account_id.rs
+++ b/src/account/account_id.rs
@@ -33,13 +33,13 @@ use crate::entity_id::{
     PartialEntityId,
     ValidateChecksums,
 };
+use crate::ledger_id::RefLedgerId;
 use crate::{
     Client,
     EntityId,
     Error,
     EvmAddress,
     FromProtobuf,
-    LedgerId,
     PublicKey,
     ToProtobuf,
 };
@@ -143,7 +143,7 @@ impl AccountId {
 }
 
 impl ValidateChecksums for AccountId {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         if self.alias.is_some() || self.evm_address.is_some() {
             Ok(())
         } else {

--- a/src/account/account_info_query.rs
+++ b/src/account/account_info_query.rs
@@ -23,6 +23,7 @@ use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
 use crate::account::AccountInfo;
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     QueryExecute,
@@ -32,7 +33,6 @@ use crate::{
     AccountId,
     BoxGrpcFuture,
     Error,
-    LedgerId,
     Query,
     ToProtobuf,
     ValidateChecksums,
@@ -96,7 +96,7 @@ impl QueryExecute for AccountInfoQueryData {
 }
 
 impl ValidateChecksums for AccountInfoQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.account_id.validate_checksums(ledger_id)
     }
 }

--- a/src/account/account_records_query.rs
+++ b/src/account/account_records_query.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     QueryExecute,
@@ -32,7 +33,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     FromProtobuf,
-    LedgerId,
     Query,
     ToProtobuf,
     TransactionRecord,
@@ -94,7 +94,7 @@ impl QueryExecute for AccountRecordsQueryData {
 }
 
 impl ValidateChecksums for AccountRecordsQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.account_id.validate_checksums(ledger_id)
     }
 }

--- a/src/account/account_stakers_query.rs
+++ b/src/account/account_stakers_query.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     QueryExecute,
@@ -32,7 +33,6 @@ use crate::{
     AllProxyStakers,
     BoxGrpcFuture,
     Error,
-    LedgerId,
     Query,
     ToProtobuf,
     ValidateChecksums,
@@ -95,7 +95,7 @@ impl QueryExecute for AccountStakersQueryData {
 }
 
 impl ValidateChecksums for AccountStakersQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.account_id.validate_checksums(ledger_id)
     }
 }

--- a/src/account/account_update_transaction.rs
+++ b/src/account/account_update_transaction.rs
@@ -26,6 +26,7 @@ use time::{
 };
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -44,7 +45,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     Key,
-    LedgerId,
     Transaction,
     ValidateChecksums,
 };
@@ -293,7 +293,7 @@ impl TransactionExecute for AccountUpdateTransactionData {
 }
 
 impl ValidateChecksums for AccountUpdateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.account_id.validate_checksums(ledger_id)?;
         self.staked_id.validate_checksums(ledger_id)
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -64,7 +64,7 @@ pub struct Client(Arc<ClientInner>);
 impl fmt::Debug for Client {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // todo: put anything important here.
-        f.debug_tuple("Client").finish()
+        f.debug_struct("Client").finish_non_exhaustive()
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -24,12 +24,11 @@ use std::sync::atomic::{
     AtomicU64,
     Ordering,
 };
-use std::sync::Arc;
 use std::time::Duration;
 
-use arc_swap::ArcSwapOption;
 pub(crate) use operator::Operator;
 use rand::thread_rng;
+use triomphe::Arc;
 
 use self::mirror_network::MirrorNetwork;
 use crate::client::network::Network;
@@ -37,6 +36,7 @@ use crate::ping_query::PingQuery;
 use crate::signer::AnySigner;
 use crate::{
     AccountId,
+    ArcSwapOption,
     Error,
     LedgerId,
     PrivateKey,
@@ -145,6 +145,7 @@ impl Client {
     }
 
     /// Returns true if checksums should be automatically validated.
+    #[must_use]
     pub fn auto_validate_checksums(&self) -> bool {
         self.0.auto_validate_checksums.load(Ordering::Relaxed)
     }
@@ -157,6 +158,7 @@ impl Client {
     /// Returns true if transaction IDs should be automatically regenerated.
     ///
     /// This is `true` by default.
+    #[must_use]
     pub fn default_regenerate_transaction_id(&self) -> bool {
         self.0.regenerate_transaction_ids.load(Ordering::Relaxed)
     }

--- a/src/client/operator.rs
+++ b/src/client/operator.rs
@@ -13,7 +13,7 @@ pub(crate) struct Operator {
 
 impl Operator {
     pub(crate) fn sign(&self, body_bytes: &[u8]) -> (PublicKey, Vec<u8>) {
-        self.signer.sign(&body_bytes)
+        self.signer.sign(body_bytes)
     }
 
     pub(crate) fn generate_transaction_id(&self) -> TransactionId {

--- a/src/contract/contract_bytecode_query.rs
+++ b/src/contract/contract_bytecode_query.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     QueryExecute,
@@ -32,7 +33,6 @@ use crate::{
     ContractId,
     Error,
     FromProtobuf,
-    LedgerId,
     Query,
     ToProtobuf,
     ValidateChecksums,
@@ -95,7 +95,7 @@ impl QueryExecute for ContractBytecodeQueryData {
 }
 
 impl ValidateChecksums for ContractBytecodeQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.contract_id.validate_checksums(ledger_id)
     }
 }

--- a/src/contract/contract_call_query.rs
+++ b/src/contract/contract_call_query.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     QueryExecute,
@@ -33,7 +34,6 @@ use crate::{
     ContractFunctionResult,
     ContractId,
     Error,
-    LedgerId,
     Query,
     ToProtobuf,
     ValidateChecksums,
@@ -156,7 +156,7 @@ impl QueryExecute for ContractCallQueryData {
 }
 
 impl ValidateChecksums for ContractCallQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.contract_id.validate_checksums(ledger_id)?;
         self.sender_account_id.validate_checksums(ledger_id)
     }

--- a/src/contract/contract_create_flow.rs
+++ b/src/contract/contract_create_flow.rs
@@ -18,8 +18,6 @@
  * ‍
  */
 
-use std::sync::Arc;
-
 use time::Duration;
 
 use crate::signer::AnySigner;
@@ -302,8 +300,7 @@ impl ContractCreateFlow {
         public_key: PublicKey,
         signer: F,
     ) -> &mut Self {
-        self.contract_data.signer =
-            Some(AnySigner::Arbitrary(Box::new(public_key), Arc::new(signer)));
+        self.contract_data.signer = Some(AnySigner::arbitrary(Box::new(public_key), signer));
 
         self
     }

--- a/src/contract/contract_create_transaction.rs
+++ b/src/contract/contract_create_transaction.rs
@@ -23,6 +23,7 @@ use hedera_proto::services::smart_contract_service_client::SmartContractServiceC
 use time::Duration;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
 use crate::staked_id::StakedId;
 use crate::transaction::{
@@ -40,7 +41,6 @@ use crate::{
     FileId,
     Hbar,
     Key,
-    LedgerId,
     ToProtobuf,
     Transaction,
     ValidateChecksums,
@@ -273,7 +273,7 @@ impl TransactionExecute for ContractCreateTransactionData {
 }
 
 impl ValidateChecksums for ContractCreateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.bytecode_file_id.validate_checksums(ledger_id)?;
         self.auto_renew_account_id.validate_checksums(ledger_id)?;
         self.staked_id.validate_checksums(ledger_id)

--- a/src/contract/contract_delete_transaction.rs
+++ b/src/contract/contract_delete_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -39,7 +40,6 @@ use crate::{
     BoxGrpcFuture,
     ContractId,
     Error,
-    LedgerId,
     Transaction,
     ValidateChecksums,
 };
@@ -109,7 +109,7 @@ impl TransactionExecute for ContractDeleteTransactionData {
 }
 
 impl ValidateChecksums for ContractDeleteTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.contract_id.validate_checksums(ledger_id)?;
         self.transfer_account_id.validate_checksums(ledger_id)?;
         self.transfer_contract_id.validate_checksums(ledger_id)

--- a/src/contract/contract_execute_transaction.rs
+++ b/src/contract/contract_execute_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
 use crate::transaction::{
     AnyTransactionData,
@@ -36,7 +37,6 @@ use crate::{
     ContractId,
     Error,
     Hbar,
-    LedgerId,
     ToProtobuf,
     Transaction,
     ValidateChecksums,
@@ -134,7 +134,7 @@ impl TransactionExecute for ContractExecuteTransactionData {
 }
 
 impl ValidateChecksums for ContractExecuteTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.contract_id.validate_checksums(ledger_id)?;
         Ok(())
     }

--- a/src/contract/contract_id.rs
+++ b/src/contract/contract_id.rs
@@ -34,12 +34,12 @@ use crate::entity_id::{
     ValidateChecksums,
 };
 use crate::ethereum::IdEvmAddress;
+use crate::ledger_id::RefLedgerId;
 use crate::{
     Client,
     EntityId,
     Error,
     FromProtobuf,
-    LedgerId,
     ToProtobuf,
 };
 
@@ -157,7 +157,7 @@ impl ContractId {
 }
 
 impl ValidateChecksums for ContractId {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         if self.evm_address.is_some() {
             Ok(())
         } else {

--- a/src/contract/contract_info_query.rs
+++ b/src/contract/contract_info_query.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     QueryExecute,
@@ -32,7 +33,6 @@ use crate::{
     ContractId,
     ContractInfo,
     Error,
-    LedgerId,
     Query,
     ToProtobuf,
     ValidateChecksums,
@@ -96,7 +96,7 @@ impl QueryExecute for ContractInfoQueryData {
 }
 
 impl ValidateChecksums for ContractInfoQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.contract_id.validate_checksums(ledger_id)
     }
 }

--- a/src/contract/contract_update_transaction.rs
+++ b/src/contract/contract_update_transaction.rs
@@ -26,6 +26,7 @@ use time::{
 };
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
 use crate::staked_id::StakedId;
 use crate::transaction::{
@@ -42,7 +43,6 @@ use crate::{
     ContractId,
     Error,
     Key,
-    LedgerId,
     ToProtobuf,
     Transaction,
     ValidateChecksums,
@@ -228,7 +228,7 @@ impl TransactionExecute for ContractUpdateTransactionData {
 }
 
 impl ValidateChecksums for ContractUpdateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.contract_id.validate_checksums(ledger_id)?;
         self.auto_renew_account_id.validate_checksums(ledger_id)?;
         self.staked_id.validate_checksums(ledger_id)?;

--- a/src/entity_id.rs
+++ b/src/entity_id.rs
@@ -56,13 +56,13 @@ impl FromStr for Checksum {
 
 impl Display for Checksum {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Display::fmt(&self.0, f)
+        f.write_str(self.0.as_str())
     }
 }
 
 impl Debug for Checksum {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "\"{self}\"")
+        write!(f, "\"{}\"", self.0.as_str())
     }
 }
 

--- a/src/entity_id.rs
+++ b/src/entity_id.rs
@@ -29,10 +29,10 @@ use std::str::FromStr;
 use tinystr::TinyAsciiStr;
 
 use crate::ethereum::IdEvmAddress;
+use crate::ledger_id::RefLedgerId;
 use crate::{
     Client,
     Error,
-    LedgerId,
 };
 
 #[derive(Hash, PartialEq, Eq, Clone, Copy)]
@@ -71,11 +71,11 @@ pub trait ValidateChecksums {
     ///
     /// # Errors
     /// - [`Error::BadEntityId`] if any of the expected checksums don't match the actual checksums.
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> crate::Result<()>;
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> crate::Result<()>;
 }
 
 impl<T: ValidateChecksums> ValidateChecksums for Option<T> {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> crate::Result<()> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> crate::Result<()> {
         if let Some(id) = &self {
             id.validate_checksums(ledger_id)?;
         }
@@ -175,13 +175,13 @@ impl EntityId {
         IdEvmAddress::try_from(self).map(|it| it.to_string())
     }
 
-    pub(crate) fn generate_checksum(entity_id_string: &str, ledger_id: &LedgerId) -> Checksum {
+    pub(crate) fn generate_checksum(entity_id_string: &str, ledger_id: &RefLedgerId) -> Checksum {
         const P3: usize = 26 * 26 * 26; // 3 digits in base 26
         const P5: usize = 26 * 26 * 26 * 26 * 26; // 5 digits in base 26
         const M: usize = 1_000_003; // min prime greater than a million. Used for the final permutation.
         const W: usize = 31; // Sum s of digit values weights them by powers of W. Should be coprime to P5.
 
-        let h = [ledger_id.to_bytes(), vec![0u8; 6]].concat();
+        let h = [ledger_id.as_bytes().to_vec(), vec![0u8; 6]].concat();
 
         // Digits with 10 for ".", so if addr == "0.0.123" then d == [0, 10, 0, 10, 1, 2, 3]
         let d = entity_id_string.chars().map(|c| {
@@ -243,7 +243,13 @@ impl EntityId {
             .as_deref()
             .expect("Client had no ledger ID (help: call `client.set_ledger_id()`");
 
-        Self::validate_checksum_internal(shard, realm, num, present_checksum, ledger_id)
+        Self::validate_checksum_internal(
+            shard,
+            realm,
+            num,
+            present_checksum,
+            ledger_id.as_ref_ledger_id(),
+        )
     }
 
     pub(crate) fn validate_checksum_for_ledger_id(
@@ -251,7 +257,7 @@ impl EntityId {
         realm: u64,
         num: u64,
         checksum: Option<Checksum>,
-        ledger_id: &LedgerId,
+        ledger_id: &RefLedgerId,
     ) -> Result<(), Error> {
         if let Some(present_checksum) = checksum {
             Self::validate_checksum_internal(shard, realm, num, present_checksum, ledger_id)
@@ -265,7 +271,7 @@ impl EntityId {
         realm: u64,
         num: u64,
         present_checksum: Checksum,
-        ledger_id: &LedgerId,
+        ledger_id: &RefLedgerId,
     ) -> Result<(), Error> {
         let expected_checksum =
             Self::generate_checksum(&format!("{shard}.{realm}.{num}"), ledger_id);
@@ -282,7 +288,7 @@ impl EntityId {
             .as_ref()
             .expect("Client had no ledger ID (help: call `client.set_ledger_id()`");
 
-        let checksum = Self::generate_checksum(&entity_id_string, ledger_id);
+        let checksum = Self::generate_checksum(&entity_id_string, ledger_id.as_ref_ledger_id());
         entity_id_string.push('-');
         entity_id_string.push_str(&checksum.0);
 
@@ -318,9 +324,9 @@ impl FromStr for EntityId {
 
 #[cfg(test)]
 mod tests {
+    use crate::ledger_id::RefLedgerId;
     use crate::{
         EntityId,
-        LedgerId,
         TopicId,
     };
 
@@ -385,7 +391,7 @@ mod tests {
         for (index, expected) in EXPECTED.iter().enumerate() {
             let actual = EntityId::generate_checksum(
                 &TopicId::from(index as u64).to_string(),
-                &LedgerId::mainnet(),
+                &RefLedgerId::MAINNET,
             )
             .to_string();
 
@@ -430,7 +436,7 @@ mod tests {
         for (index, expected) in EXPECTED.iter().enumerate() {
             let actual = EntityId::generate_checksum(
                 &TopicId::from(index as u64).to_string(),
-                &LedgerId::testnet(),
+                RefLedgerId::TESTNET,
             )
             .to_string();
 

--- a/src/ethereum/ethereum_transaction.rs
+++ b/src/ethereum/ethereum_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
 use crate::transaction::{
     AnyTransactionData,
@@ -35,7 +36,6 @@ use crate::{
     Error,
     FileId,
     Hbar,
-    LedgerId,
     ToProtobuf,
     Transaction,
     ValidateChecksums,
@@ -122,7 +122,7 @@ impl TransactionExecute for EthereumTransactionData {
 }
 
 impl ValidateChecksums for EthereumTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.call_data_file_id.validate_checksums(ledger_id)
     }
 }

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -55,7 +55,7 @@ pub(crate) trait Execute: ValidateChecksums {
 
     /// Account ID to be used for generating transaction IDs.
     ///
-    /// THis is only used `self.requires_transaction` and `self.transaction_id.is_none()`.
+    /// This is only used `self.requires_transaction` and `self.transaction_id.is_none()`.
     fn operator_account_id(&self) -> Option<&AccountId>;
 
     /// Get the _explicit_ nodes that this request will be submitted to.
@@ -159,7 +159,7 @@ where
     let explicit_transaction_id = executable.transaction_id();
     let mut transaction_id = executable
         .requires_transaction_id()
-        .then(|| explicit_transaction_id)
+        .then_some(explicit_transaction_id)
         .flatten()
         .or_else(|| executable.operator_account_id().copied().map(TransactionId::generate))
         .or_else(|| client.generate_transaction_id());

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -149,7 +149,7 @@ where
             .as_ref()
             .expect("Client had auto_validate_checksums enabled but no ledger ID");
 
-        executable.validate_checksums(ledger_id)?;
+        executable.validate_checksums(ledger_id.as_ref_ledger_id())?;
     }
 
     // TODO: cache requests to avoid signing a new request for every node in a delayed back-off

--- a/src/file/file_append_transaction.rs
+++ b/src/file/file_append_transaction.rs
@@ -25,6 +25,7 @@ use hedera_proto::services;
 use hedera_proto::services::file_service_client::FileServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -44,7 +45,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     FileId,
-    LedgerId,
     Transaction,
     ValidateChecksums,
 };
@@ -119,7 +119,7 @@ impl TransactionExecute for FileAppendTransactionData {
 impl TransactionExecuteChunked for FileAppendTransactionData {}
 
 impl ValidateChecksums for FileAppendTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.file_id.validate_checksums(ledger_id)
     }
 }

--- a/src/file/file_contents_query.rs
+++ b/src/file/file_contents_query.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::file_service_client::FileServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     Query,
@@ -33,7 +34,6 @@ use crate::{
     Error,
     FileContentsResponse,
     FileId,
-    LedgerId,
     ToProtobuf,
     ValidateChecksums,
 };
@@ -92,7 +92,7 @@ impl QueryExecute for FileContentsQueryData {
 }
 
 impl ValidateChecksums for FileContentsQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.file_id.validate_checksums(ledger_id)
     }
 }

--- a/src/file/file_create_transaction.rs
+++ b/src/file/file_create_transaction.rs
@@ -27,6 +27,7 @@ use time::{
 use tonic::transport::Channel;
 
 use crate::entity_id::ValidateChecksums;
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -44,7 +45,6 @@ use crate::{
     BoxGrpcFuture,
     Key,
     KeyList,
-    LedgerId,
     Transaction,
 };
 
@@ -191,7 +191,7 @@ impl TransactionExecute for FileCreateTransactionData {
 }
 
 impl ValidateChecksums for FileCreateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> crate::Result<()> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> crate::Result<()> {
         self.auto_renew_account_id.validate_checksums(ledger_id)?;
 
         Ok(())

--- a/src/file/file_delete_transaction.rs
+++ b/src/file/file_delete_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::file_service_client::FileServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -38,7 +39,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     FileId,
-    LedgerId,
     Transaction,
     ValidateChecksums,
 };
@@ -84,7 +84,7 @@ impl TransactionExecute for FileDeleteTransactionData {
 }
 
 impl ValidateChecksums for FileDeleteTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.file_id.validate_checksums(ledger_id)
     }
 }

--- a/src/file/file_id.rs
+++ b/src/file/file_id.rs
@@ -32,12 +32,12 @@ use crate::entity_id::{
     Checksum,
     ValidateChecksums,
 };
+use crate::ledger_id::RefLedgerId;
 use crate::{
     Client,
     EntityId,
     Error,
     FromProtobuf,
-    LedgerId,
     ToProtobuf,
 };
 
@@ -121,7 +121,7 @@ impl FileId {
 }
 
 impl ValidateChecksums for FileId {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         EntityId::validate_checksum_for_ledger_id(
             self.shard,
             self.realm,

--- a/src/file/file_info_query.rs
+++ b/src/file/file_info_query.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::file_service_client::FileServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     QueryExecute,
@@ -32,7 +33,6 @@ use crate::{
     Error,
     FileId,
     FileInfo,
-    LedgerId,
     Query,
     ToProtobuf,
     ValidateChecksums,
@@ -93,7 +93,7 @@ impl QueryExecute for FileInfoQueryData {
 }
 
 impl ValidateChecksums for FileInfoQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.file_id.validate_checksums(ledger_id)
     }
 }

--- a/src/file/file_update_transaction.rs
+++ b/src/file/file_update_transaction.rs
@@ -26,6 +26,7 @@ use time::{
 };
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -45,7 +46,6 @@ use crate::{
     FileId,
     Key,
     KeyList,
-    LedgerId,
     Transaction,
     ValidateChecksums,
 };
@@ -198,7 +198,7 @@ impl TransactionExecute for FileUpdateTransactionData {
 }
 
 impl ValidateChecksums for FileUpdateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.file_id.validate_checksums(ledger_id)
     }
 }

--- a/src/key/private_key/mod.rs
+++ b/src/key/private_key/mod.rs
@@ -28,7 +28,7 @@ use std::fmt::{
     Formatter,
 };
 use std::str::FromStr;
-use std::sync::Arc;
+use triomphe::Arc;
 
 use ed25519_dalek::Signer;
 use hmac::{

--- a/src/key/private_key/mod.rs
+++ b/src/key/private_key/mod.rs
@@ -28,7 +28,6 @@ use std::fmt::{
     Formatter,
 };
 use std::str::FromStr;
-use triomphe::Arc;
 
 use ed25519_dalek::Signer;
 use hmac::{
@@ -43,6 +42,7 @@ use pkcs8::der::{
 };
 use sha2::Sha512;
 use sha3::Digest;
+use triomphe::Arc;
 
 use crate::signer::AnySigner;
 use crate::{

--- a/src/key/private_key/tests.rs
+++ b/src/key/private_key/tests.rs
@@ -1,12 +1,15 @@
 use std::str::FromStr;
-use triomphe::Arc;
 
 use assert_matches::assert_matches;
 use expect_test::expect;
 use hex_literal::hex;
+use triomphe::Arc;
 
 use super::PrivateKey;
-use crate::key::private_key::{ED25519_OID, K256_OID};
+use crate::key::private_key::{
+    ED25519_OID,
+    K256_OID,
+};
 use crate::Error;
 
 #[test]

--- a/src/key/private_key/tests.rs
+++ b/src/key/private_key/tests.rs
@@ -1,18 +1,12 @@
 use std::str::FromStr;
-use std::sync::Arc;
+use triomphe::Arc;
 
 use assert_matches::assert_matches;
 use expect_test::expect;
 use hex_literal::hex;
 
-use super::{
-    PrivateKey,
-    PrivateKeyDataWrapper,
-};
-use crate::key::private_key::{
-    ED25519_OID,
-    K256_OID,
-};
+use super::PrivateKey;
+use crate::key::private_key::{ED25519_OID, K256_OID};
 use crate::Error;
 
 #[test]
@@ -101,14 +95,12 @@ fn ed25519_legacy_derive_2() {
 /// # Panics
 /// If `data` and `chain_code` don't make a valid [`PrivateKey`].
 fn key_with_chain(data: &str, chain_code: [u8; 32]) -> PrivateKey {
-    let key_without_chain = PrivateKey::from_str(data).unwrap();
+    let mut key = PrivateKey::from_str(data).unwrap();
 
-    let data = match Arc::try_unwrap(key_without_chain.0) {
-        Ok(it) => it.data,
-        Err(_) => unreachable!(),
-    };
+    // note: we create the key here, so, there shouldn't be any other references to it.
+    Arc::get_mut(&mut key.0).unwrap().chain_code = Some(chain_code);
 
-    PrivateKey(Arc::new(PrivateKeyDataWrapper::new_derivable(data, chain_code)))
+    key
 }
 
 // "iosKey"

--- a/src/key/public_key/mod.rs
+++ b/src/key/public_key/mod.rs
@@ -359,8 +359,6 @@ impl PublicKey {
                 key.verify(msg, &signature).map_err(Error::signature_verify)
             }
             PublicKeyData::Ecdsa(key) => {
-                // todo: see above comment on ed25519 signatures
-
                 let signature =
                     ecdsa::Signature::try_from(signature).map_err(Error::signature_verify)?;
 

--- a/src/ledger_id.rs
+++ b/src/ledger_id.rs
@@ -15,13 +15,10 @@ use crate::Error;
 ///
 /// It also allows for const constructable `LedgerId`s.
 ///
-/// todo: actually use this everywhere
-/// (it'd be a big refactor for the middle of the current PR)
-///
 /// Internal API, don't publically expose.
 #[repr(transparent)]
 #[derive(Eq, PartialEq)]
-pub(crate) struct RefLedgerId([u8]);
+pub struct RefLedgerId([u8]);
 
 impl RefLedgerId {
     pub(crate) const MAINNET: &Self = Self::new(&[0]);
@@ -57,10 +54,6 @@ impl ToOwned for RefLedgerId {
     }
 }
 
-// todo: use `Box<[u8]>` (16 bytes on cpus with 64 bit pointers)
-// or use an enum of `Mainnet`, `Testnet`, `Previewnet`, `Other`, and `Static`, don't expose the enum though.
-// `Other` would be `Box<[u8]>`, but nothing else would have an alloc, the whole struct would be 24 bytes on x86-64,
-// wouldn't allocate 99.99% of the time, and could be const constructable in 99.999% of cases.
 /// The ID of a Hedera Ledger.
 #[derive(Eq, PartialEq)]
 pub struct LedgerId(Box<RefLedgerId>);
@@ -112,6 +105,11 @@ impl LedgerId {
     #[must_use]
     pub fn is_known_network(&self) -> bool {
         self.is_mainnet() || self.is_previewnet() || self.is_testnet()
+    }
+
+    #[must_use]
+    pub(crate) fn as_ref_ledger_id(&self) -> &RefLedgerId {
+        &self.0
     }
 
     // todo: remove so that we can have `LedgerId` be an enum internally?

--- a/src/ledger_id.rs
+++ b/src/ledger_id.rs
@@ -9,6 +9,12 @@ use std::str::FromStr;
 
 use crate::Error;
 
+enum KnownKind {
+    Mainnet,
+    Testnet,
+    Previewnet,
+}
+
 /// DST that's semantically a [`LedgerId`].
 ///
 /// `&Self` saves a pointer indirection vs `&LedgerId` because `LedgerId` is a `Box<[u8]>`, so `&LedgerId` is a `&Box<[u8]>`.
@@ -35,6 +41,18 @@ impl RefLedgerId {
         unsafe { Box::from_raw(Box::into_raw(data) as *mut RefLedgerId) }
     }
 
+    const fn kind(&self) -> Option<KnownKind> {
+        const MAINNET_BYTES: &[u8] = RefLedgerId::MAINNET.as_bytes();
+        const TESTNET_BYTES: &[u8] = RefLedgerId::TESTNET.as_bytes();
+        const PREVIEWNET_BYTES: &[u8] = RefLedgerId::PREVIEWNET.as_bytes();
+        match self.as_bytes() {
+            MAINNET_BYTES => Some(KnownKind::Mainnet),
+            TESTNET_BYTES => Some(KnownKind::Testnet),
+            PREVIEWNET_BYTES => Some(KnownKind::Previewnet),
+            _ => None,
+        }
+    }
+
     pub const fn as_bytes(&self) -> &[u8] {
         &self.0
     }
@@ -59,6 +77,11 @@ impl ToOwned for RefLedgerId {
 pub struct LedgerId(Box<RefLedgerId>);
 
 impl LedgerId {
+    #[must_use]
+    const fn kind(&self) -> Option<KnownKind> {
+        self.0.kind()
+    }
+
     /// ID for the `mainnet` ledger.
     #[must_use]
     pub fn mainnet() -> Self {
@@ -86,25 +109,25 @@ impl LedgerId {
     /// Returns `true` if `self` is `mainnet`.
     #[must_use]
     pub fn is_mainnet(&self) -> bool {
-        self.as_ref() == RefLedgerId::MAINNET
+        matches!(self.kind(), Some(KnownKind::Mainnet))
     }
 
     /// Returns `true` if `self` is `testnet`.
     #[must_use]
     pub fn is_testnet(&self) -> bool {
-        self.as_ref() == RefLedgerId::TESTNET
+        matches!(self.kind(), Some(KnownKind::Testnet))
     }
 
     /// Returns `true` if `self` is `previewnet`.
     #[must_use]
     pub fn is_previewnet(&self) -> bool {
-        self.as_ref() == RefLedgerId::PREVIEWNET
+        matches!(self.kind(), Some(KnownKind::Previewnet))
     }
 
     /// Returns `true` if `self` is `mainnet`, `testnet`, or `previewnet`.
     #[must_use]
     pub fn is_known_network(&self) -> bool {
-        self.is_mainnet() || self.is_previewnet() || self.is_testnet()
+        matches!(self.kind(), Some(_))
     }
 
     #[must_use]
@@ -153,14 +176,14 @@ impl Debug for LedgerId {
 
 impl Display for LedgerId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        if self.is_mainnet() {
-            f.write_str("mainnet")
-        } else if self.is_testnet() {
-            f.write_str("testnet")
-        } else if self.is_previewnet() {
-            f.write_str("previewnet")
-        } else {
-            f.write_str(&hex::encode(self.as_bytes()))
+        match self.kind() {
+            Some(it) => f.write_str(match it {
+                KnownKind::Mainnet => "mainnet",
+                KnownKind::Testnet => "testnet",
+                KnownKind::Previewnet => "previewnet",
+            }),
+
+            None => f.write_str(&hex::encode(self.as_bytes())),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,6 @@
     clippy::zero_sized_map_values
 )]
 #![allow(clippy::enum_glob_use, clippy::enum_variant_names)]
-
 #[macro_use]
 mod protobuf;
 
@@ -166,49 +165,23 @@ mod transfer;
 mod transfer_transaction;
 
 pub use account::{
-    account_info_flow,
-    AccountAllowanceApproveTransaction,
-    AccountAllowanceDeleteTransaction,
-    AccountBalance,
-    AccountBalanceQuery,
-    AccountCreateTransaction,
-    AccountDeleteTransaction,
-    AccountId,
-    AccountInfo,
-    AccountInfoQuery,
-    AccountRecordsQuery,
-    AccountStakersQuery,
-    AccountUpdateTransaction,
-    AllProxyStakers,
-    ProxyStaker,
+    account_info_flow, AccountAllowanceApproveTransaction, AccountAllowanceDeleteTransaction,
+    AccountBalance, AccountBalanceQuery, AccountCreateTransaction, AccountDeleteTransaction,
+    AccountId, AccountInfo, AccountInfoQuery, AccountRecordsQuery, AccountStakersQuery,
+    AccountUpdateTransaction, AllProxyStakers, ProxyStaker,
 };
 pub use client::Client;
 pub(crate) use client::Operator;
 pub use contract::{
-    ContractBytecodeQuery,
-    ContractCallQuery,
-    ContractCreateFlow,
-    ContractCreateTransaction,
-    ContractExecuteTransaction,
-    ContractFunctionParameters,
-    ContractFunctionResult,
-    ContractId,
-    ContractInfo,
-    ContractInfoQuery,
-    ContractLogInfo,
-    ContractUpdateTransaction,
+    ContractBytecodeQuery, ContractCallQuery, ContractCreateFlow, ContractCreateTransaction,
+    ContractExecuteTransaction, ContractFunctionParameters, ContractFunctionResult, ContractId,
+    ContractInfo, ContractInfoQuery, ContractLogInfo, ContractUpdateTransaction,
 };
 pub use entity_id::EntityId;
 pub(crate) use entity_id::ValidateChecksums;
-pub use error::{
-    Error,
-    Result,
-};
+pub use error::{Error, Result};
 #[cfg(feature = "mnemonic")]
-pub use error::{
-    MnemonicEntropyError,
-    MnemonicParseError,
-};
+pub use error::{MnemonicEntropyError, MnemonicParseError};
 pub use ethereum::{
     // we probably *do* want to expose these, just, code review first?
     // EthereumData,
@@ -218,48 +191,20 @@ pub use ethereum::{
     EthereumTransaction,
     EvmAddress,
 };
-pub use exchange_rates::{
-    ExchangeRate,
-    ExchangeRates,
-};
+pub use exchange_rates::{ExchangeRate, ExchangeRates};
 pub use fee_schedules::{
-    FeeComponents,
-    FeeData,
-    FeeDataType,
-    FeeSchedule,
-    FeeSchedules,
-    RequestType,
+    FeeComponents, FeeData, FeeDataType, FeeSchedule, FeeSchedules, RequestType,
     TransactionFeeSchedule,
 };
 pub use file::{
-    FileAppendTransaction,
-    FileContentsQuery,
-    FileContentsResponse,
-    FileCreateTransaction,
-    FileDeleteTransaction,
-    FileId,
-    FileInfo,
-    FileInfoQuery,
-    FileUpdateTransaction,
+    FileAppendTransaction, FileContentsQuery, FileContentsResponse, FileCreateTransaction,
+    FileDeleteTransaction, FileId, FileInfo, FileInfoQuery, FileUpdateTransaction,
 };
-pub use hbar::{
-    Hbar,
-    HbarUnit,
-    Tinybar,
-};
+pub use hbar::{Hbar, HbarUnit, Tinybar};
 pub use hedera_proto::services::ResponseCodeEnum as Status;
-pub use key::{
-    Key,
-    KeyList,
-    PrivateKey,
-    PublicKey,
-};
+pub use key::{Key, KeyList, PrivateKey, PublicKey};
 pub use ledger_id::LedgerId;
-pub use mirror_query::{
-    AnyMirrorQuery,
-    AnyMirrorQueryResponse,
-    MirrorQuery,
-};
+pub use mirror_query::{AnyMirrorQuery, AnyMirrorQueryResponse, MirrorQuery};
 #[cfg(feature = "mnemonic")]
 pub use mnemonic::Mnemonic;
 pub use network_version_info::NetworkVersionInfo;
@@ -270,76 +215,32 @@ pub use node_address_book::NodeAddressBook;
 pub use node_address_book_query::NodeAddressBookQuery;
 pub(crate) use node_address_book_query::NodeAddressBookQueryData;
 pub use prng_transaction::PrngTransaction;
-pub(crate) use protobuf::{
-    FromProtobuf,
-    ToProtobuf,
-};
-pub use query::{
-    AnyQuery,
-    AnyQueryResponse,
-    Query,
-};
+pub(crate) use protobuf::{FromProtobuf, ToProtobuf};
+pub use query::{AnyQuery, AnyQueryResponse, Query};
 pub(crate) use retry::retry;
 pub use schedule::{
-    ScheduleCreateTransaction,
-    ScheduleDeleteTransaction,
-    ScheduleId,
-    ScheduleInfo,
-    ScheduleInfoQuery,
-    ScheduleSignTransaction,
+    ScheduleCreateTransaction, ScheduleDeleteTransaction, ScheduleId, ScheduleInfo,
+    ScheduleInfoQuery, ScheduleSignTransaction,
 };
 pub use semantic_version::SemanticVersion;
 pub use staking_info::StakingInfo;
 pub use system::{
-    FreezeTransaction,
-    FreezeType,
-    SystemDeleteTransaction,
-    SystemUndeleteTransaction,
+    FreezeTransaction, FreezeType, SystemDeleteTransaction, SystemUndeleteTransaction,
 };
 pub use token::{
-    AssessedCustomFee,
-    FeeAssessmentMethod,
-    NftId,
-    TokenAssociateTransaction,
-    TokenAssociation,
-    TokenBurnTransaction,
-    TokenCreateTransaction,
-    TokenDeleteTransaction,
-    TokenDissociateTransaction,
-    TokenFeeScheduleUpdateTransaction,
-    TokenFreezeTransaction,
-    TokenGrantKycTransaction,
-    TokenId,
-    TokenInfo,
-    TokenInfoQuery,
-    TokenMintTransaction,
-    TokenNftInfo,
-    TokenNftInfoQuery,
-    TokenNftTransfer,
-    TokenPauseTransaction,
-    TokenRevokeKycTransaction,
-    TokenSupplyType,
-    TokenType,
-    TokenUnfreezeTransaction,
-    TokenUnpauseTransaction,
-    TokenUpdateTransaction,
-    TokenWipeTransaction,
+    AssessedCustomFee, FeeAssessmentMethod, NftId, TokenAssociateTransaction, TokenAssociation,
+    TokenBurnTransaction, TokenCreateTransaction, TokenDeleteTransaction,
+    TokenDissociateTransaction, TokenFeeScheduleUpdateTransaction, TokenFreezeTransaction,
+    TokenGrantKycTransaction, TokenId, TokenInfo, TokenInfoQuery, TokenMintTransaction,
+    TokenNftInfo, TokenNftInfoQuery, TokenNftTransfer, TokenPauseTransaction,
+    TokenRevokeKycTransaction, TokenSupplyType, TokenType, TokenUnfreezeTransaction,
+    TokenUnpauseTransaction, TokenUpdateTransaction, TokenWipeTransaction,
 };
 pub use topic::{
-    TopicCreateTransaction,
-    TopicDeleteTransaction,
-    TopicId,
-    TopicInfo,
-    TopicInfoQuery,
-    TopicMessage,
-    TopicMessageQuery,
-    TopicMessageSubmitTransaction,
-    TopicUpdateTransaction,
+    TopicCreateTransaction, TopicDeleteTransaction, TopicId, TopicInfo, TopicInfoQuery,
+    TopicMessage, TopicMessageQuery, TopicMessageSubmitTransaction, TopicUpdateTransaction,
 };
-pub use transaction::{
-    AnyTransaction,
-    Transaction,
-};
+pub use transaction::{AnyTransaction, Transaction};
 pub use transaction_hash::TransactionHash;
 pub use transaction_id::TransactionId;
 pub use transaction_receipt::TransactionReceipt;
@@ -350,6 +251,9 @@ pub(crate) use transaction_record_query::TransactionRecordQueryData;
 pub use transaction_response::TransactionResponse;
 pub use transfer::Transfer;
 pub use transfer_transaction::TransferTransaction;
+
+/// Like [`arc_swap::ArcSwapOption`] but with a [`triomphe::Arc`].
+pub(crate) type ArcSwapOption<T> = arc_swap::ArcSwapAny<Option<triomphe::Arc<T>>>;
 
 /// Boxed future for GRPC calls.
 pub(crate) type BoxGrpcFuture<'a, T> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,23 +165,49 @@ mod transfer;
 mod transfer_transaction;
 
 pub use account::{
-    account_info_flow, AccountAllowanceApproveTransaction, AccountAllowanceDeleteTransaction,
-    AccountBalance, AccountBalanceQuery, AccountCreateTransaction, AccountDeleteTransaction,
-    AccountId, AccountInfo, AccountInfoQuery, AccountRecordsQuery, AccountStakersQuery,
-    AccountUpdateTransaction, AllProxyStakers, ProxyStaker,
+    account_info_flow,
+    AccountAllowanceApproveTransaction,
+    AccountAllowanceDeleteTransaction,
+    AccountBalance,
+    AccountBalanceQuery,
+    AccountCreateTransaction,
+    AccountDeleteTransaction,
+    AccountId,
+    AccountInfo,
+    AccountInfoQuery,
+    AccountRecordsQuery,
+    AccountStakersQuery,
+    AccountUpdateTransaction,
+    AllProxyStakers,
+    ProxyStaker,
 };
 pub use client::Client;
 pub(crate) use client::Operator;
 pub use contract::{
-    ContractBytecodeQuery, ContractCallQuery, ContractCreateFlow, ContractCreateTransaction,
-    ContractExecuteTransaction, ContractFunctionParameters, ContractFunctionResult, ContractId,
-    ContractInfo, ContractInfoQuery, ContractLogInfo, ContractUpdateTransaction,
+    ContractBytecodeQuery,
+    ContractCallQuery,
+    ContractCreateFlow,
+    ContractCreateTransaction,
+    ContractExecuteTransaction,
+    ContractFunctionParameters,
+    ContractFunctionResult,
+    ContractId,
+    ContractInfo,
+    ContractInfoQuery,
+    ContractLogInfo,
+    ContractUpdateTransaction,
 };
 pub use entity_id::EntityId;
 pub(crate) use entity_id::ValidateChecksums;
-pub use error::{Error, Result};
+pub use error::{
+    Error,
+    Result,
+};
 #[cfg(feature = "mnemonic")]
-pub use error::{MnemonicEntropyError, MnemonicParseError};
+pub use error::{
+    MnemonicEntropyError,
+    MnemonicParseError,
+};
 pub use ethereum::{
     // we probably *do* want to expose these, just, code review first?
     // EthereumData,
@@ -191,20 +217,48 @@ pub use ethereum::{
     EthereumTransaction,
     EvmAddress,
 };
-pub use exchange_rates::{ExchangeRate, ExchangeRates};
+pub use exchange_rates::{
+    ExchangeRate,
+    ExchangeRates,
+};
 pub use fee_schedules::{
-    FeeComponents, FeeData, FeeDataType, FeeSchedule, FeeSchedules, RequestType,
+    FeeComponents,
+    FeeData,
+    FeeDataType,
+    FeeSchedule,
+    FeeSchedules,
+    RequestType,
     TransactionFeeSchedule,
 };
 pub use file::{
-    FileAppendTransaction, FileContentsQuery, FileContentsResponse, FileCreateTransaction,
-    FileDeleteTransaction, FileId, FileInfo, FileInfoQuery, FileUpdateTransaction,
+    FileAppendTransaction,
+    FileContentsQuery,
+    FileContentsResponse,
+    FileCreateTransaction,
+    FileDeleteTransaction,
+    FileId,
+    FileInfo,
+    FileInfoQuery,
+    FileUpdateTransaction,
 };
-pub use hbar::{Hbar, HbarUnit, Tinybar};
+pub use hbar::{
+    Hbar,
+    HbarUnit,
+    Tinybar,
+};
 pub use hedera_proto::services::ResponseCodeEnum as Status;
-pub use key::{Key, KeyList, PrivateKey, PublicKey};
+pub use key::{
+    Key,
+    KeyList,
+    PrivateKey,
+    PublicKey,
+};
 pub use ledger_id::LedgerId;
-pub use mirror_query::{AnyMirrorQuery, AnyMirrorQueryResponse, MirrorQuery};
+pub use mirror_query::{
+    AnyMirrorQuery,
+    AnyMirrorQueryResponse,
+    MirrorQuery,
+};
 #[cfg(feature = "mnemonic")]
 pub use mnemonic::Mnemonic;
 pub use network_version_info::NetworkVersionInfo;
@@ -215,32 +269,76 @@ pub use node_address_book::NodeAddressBook;
 pub use node_address_book_query::NodeAddressBookQuery;
 pub(crate) use node_address_book_query::NodeAddressBookQueryData;
 pub use prng_transaction::PrngTransaction;
-pub(crate) use protobuf::{FromProtobuf, ToProtobuf};
-pub use query::{AnyQuery, AnyQueryResponse, Query};
+pub(crate) use protobuf::{
+    FromProtobuf,
+    ToProtobuf,
+};
+pub use query::{
+    AnyQuery,
+    AnyQueryResponse,
+    Query,
+};
 pub(crate) use retry::retry;
 pub use schedule::{
-    ScheduleCreateTransaction, ScheduleDeleteTransaction, ScheduleId, ScheduleInfo,
-    ScheduleInfoQuery, ScheduleSignTransaction,
+    ScheduleCreateTransaction,
+    ScheduleDeleteTransaction,
+    ScheduleId,
+    ScheduleInfo,
+    ScheduleInfoQuery,
+    ScheduleSignTransaction,
 };
 pub use semantic_version::SemanticVersion;
 pub use staking_info::StakingInfo;
 pub use system::{
-    FreezeTransaction, FreezeType, SystemDeleteTransaction, SystemUndeleteTransaction,
+    FreezeTransaction,
+    FreezeType,
+    SystemDeleteTransaction,
+    SystemUndeleteTransaction,
 };
 pub use token::{
-    AssessedCustomFee, FeeAssessmentMethod, NftId, TokenAssociateTransaction, TokenAssociation,
-    TokenBurnTransaction, TokenCreateTransaction, TokenDeleteTransaction,
-    TokenDissociateTransaction, TokenFeeScheduleUpdateTransaction, TokenFreezeTransaction,
-    TokenGrantKycTransaction, TokenId, TokenInfo, TokenInfoQuery, TokenMintTransaction,
-    TokenNftInfo, TokenNftInfoQuery, TokenNftTransfer, TokenPauseTransaction,
-    TokenRevokeKycTransaction, TokenSupplyType, TokenType, TokenUnfreezeTransaction,
-    TokenUnpauseTransaction, TokenUpdateTransaction, TokenWipeTransaction,
+    AssessedCustomFee,
+    FeeAssessmentMethod,
+    NftId,
+    TokenAssociateTransaction,
+    TokenAssociation,
+    TokenBurnTransaction,
+    TokenCreateTransaction,
+    TokenDeleteTransaction,
+    TokenDissociateTransaction,
+    TokenFeeScheduleUpdateTransaction,
+    TokenFreezeTransaction,
+    TokenGrantKycTransaction,
+    TokenId,
+    TokenInfo,
+    TokenInfoQuery,
+    TokenMintTransaction,
+    TokenNftInfo,
+    TokenNftInfoQuery,
+    TokenNftTransfer,
+    TokenPauseTransaction,
+    TokenRevokeKycTransaction,
+    TokenSupplyType,
+    TokenType,
+    TokenUnfreezeTransaction,
+    TokenUnpauseTransaction,
+    TokenUpdateTransaction,
+    TokenWipeTransaction,
 };
 pub use topic::{
-    TopicCreateTransaction, TopicDeleteTransaction, TopicId, TopicInfo, TopicInfoQuery,
-    TopicMessage, TopicMessageQuery, TopicMessageSubmitTransaction, TopicUpdateTransaction,
+    TopicCreateTransaction,
+    TopicDeleteTransaction,
+    TopicId,
+    TopicInfo,
+    TopicInfoQuery,
+    TopicMessage,
+    TopicMessageQuery,
+    TopicMessageSubmitTransaction,
+    TopicUpdateTransaction,
 };
-pub use transaction::{AnyTransaction, Transaction};
+pub use transaction::{
+    AnyTransaction,
+    Transaction,
+};
 pub use transaction_hash::TransactionHash;
 pub use transaction_id::TransactionId;
 pub use transaction_receipt::TransactionReceipt;

--- a/src/mirror_query/subscribe.rs
+++ b/src/mirror_query/subscribe.rs
@@ -29,11 +29,7 @@ use tonic::transport::Channel;
 use tonic::Status;
 
 use crate::mirror_query::AnyMirrorQueryData;
-use crate::{
-    Client,
-    Error,
-    MirrorQuery,
-};
+use crate::{Client, Error, MirrorQuery};
 
 impl<D> MirrorQuery<D>
 where
@@ -207,10 +203,12 @@ pub(crate) fn subscribe<I: Send, R: MirrorRequest<GrpcItem = I> + Send + Sync>(
             max_elapsed_time: Some(timeout),
             ..ExponentialBackoff::default()
         };
-        let mut backoff_inf = ExponentialBackoff::default();
 
-        // remove maximum elapsed time for # of back-offs on inf.
-        backoff_inf.max_elapsed_time = None;
+        let mut backoff_inf = ExponentialBackoff {
+            max_elapsed_time: None,
+            // remove maximum elapsed time for # of back-offs on inf.
+            .. ExponentialBackoff::default()
+        };
 
         let mut context = R::Context::default();
 

--- a/src/mirror_query/subscribe.rs
+++ b/src/mirror_query/subscribe.rs
@@ -29,7 +29,11 @@ use tonic::transport::Channel;
 use tonic::Status;
 
 use crate::mirror_query::AnyMirrorQueryData;
-use crate::{Client, Error, MirrorQuery};
+use crate::{
+    Client,
+    Error,
+    MirrorQuery,
+};
 
 impl<D> MirrorQuery<D>
 where

--- a/src/network_version_info_query.rs
+++ b/src/network_version_info_query.rs
@@ -18,8 +18,6 @@
  * ‍
  */
 
-use std::marker::PhantomData;
-
 use hedera_proto::services;
 use hedera_proto::services::network_service_client::NetworkServiceClient;
 use tonic::transport::Channel;
@@ -33,7 +31,6 @@ use crate::query::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     NetworkVersionInfo,
     Query,
 };
@@ -42,10 +39,8 @@ use crate::{
 pub type NetworkVersionInfoQuery = Query<NetworkVersionInfoQueryData>;
 
 #[derive(Default, Clone, Debug)]
-pub struct NetworkVersionInfoQueryData {
-    // make this not publicly constructable.
-    _phantom: PhantomData<()>,
-}
+#[non_exhaustive]
+pub struct NetworkVersionInfoQueryData {}
 
 impl From<NetworkVersionInfoQueryData> for AnyQueryData {
     #[inline]
@@ -81,7 +76,7 @@ impl QueryExecute for NetworkVersionInfoQueryData {
 }
 
 impl ValidateChecksums for NetworkVersionInfoQueryData {
-    fn validate_checksums(&self, _ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, _ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/ping_query.rs
+++ b/src/ping_query.rs
@@ -41,7 +41,10 @@ impl PingQuery {
 }
 
 impl ValidateChecksums for PingQuery {
-    fn validate_checksums(&self, ledger_id: &crate::LedgerId) -> Result<(), crate::Error> {
+    fn validate_checksums(
+        &self,
+        ledger_id: &crate::ledger_id::RefLedgerId,
+    ) -> Result<(), crate::Error> {
         self.node_account_id.validate_checksums(ledger_id)
     }
 }

--- a/src/prng_transaction.rs
+++ b/src/prng_transaction.rs
@@ -83,7 +83,7 @@ impl From<PrngTransactionData> for AnyTransactionData {
 }
 
 impl ValidateChecksums for PrngTransactionData {
-    fn validate_checksums(&self, _ledger_id: &crate::LedgerId) -> crate::Result<()> {
+    fn validate_checksums(&self, _ledger_id: &crate::ledger_id::RefLedgerId) -> crate::Result<()> {
         Ok(())
     }
 }

--- a/src/query/any.rs
+++ b/src/query/any.rs
@@ -38,6 +38,7 @@ use crate::file::{
     FileContentsQueryData,
     FileInfoQueryData,
 };
+use crate::ledger_id::RefLedgerId;
 use crate::query::QueryExecute;
 use crate::schedule::ScheduleInfoQueryData;
 use crate::token::{
@@ -58,7 +59,6 @@ use crate::{
     FileInfo,
     FromProtobuf,
     Hbar,
-    LedgerId,
     NetworkVersionInfo,
     NetworkVersionInfoQueryData,
     Query,
@@ -359,7 +359,7 @@ impl QueryExecute for AnyQueryData {
 }
 
 impl ValidateChecksums for AnyQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         match self {
             Self::AccountBalance(query) => query.validate_checksums(ledger_id),
             Self::AccountInfo(query) => query.validate_checksums(ledger_id),

--- a/src/query/cost.rs
+++ b/src/query/cost.rs
@@ -32,9 +32,7 @@ use crate::{
     AccountId,
     BoxGrpcFuture,
     Client,
-    Error,
     Hbar,
-    LedgerId,
     Query,
     Tinybar,
     TransactionId,
@@ -139,7 +137,7 @@ where
 }
 
 impl<'a, D: QueryExecute> ValidateChecksums for QueryCost<'a, D> {
-    fn validate_checksums(&self, _ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, _ledger_id: &crate::ledger_id::RefLedgerId) -> crate::Result<()> {
         Ok(())
     }
 }

--- a/src/query/execute.rs
+++ b/src/query/execute.rs
@@ -35,7 +35,6 @@ use crate::{
     Error,
     FromProtobuf,
     Hbar,
-    LedgerId,
     Query,
     Status,
     TransactionId,
@@ -182,7 +181,7 @@ where
 }
 
 impl<D: QueryExecute + ValidateChecksums> ValidateChecksums for Query<D> {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         self.data.validate_checksums(ledger_id)?;
         self.payment.validate_checksums(ledger_id)
     }

--- a/src/query/payment_transaction.rs
+++ b/src/query/payment_transaction.rs
@@ -33,7 +33,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     Hbar,
-    LedgerId,
     ToProtobuf,
     Transaction,
     ValidateChecksums,
@@ -81,7 +80,7 @@ impl TransactionExecute for PaymentTransactionData {
 }
 
 impl ValidateChecksums for PaymentTransactionData {
-    fn validate_checksums(&self, _ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, _ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/schedule/schedule_create_transaction.rs
+++ b/src/schedule/schedule_create_transaction.rs
@@ -41,7 +41,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     Key,
-    LedgerId,
     Transaction,
     ValidateChecksums,
 };
@@ -179,7 +178,7 @@ impl TransactionExecute for ScheduleCreateTransactionData {
 }
 
 impl ValidateChecksums for ScheduleCreateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         self.payer_account_id.validate_checksums(ledger_id)
     }
 }

--- a/src/schedule/schedule_delete_transaction.rs
+++ b/src/schedule/schedule_delete_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::schedule_service_client::ScheduleServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -37,7 +38,6 @@ use crate::transaction::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     ScheduleId,
     Transaction,
     ValidateChecksums,
@@ -79,7 +79,7 @@ impl TransactionExecute for ScheduleDeleteTransactionData {
 }
 
 impl ValidateChecksums for ScheduleDeleteTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.schedule_id.validate_checksums(ledger_id)
     }
 }

--- a/src/schedule/schedule_id.rs
+++ b/src/schedule/schedule_id.rs
@@ -32,12 +32,12 @@ use crate::entity_id::{
     Checksum,
     ValidateChecksums,
 };
+use crate::ledger_id::RefLedgerId;
 use crate::{
     Client,
     EntityId,
     Error,
     FromProtobuf,
-    LedgerId,
     ToProtobuf,
 };
 
@@ -109,7 +109,7 @@ impl ScheduleId {
 }
 
 impl ValidateChecksums for ScheduleId {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         EntityId::validate_checksum_for_ledger_id(
             self.shard,
             self.realm,

--- a/src/schedule/schedule_info_query.rs
+++ b/src/schedule/schedule_info_query.rs
@@ -30,7 +30,6 @@ use crate::query::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     Query,
     ScheduleId,
     ScheduleInfo,
@@ -93,7 +92,7 @@ impl QueryExecute for ScheduleInfoQueryData {
 }
 
 impl ValidateChecksums for ScheduleInfoQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         self.schedule_id.validate_checksums(ledger_id)
     }
 }

--- a/src/schedule/schedule_sign_transaction.rs
+++ b/src/schedule/schedule_sign_transaction.rs
@@ -36,7 +36,6 @@ use crate::transaction::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     ScheduleId,
     Transaction,
     ValidateChecksums,
@@ -77,7 +76,7 @@ impl TransactionExecute for ScheduleSignTransactionData {
 }
 
 impl ValidateChecksums for ScheduleSignTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         self.schedule_id.validate_checksums(ledger_id)
     }
 }

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -60,7 +60,7 @@ impl AnySigner {
 impl fmt::Debug for AnySigner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::PrivateKey(_) => f.debug_tuple("PrivateKey").field(&"[redacted]").finish(),
+            Self::PrivateKey(_) => f.debug_tuple("PrivateKey").field(&"..").finish(),
             Self::Arbitrary(arg0, _) => {
                 f.debug_tuple("Arbitrary").field(arg0).field(&"Fn").finish()
             }

--- a/src/staked_id.rs
+++ b/src/staked_id.rs
@@ -29,7 +29,10 @@ impl StakedId {
 }
 
 impl ValidateChecksums for StakedId {
-    fn validate_checksums(&self, ledger_id: &crate::LedgerId) -> Result<(), crate::Error> {
+    fn validate_checksums(
+        &self,
+        ledger_id: &crate::ledger_id::RefLedgerId,
+    ) -> Result<(), crate::Error> {
         self.to_account_id().validate_checksums(ledger_id)
     }
 }

--- a/src/system/freeze_transaction.rs
+++ b/src/system/freeze_transaction.rs
@@ -37,7 +37,6 @@ use crate::{
     Error,
     FileId,
     FreezeType,
-    LedgerId,
     ToProtobuf,
     Transaction,
     ValidateChecksums,
@@ -121,7 +120,7 @@ impl TransactionExecute for FreezeTransactionData {
 }
 
 impl ValidateChecksums for FreezeTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         self.file_id.validate_checksums(ledger_id)
     }
 }

--- a/src/system/system_delete_transaction.rs
+++ b/src/system/system_delete_transaction.rs
@@ -41,7 +41,6 @@ use crate::{
     ContractId,
     Error,
     FileId,
-    LedgerId,
     Transaction,
     ValidateChecksums,
 };
@@ -130,7 +129,7 @@ impl TransactionExecute for SystemDeleteTransactionData {
 }
 
 impl ValidateChecksums for SystemDeleteTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         self.file_id.validate_checksums(ledger_id)?;
         self.contract_id.validate_checksums(ledger_id)
     }

--- a/src/system/system_undelete_transaction.rs
+++ b/src/system/system_undelete_transaction.rs
@@ -40,7 +40,6 @@ use crate::{
     ContractId,
     Error,
     FileId,
-    LedgerId,
     Transaction,
     ValidateChecksums,
 };
@@ -104,7 +103,7 @@ impl TransactionExecute for SystemUndeleteTransactionData {
 }
 
 impl ValidateChecksums for SystemUndeleteTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         self.contract_id.validate_checksums(ledger_id)?;
         self.file_id.validate_checksums(ledger_id)
     }

--- a/src/token/nft_id.rs
+++ b/src/token/nft_id.rs
@@ -29,6 +29,7 @@ use std::str::FromStr;
 use hedera_proto::services;
 
 use crate::entity_id::ValidateChecksums;
+use crate::ledger_id::RefLedgerId;
 use crate::{
     Client,
     Error,
@@ -124,7 +125,7 @@ impl From<(TokenId, u64)> for NftId {
 }
 
 impl ValidateChecksums for NftId {
-    fn validate_checksums(&self, ledger_id: &crate::LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.token_id.validate_checksums(ledger_id)
     }
 }

--- a/src/token/token_associate_transaction.rs
+++ b/src/token/token_associate_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
 use crate::transaction::{
     AnyTransactionData,
@@ -35,7 +36,6 @@ use crate::{
     AccountId,
     BoxGrpcFuture,
     Error,
-    LedgerId,
     ToProtobuf,
     TokenId,
     Transaction,
@@ -105,7 +105,7 @@ impl TransactionExecute for TokenAssociateTransactionData {
 }
 
 impl ValidateChecksums for TokenAssociateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.account_id.validate_checksums(ledger_id)?;
         for token_id in &self.token_ids {
             token_id.validate_checksums(ledger_id)?;

--- a/src/token/token_burn_transaction.rs
+++ b/src/token/token_burn_transaction.rs
@@ -37,7 +37,6 @@ use crate::transaction::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -131,7 +130,7 @@ impl TransactionExecute for TokenBurnTransactionData {
 }
 
 impl ValidateChecksums for TokenBurnTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         self.token_id.validate_checksums(ledger_id)
     }
 }

--- a/src/token/token_create_transaction.rs
+++ b/src/token/token_create_transaction.rs
@@ -26,6 +26,7 @@ use time::{
 };
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -46,7 +47,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     Key,
-    LedgerId,
     Transaction,
     ValidateChecksums,
 };
@@ -458,7 +458,7 @@ impl TransactionExecute for TokenCreateTransactionData {
 }
 
 impl ValidateChecksums for TokenCreateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         // TODO: validate custom fees.
         self.treasury_account_id.validate_checksums(ledger_id)?;
         self.auto_renew_account_id.validate_checksums(ledger_id)

--- a/src/token/token_delete_transaction.rs
+++ b/src/token/token_delete_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -37,7 +38,6 @@ use crate::transaction::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -87,7 +87,7 @@ impl TransactionExecute for TokenDeleteTransactionData {
 }
 
 impl ValidateChecksums for TokenDeleteTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.token_id.validate_checksums(ledger_id)
     }
 }

--- a/src/token/token_dissociate_transaction.rs
+++ b/src/token/token_dissociate_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -38,7 +39,6 @@ use crate::{
     AccountId,
     BoxGrpcFuture,
     Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -111,7 +111,7 @@ impl TransactionExecute for TokenDissociateTransactionData {
 }
 
 impl ValidateChecksums for TokenDissociateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.account_id.validate_checksums(ledger_id)?;
         for token_id in &self.token_ids {
             token_id.validate_checksums(ledger_id)?;

--- a/src/token/token_fee_schedule_update_transaction.rs
+++ b/src/token/token_fee_schedule_update_transaction.rs
@@ -38,7 +38,6 @@ use crate::transaction::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -108,7 +107,7 @@ impl TransactionExecute for TokenFeeScheduleUpdateTransactionData {
 }
 
 impl ValidateChecksums for TokenFeeScheduleUpdateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         // TODO: validate custom fees (they need an impl)
         self.token_id.validate_checksums(ledger_id)
     }

--- a/src/token/token_freeze_transaction.rs
+++ b/src/token/token_freeze_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -38,7 +39,6 @@ use crate::{
     AccountId,
     BoxGrpcFuture,
     Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -106,7 +106,7 @@ impl TransactionExecute for TokenFreezeTransactionData {
 }
 
 impl ValidateChecksums for TokenFreezeTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.account_id.validate_checksums(ledger_id)?;
         self.token_id.validate_checksums(ledger_id)
     }

--- a/src/token/token_grant_kyc_transaction.rs
+++ b/src/token/token_grant_kyc_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -38,7 +39,6 @@ use crate::{
     AccountId,
     BoxGrpcFuture,
     Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -107,7 +107,7 @@ impl TransactionExecute for TokenGrantKycTransactionData {
 }
 
 impl ValidateChecksums for TokenGrantKycTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.account_id.validate_checksums(ledger_id)?;
         self.token_id.validate_checksums(ledger_id)
     }

--- a/src/token/token_id.rs
+++ b/src/token/token_id.rs
@@ -37,7 +37,6 @@ use crate::{
     EntityId,
     Error,
     FromProtobuf,
-    LedgerId,
     NftId,
     ToProtobuf,
 };
@@ -121,7 +120,7 @@ impl TokenId {
 }
 
 impl ValidateChecksums for TokenId {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         EntityId::validate_checksum_for_ledger_id(
             self.shard,
             self.realm,

--- a/src/token/token_info_query.rs
+++ b/src/token/token_info_query.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     QueryExecute,
@@ -31,7 +32,6 @@ use crate::token::token_info::TokenInfo;
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     Query,
     ToProtobuf,
     TokenId,
@@ -94,7 +94,7 @@ impl QueryExecute for TokenInfoQueryData {
 }
 
 impl ValidateChecksums for TokenInfoQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.token_id.validate_checksums(ledger_id)
     }
 }

--- a/src/token/token_mint_transaction.rs
+++ b/src/token/token_mint_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -37,7 +38,6 @@ use crate::transaction::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -131,7 +131,7 @@ impl TransactionExecute for TokenMintTransactionData {
 }
 
 impl ValidateChecksums for TokenMintTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.token_id.validate_checksums(ledger_id)
     }
 }

--- a/src/token/token_nft_info.rs
+++ b/src/token/token_nft_info.rs
@@ -30,7 +30,6 @@ use crate::{
     NftId,
 };
 
-// TODO pub ledger_id: LedgerId, --- also shows as todo in account_info.rs
 /// Response from [`TokenNftInfoQuery`][crate::TokenNftInfoQuery].
 
 #[derive(Debug, Clone)]

--- a/src/token/token_nft_info_query.rs
+++ b/src/token/token_nft_info_query.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     Query,
@@ -31,7 +32,6 @@ use crate::query::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     NftId,
     ToProtobuf,
     TokenNftInfo,
@@ -94,7 +94,7 @@ impl QueryExecute for TokenNftInfoQueryData {
 }
 
 impl ValidateChecksums for TokenNftInfoQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.nft_id.validate_checksums(ledger_id)
     }
 }

--- a/src/token/token_pause_transaction.rs
+++ b/src/token/token_pause_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -36,8 +37,6 @@ use crate::transaction::{
 };
 use crate::{
     BoxGrpcFuture,
-    Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -88,7 +87,7 @@ impl TransactionExecute for TokenPauseTransactionData {
 }
 
 impl ValidateChecksums for TokenPauseTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> crate::Result<()> {
         self.token_id.validate_checksums(ledger_id)
     }
 }

--- a/src/token/token_revoke_kyc_transaction.rs
+++ b/src/token/token_revoke_kyc_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -37,8 +38,6 @@ use crate::transaction::{
 use crate::{
     AccountId,
     BoxGrpcFuture,
-    Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -108,7 +107,7 @@ impl TransactionExecute for TokenRevokeKycTransactionData {
 }
 
 impl ValidateChecksums for TokenRevokeKycTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> crate::Result<()> {
         self.token_id.validate_checksums(ledger_id)?;
         self.account_id.validate_checksums(ledger_id)
     }

--- a/src/token/token_unfreeze_transaction.rs
+++ b/src/token/token_unfreeze_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -37,8 +38,6 @@ use crate::transaction::{
 use crate::{
     AccountId,
     BoxGrpcFuture,
-    Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -106,7 +105,7 @@ impl TransactionExecute for TokenUnfreezeTransactionData {
 }
 
 impl ValidateChecksums for TokenUnfreezeTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> crate::Result<()> {
         self.token_id.validate_checksums(ledger_id)?;
         self.account_id.validate_checksums(ledger_id)
     }

--- a/src/token/token_unpause_transaction.rs
+++ b/src/token/token_unpause_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -36,8 +37,6 @@ use crate::transaction::{
 };
 use crate::{
     BoxGrpcFuture,
-    Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -87,7 +86,7 @@ impl TransactionExecute for TokenUnpauseTransactionData {
 }
 
 impl ValidateChecksums for TokenUnpauseTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> crate::Result<()> {
         self.token_id.validate_checksums(ledger_id)
     }
 }

--- a/src/token/token_update_transaction.rs
+++ b/src/token/token_update_transaction.rs
@@ -26,6 +26,7 @@ use time::{
 };
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -43,7 +44,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     Key,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -350,7 +350,7 @@ impl TransactionExecute for TokenUpdateTransactionData {
 }
 
 impl ValidateChecksums for TokenUpdateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.token_id.validate_checksums(ledger_id)?;
         self.auto_renew_account_id.validate_checksums(ledger_id)?;
         self.treasury_account_id.validate_checksums(ledger_id)

--- a/src/token/token_wipe_transaction.rs
+++ b/src/token/token_wipe_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -38,7 +39,6 @@ use crate::{
     AccountId,
     BoxGrpcFuture,
     Error,
-    LedgerId,
     TokenId,
     Transaction,
     ValidateChecksums,
@@ -154,7 +154,7 @@ impl TransactionExecute for TokenWipeTransactionData {
 }
 
 impl ValidateChecksums for TokenWipeTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.account_id.validate_checksums(ledger_id)?;
         self.token_id.validate_checksums(ledger_id)
     }

--- a/src/topic/topic_create_transaction.rs
+++ b/src/topic/topic_create_transaction.rs
@@ -23,6 +23,7 @@ use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
 use time::Duration;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -40,7 +41,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     Key,
-    LedgerId,
     Transaction,
     ValidateChecksums,
 };
@@ -168,7 +168,7 @@ impl TransactionExecute for TopicCreateTransactionData {
 }
 
 impl ValidateChecksums for TopicCreateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.auto_renew_account_id.validate_checksums(ledger_id)
     }
 }

--- a/src/topic/topic_delete_transaction.rs
+++ b/src/topic/topic_delete_transaction.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -37,7 +38,6 @@ use crate::transaction::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     TopicId,
     Transaction,
     ValidateChecksums,
@@ -85,7 +85,7 @@ impl TransactionExecute for TopicDeleteTransactionData {
 }
 
 impl ValidateChecksums for TopicDeleteTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.topic_id.validate_checksums(ledger_id)
     }
 }

--- a/src/topic/topic_id.rs
+++ b/src/topic/topic_id.rs
@@ -37,7 +37,6 @@ use crate::{
     EntityId,
     Error,
     FromProtobuf,
-    LedgerId,
     ToProtobuf,
 };
 
@@ -109,7 +108,7 @@ impl TopicId {
 }
 
 impl ValidateChecksums for TopicId {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> Result<(), Error> {
         EntityId::validate_checksum_for_ledger_id(
             self.shard,
             self.realm,

--- a/src/topic/topic_info_query.rs
+++ b/src/topic/topic_info_query.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     QueryExecute,
@@ -30,7 +31,6 @@ use crate::query::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     Query,
     ToProtobuf,
     TopicId,
@@ -92,7 +92,7 @@ impl QueryExecute for TopicInfoQueryData {
 }
 
 impl ValidateChecksums for TopicInfoQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.topic_id.validate_checksums(ledger_id)
     }
 }

--- a/src/topic/topic_message_submit_transaction.rs
+++ b/src/topic/topic_message_submit_transaction.rs
@@ -25,6 +25,7 @@ use hedera_proto::services;
 use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -43,7 +44,6 @@ use crate::transaction::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     TopicId,
     Transaction,
     ValidateChecksums,
@@ -127,7 +127,7 @@ impl TransactionExecute for TopicMessageSubmitTransactionData {
 impl TransactionExecuteChunked for TopicMessageSubmitTransactionData {}
 
 impl ValidateChecksums for TopicMessageSubmitTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.topic_id.validate_checksums(ledger_id)
     }
 }

--- a/src/topic/topic_update_transaction.rs
+++ b/src/topic/topic_update_transaction.rs
@@ -26,6 +26,7 @@ use time::{
 };
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::{
     FromProtobuf,
     ToProtobuf,
@@ -43,7 +44,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     Key,
-    LedgerId,
     TopicId,
     Transaction,
     ValidateChecksums,
@@ -184,7 +184,7 @@ impl TransactionExecute for TopicUpdateTransactionData {
 }
 
 impl ValidateChecksums for TopicUpdateTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.topic_id.validate_checksums(ledger_id)?;
         self.auto_renew_account_id.validate_checksums(ledger_id)
     }

--- a/src/transaction/any.rs
+++ b/src/transaction/any.rs
@@ -28,6 +28,7 @@ use super::{
 };
 use crate::downcast::DowncastOwned;
 use crate::entity_id::ValidateChecksums;
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
 use crate::transaction::{
     ToTransactionDataProtobuf,
@@ -38,7 +39,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     Hbar,
-    LedgerId,
     Transaction,
     TransactionId,
 };
@@ -476,7 +476,7 @@ impl TransactionExecute for AnyTransactionData {
 impl TransactionExecuteChunked for AnyTransactionData {}
 
 impl ValidateChecksums for AnyTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         match self {
             Self::AccountCreate(transaction) => transaction.validate_checksums(ledger_id),
             Self::AccountUpdate(transaction) => transaction.validate_checksums(ledger_id),

--- a/src/transaction/chunked.rs
+++ b/src/transaction/chunked.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use crate::entity_id::ValidateChecksums;
 use crate::execute::Execute;
+use crate::ledger_id::RefLedgerId;
 use crate::{
     AccountId,
     BoxGrpcFuture,
@@ -215,7 +216,7 @@ where
 }
 
 impl<'a, D: ValidateChecksums> ValidateChecksums for FirstChunkView<'a, D> {
-    fn validate_checksums(&self, ledger_id: &crate::LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.transaction.validate_checksums(ledger_id)
     }
 }
@@ -319,7 +320,7 @@ where
 }
 
 impl<'a, D: ValidateChecksums> ValidateChecksums for ChunkView<'a, D> {
-    fn validate_checksums(&self, ledger_id: &crate::LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.transaction.validate_checksums(ledger_id)?;
         self.initial_transaction_id.validate_checksums(ledger_id)?;
 

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -417,7 +417,7 @@ impl<D: ValidateChecksums> Transaction<D> {
                     .as_ref()
                     .expect("Client had auto_validate_checksums enabled but no ledger ID");
 
-                self.validate_checksums(ledger_id)?;
+                self.validate_checksums(ledger_id.as_ref_ledger_id())?;
             }
         }
 
@@ -720,8 +720,9 @@ where
             .await?;
 
             if wait_for_receipts {
-                // todo `get_receipt_with_optional_timeout`.
-                resp.get_receipt(client).await?;
+                resp.get_receipt_query()
+                    .execute_with_optional_timeout(client, timeout_per_chunk)
+                    .await?;
             }
 
             let initial_transaction_id = resp.transaction_id;
@@ -744,8 +745,9 @@ where
             .await?;
 
             if wait_for_receipts {
-                // todo `get_receipt_with_optional_timeout`.
-                resp.get_receipt(client).await?;
+                resp.get_receipt_query()
+                    .execute_with_optional_timeout(client, timeout_per_chunk)
+                    .await?;
             }
 
             responses.push(resp);

--- a/src/transaction_id.rs
+++ b/src/transaction_id.rs
@@ -117,6 +117,7 @@ impl Display for TransactionId {
             self.valid_start.unix_timestamp(),
             self.valid_start.nanosecond(),
             if self.scheduled { "?scheduled" } else { "" },
+            // https://github.com/rust-lang/rust/issues/92698
             self.nonce.map(|nonce| format!("/{nonce}")).as_deref().unwrap_or_default()
         )
     }

--- a/src/transaction_id.rs
+++ b/src/transaction_id.rs
@@ -36,11 +36,11 @@ use time::{
     OffsetDateTime,
 };
 
+use crate::ledger_id::RefLedgerId;
 use crate::{
     AccountId,
     Error,
     FromProtobuf,
-    LedgerId,
     ToProtobuf,
     ValidateChecksums,
 };
@@ -97,7 +97,7 @@ impl TransactionId {
 }
 
 impl ValidateChecksums for TransactionId {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.account_id.validate_checksums(ledger_id)
     }
 }

--- a/src/transaction_receipt_query.rs
+++ b/src/transaction_receipt_query.rs
@@ -23,6 +23,7 @@ use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use hedera_proto::services::response::Response;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     QueryExecute,
@@ -31,7 +32,6 @@ use crate::query::{
 use crate::{
     BoxGrpcFuture,
     Error,
-    LedgerId,
     Query,
     Status,
     ToProtobuf,
@@ -188,7 +188,7 @@ impl QueryExecute for TransactionReceiptQueryData {
 }
 
 impl ValidateChecksums for TransactionReceiptQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.transaction_id.validate_checksums(ledger_id)
     }
 }

--- a/src/transaction_record_query.rs
+++ b/src/transaction_record_query.rs
@@ -23,6 +23,7 @@ use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use hedera_proto::services::response::Response;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::query::{
     AnyQueryData,
     QueryExecute,
@@ -32,7 +33,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     FromProtobuf,
-    LedgerId,
     Query,
     Status,
     ToProtobuf,
@@ -163,7 +163,7 @@ impl QueryExecute for TransactionRecordQueryData {
 }
 
 impl ValidateChecksums for TransactionRecordQueryData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         self.transaction_id.validate_checksums(ledger_id)
     }
 }

--- a/src/transfer_transaction.rs
+++ b/src/transfer_transaction.rs
@@ -24,6 +24,7 @@ use hedera_proto::services;
 use hedera_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
+use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
 use crate::transaction::{
     AnyTransactionData,
@@ -38,7 +39,6 @@ use crate::{
     BoxGrpcFuture,
     Error,
     Hbar,
-    LedgerId,
     NftId,
     ToProtobuf,
     TokenId,
@@ -246,7 +246,7 @@ impl TransactionExecute for TransferTransactionData {
 impl TransactionData for TransferTransactionData {}
 
 impl ValidateChecksums for TransferTransactionData {
-    fn validate_checksums(&self, ledger_id: &LedgerId) -> Result<(), Error> {
+    fn validate_checksums(&self, ledger_id: &RefLedgerId) -> Result<(), Error> {
         for transfer in &self.transfers {
             transfer.account_id.validate_checksums(ledger_id)?;
         }


### PR DESCRIPTION
**Description**:
- Clean up some tech debt by using `RefLedgerId` where we're supposed to (internally)
- Use `triomphe` instead of `std::sync::Arc` where applicable 

**Related issue(s)**:


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
