### PR TITLE
fix!: Avoid setting node account IDs where possible

### DIFF
--- a/src/transaction_response.rs
+++ b/src/transaction_response.rs
@@ -69,10 +69,7 @@ impl TransactionResponse {
     pub fn get_receipt_query(&self) -> TransactionReceiptQuery {
         let mut query = TransactionReceiptQuery::new();
 
-        query
-            .transaction_id(self.transaction_id)
-            .node_account_ids([self.node_account_id])
-            .validate_status(self.validate_status);
+        query.transaction_id(self.transaction_id).validate_status(self.validate_status);
 
         query
     }
@@ -82,10 +79,7 @@ impl TransactionResponse {
     pub fn get_record_query(&self) -> TransactionRecordQuery {
         let mut query = TransactionRecordQuery::new();
 
-        query
-            .transaction_id(self.transaction_id)
-            .node_account_ids([self.node_account_id])
-            .validate_status(self.validate_status);
+        query.transaction_id(self.transaction_id).validate_status(self.validate_status);
 
         query
     }


### PR DESCRIPTION
**Description**:
Specifically when it comes to receipts/records from a transaction response

In theory the node in question is probably going to be faster in practice, node proxies sometimes return *http* 503s. The effect of the receipt/record may or may have gone through when that happens for receipts... It's free to try again with a different node, but records cost money to request, so being able to work around the node being broken is needed.


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
