### PR TITLE
chore: fixing some docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,69 @@
 # Hedera™ Rust SDK
 
 > The SDK for interacting with Hedera Hashgraph: the official distributed
-> consensus platform built using the hashgraph consensus algorithm for fast,
+> consensus platform built using the Hashgraph consensus algorithm for fast,
 > fair and secure transactions. Hedera enables and empowers developers to
 > build an entirely new class of decentralized applications.
 
 <sub>Maintained with ❤️ by <a href="https://launchbadge.com" target="_blank">LaunchBadge</a>, <a href="https://www.swirlds.com/" target="_blank">Swirlds Labs</a>, and the Hedera community</sub>
 
-## SDK IS NOT READY FOR PRODUCTION USE. IT IS CURRENTLY STILL UNDER DEVELOPEMENT.
+## SDK IS NOT READY FOR PRODUCTION USE. IT IS CURRENTLY STILL UNDER DEVELOPMENT
 
 ## Requirements
 
 - [Rust](https://rustup.rs)
 - [protoc](https://grpc.io/docs/protoc-installation)
 
-Execute command in root directory:
+Clone this repository and its submodules:
+
+```bash
+git clone --recursive https://github.com/hashgraph/hedera-sdk-rust.git
+```
+
+To check dependencies validity, run the following command in the root directory:
+
 ```bash
 cargo check
 ```
 
 ## API Docs
 
-Check out the Hedera Rust SDK API reference docs [here](http://docs.rs/hedera/latest/hedera/index.html).
+Check out the [Hedera Rust SDK API reference docs](http://docs.rs/hedera/latest/hedera/index.html).
 
 ## Community and Support
 
-If you have any questions on the Hedera SDK or Hedera more generally,
-you can join our team and hundreds of other developers using Hedera in our 
-community Discord:
+If you have any questions on the Hedera SDK or Hedera more generally, you can join our team and hundreds of other developers using Hedera in our community Discord:
 
 <a href="https://hedera.com/discord" target="_blank">
   <img alt="" src="https://user-images.githubusercontent.com/753919/167244200-b95cd3a6-6256-4eaf-b9b4-f1f192341485.png" height="60">
 </a>
 
-###  Integration Tests
+### Integration Tests
 
-Before running the integration tests, an operator key, operator account id, and a network name must be set in an `.env` file. 
+Before running the integration tests, an operator key, operator account id, and a network name must be set in an `.env` file.
+
 ```bash
-# Account that will pay query and transaction fees
+# Account that will pay query and transaction fees.
 TEST_OPERATOR_ACCOUNT_ID=
-# Default private key to use to sign for all transactions and queries
+# Default private key to use to sign for all transactions and queries.
 TEST_OPERATOR_KEY=
-# Network names: `"localhost"`, `"testnet"`, `"previewnet"`, `"mainnet"`
+# Network names: "localhost", "testnet", "previewnet", "mainnet".
 TEST_NETWORK_NAME=
+# Running on-chain tests if this value is set to 1.
+TEST_RUN_NONFREE=
 ```
-```bash
-# Run tests
-$  cargo test 
-```
+
+Run the tests using `cargo test`
 
 #### Local Environment Testing
-Hedera offers a way to run tests through your localhost using the `hedera-local-node` service. 
+
+Hedera offers a way to run tests through your localhost using the `hedera-local-node` service.
 
 For instructions on how to set up and run local node, follow the steps in the git repository:
-https://github.com/hashgraph/hedera-local-node
+<https://github.com/hashgraph/hedera-local-node>
 
 Once the local node is running in Docker, the appropriate `.env` values must be set:
+
 ```bash
 TEST_OPERATOR_ACCOUNT_ID=0.0.2
 TEST_OPERATOR_KEY=3030020100300706052b8104000a042204205bc004059ffa2943965d306f2c44d266255318b3775bacfec42a77ca83e998f2
@@ -66,16 +74,11 @@ Lastly, run the tests using `cargo test`
 
 ## Contributing
 
-Contributions are welcome. Please see the
-[contributing guide](https://github.com/hashgraph/.github/blob/main/CONTRIBUTING.md)
-to see how you can get involved.
+Contributions are welcome. Please see the [contributing guide](https://github.com/hashgraph/.github/blob/main/CONTRIBUTING.md) to see how you can get involved.
 
 ## Code of Conduct
 
-This project is governed by the
-[Contributor Covenant Code of Conduct](https://github.com/hashgraph/.github/blob/main/CODE_OF_CONDUCT.md). By
-participating, you are expected to uphold this code of conduct. Please report unacceptable behavior
-to [oss@hedera.com](mailto:oss@hedera.com).
+This project is governed by the [Contributor Covenant Code of Conduct](https://github.com/hashgraph/.github/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code of conduct. Please report unacceptable behavior to [oss@hedera.com](mailto:oss@hedera.com).
 
 ## License
 


### PR DESCRIPTION
**Description**:

Fixing some docs, especially the need for `--recursive` parameter when cloning the repo.

**Related issue(s)**:

Fixes later compilation errors if you don't include submodules in the repo.

```bash
   Compiling hedera-proto v0.8.1 (/home/developer/workspace/hedera/hedera-sdk-rust/protobufs)
error: failed to run custom build command for `hedera-proto v0.8.1 (/home/developer/workspace/hedera/hedera-sdk-rust/protobufs)`

Caused by:
  process didn't exit successfully: `/home/developer/workspace/hedera/hedera-sdk-rust/target/debug/build/hedera-proto-1822a64e67ed6dbd/build-script-build` (exit status: 1)
  --- stderr
  Error: No such file or directory (os error 2)
warning: build failed, waiting for other jobs to finish...
```

**Notes for reviewer**:
N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
