### PR TITLE
chore(build): Provide friendly error when build fails due to git submodule being missing

### DIFF
--- a/protobufs/build.rs
+++ b/protobufs/build.rs
@@ -28,12 +28,19 @@ use std::path::Path;
 
 const DERIVE_EQ_HASH: &str = "#[derive(Eq, Hash)]";
 const DERIVE_EQ_HASH_COPY: &str = "#[derive(Copy, Eq, Hash)]";
+const SERVICES_FOLDER: &str = "./protobufs/services";
 
 fn main() -> anyhow::Result<()> {
     // services is the "base" module for the hedera protobufs
     // in the beginning, there was only services and it was named "protos"
 
-    let services: Vec<_> = read_dir("./protobufs/services")?
+    let services_path = Path::new(SERVICES_FOLDER);
+
+    if !services_path.is_dir() {
+        anyhow::bail!("Folder {SERVICES_FOLDER} does not exist; do you need to `git submodule update --init`?");
+    }
+
+    let services: Vec<_> = read_dir(services_path)?
         .filter_map(|entry| {
             let entry = entry.ok()?;
             entry.file_type().ok()?.is_file().then(|| entry.path())


### PR DESCRIPTION

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

0. Install `protoc` using OS package manager
1. Pull repo
2. `cargo b`
3. Fails with an error about a file being missing but doesn't say which file

After this change, the build error will include the name of the missing folder, and a suggestion to check git submodules (since that is where this folder comes from).

**Related issue(s)**:

n/a

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)

No additional documentation required. Tested by removing the folder, running the build to failure, adding the folder back, and running the build to success.