### PR TITLE
chore: fixing CI env variable name

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
             touch .env
             echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
-            echo TEST_OPERATOR_ID="0.0.2" >> .env
+            echo TEST_OPERATOR_ACCOUNT_ID="0.0.2" >> .env
             echo TEST_HEDERA_NETWORK="localhost" >> .env
             echo TEST_RUN_NONFREE="1" >> .env
             cat .env


### PR DESCRIPTION
**Description**:

Operator account variable in CI configuration was wrong.

**Related issue(s)**:

N/A

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
