### PR TITLE
fix: 778 bug rust sdk fails to build

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup GCC
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev
+          sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev libssl-dev
 
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Setup GCC
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev
+          sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev libssl-dev
 
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
**Description**:
Added libssl-dev to the installs in multiple jobs within the sdk-rust workflows

**Related issue(s)**:

Fixes #778

