### PR TITLE
bug: fix nonfree tests execution

### DIFF
--- a/tests/e2e/common/mod.rs
+++ b/tests/e2e/common/mod.rs
@@ -17,7 +17,7 @@ mod keys {
 
     pub(super) const OPERATOR_ACCOUNT_ID: &str = "TEST_OPERATOR_ACCOUNT_ID";
 
-    pub(super) const RUN_NONFREE: &str = "TEST_RUN_NONEFREE";
+    pub(super) const RUN_NONFREE: &str = "TEST_RUN_NONFREE";
 }
 
 static CONFIG: Lazy<Config> = Lazy::new(Config::parse_env);


### PR DESCRIPTION
**Description**:

Nonfree env variable name was wrong.

**Related issue(s)**:

N/A

**Notes for reviewer**:

`Rust CI / test` for this PR fails because now it is executed as expected ;)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
