### PR TITLE
fix(hack): Allow `random_node_ids` to return unhealthy nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,7 @@ checksum = "261391cc14a85f1f05253c3f7b6f75937280f4171d72b3acf6548bad73b99626"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/src/client/network/mod.rs
+++ b/src/client/network/mod.rs
@@ -402,7 +402,13 @@ impl NetworkData {
     }
 
     pub(crate) fn random_node_ids(&self) -> Vec<AccountId> {
-        let node_ids: Vec<_> = self.healthy_node_ids().collect();
+        let mut node_ids: Vec<_> = self.healthy_node_ids().collect();
+
+        if node_ids.is_empty() {
+            log::warn!("No healthy nodes, randomly picking some unhealthy ones");
+            // hack, slowpath, don't care perf, fix this better later tho.
+            node_ids = self.node_ids.to_vec();
+        }
 
         let node_sample_amount = (node_ids.len() + 2) / 3;
 


### PR DESCRIPTION
A better fix would be to not make the nodes unhealthy quite so quickly?

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
