### PR TITLE
feat: add #get_cost() to Transaction to estimate transaction fees

### DIFF
--- a/examples/transfer_crypto_cost.rs
+++ b/examples/transfer_crypto_cost.rs
@@ -1,0 +1,72 @@
+/*
+ * ‌
+ * Hedera Rust SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+use clap::Parser;
+use hedera::{AccountId, Client, Hbar, PrivateKey, TransferTransaction};
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[clap(long, env)]
+    operator_account_id: AccountId,
+
+    #[clap(long, env)]
+    operator_key: PrivateKey,
+
+    #[clap(long)]
+    sender: Option<AccountId>,
+
+    #[clap(long, default_value = "0.0.1001")]
+    receiver: AccountId,
+
+    #[clap(long, default_value = "10 μℏ")]
+    amount: Hbar,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let _ = dotenvy::dotenv();
+    let args = Args::parse();
+
+    let client = Client::for_testnet();
+
+    client.set_operator(args.operator_account_id, args.operator_key);
+
+    let sender = args.sender.unwrap_or(args.operator_account_id);
+
+    let mut txn = TransferTransaction::new();
+
+    txn.hbar_transfer(sender, -args.amount)
+        .hbar_transfer(args.receiver, args.amount);
+
+    // query the cost
+    let cost = txn.get_cost(&client).await?;
+
+    println!(" > transfer estimated cost: {}", cost);
+
+    // now execute
+    let resp = txn.execute(&client).await?;
+
+    // and then get the actual cost
+    let record = resp.get_record(&client).await?;
+
+    println!(" > transfer actual cost: {}", record.transaction_fee);
+
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,8 +64,12 @@ pub enum Error {
     TransactionPreCheckStatus {
         /// The status that caused the [`Transaction`](crate::Transaction) to fail pre-check.
         status: Status,
+
         /// The `TransactionId` of the failed [`Transaction`](crate::Transaction) .
         transaction_id: Box<TransactionId>,
+
+        /// The estimated transaction fee, if the status was [`InsufficientTxFee`].
+        cost: Option<Hbar>,
     },
 
     /// A [`Query`](crate::Query) for `transaction_id` failed pre-check.

--- a/src/ping_query.rs
+++ b/src/ping_query.rs
@@ -124,6 +124,7 @@ impl Execute for PingQuery {
         &self,
         status: hedera_proto::services::ResponseCodeEnum,
         _transaction_id: Option<&crate::TransactionId>,
+        _response: Self::GrpcResponse,
     ) -> crate::Error {
         crate::Error::QueryNoPaymentPreCheckStatus { status }
     }

--- a/src/query/cost.rs
+++ b/src/query/cost.rs
@@ -118,6 +118,7 @@ where
         &self,
         status: crate::Status,
         transaction_id: Option<&TransactionId>,
+        _response: Self::GrpcResponse,
     ) -> crate::Error {
         if let Some(transaction_id) = self.0.data.transaction_id() {
             crate::Error::QueryPreCheckStatus { status, transaction_id: Box::new(transaction_id) }

--- a/src/query/execute.rs
+++ b/src/query/execute.rs
@@ -162,6 +162,7 @@ where
         &self,
         status: crate::Status,
         transaction_id: Option<&TransactionId>,
+        _response: Self::GrpcResponse,
     ) -> crate::Error {
         if let Some(transaction_id) = self.data.transaction_id() {
             crate::Error::QueryPreCheckStatus { status, transaction_id: Box::new(transaction_id) }

--- a/src/transaction/chunked.rs
+++ b/src/transaction/chunked.rs
@@ -15,6 +15,7 @@ use crate::{
     AccountId,
     BoxGrpcFuture,
     Error,
+    Hbar,
     Transaction,
     TransactionHash,
     TransactionId,
@@ -199,9 +200,11 @@ where
         &self,
         status: services::ResponseCodeEnum,
         transaction_id: Option<&TransactionId>,
+        response: Self::GrpcResponse,
     ) -> crate::Error {
         crate::Error::TransactionPreCheckStatus {
             status,
+            cost: (response.cost != 0).then(|| Hbar::from_tinybars(response.cost as i64)),
             transaction_id: Box::new(
                 *transaction_id.expect("transactions must have transaction IDs"),
             ),
@@ -301,9 +304,11 @@ where
         &self,
         status: services::ResponseCodeEnum,
         transaction_id: Option<&TransactionId>,
+        response: Self::GrpcResponse,
     ) -> crate::Error {
         crate::Error::TransactionPreCheckStatus {
             status,
+            cost: (response.cost != 0).then(|| Hbar::from_tinybars(response.cost as i64)),
             transaction_id: Box::new(
                 *transaction_id.expect("transactions must have transaction IDs"),
             ),

--- a/src/transaction/cost.rs
+++ b/src/transaction/cost.rs
@@ -1,0 +1,84 @@
+use hedera_proto::services;
+use tonic::transport::Channel;
+
+use super::{
+    AnyTransactionData,
+    ChunkInfo,
+    ToTransactionDataProtobuf,
+    TransactionBody,
+    TransactionData,
+    TransactionExecute,
+};
+use crate::{
+    BoxGrpcFuture,
+    Transaction,
+    ValidateChecksums,
+};
+
+#[derive(Clone)]
+pub(crate) struct CostTransactionData<D> {
+    pub(crate) inner: D,
+}
+
+pub(crate) type CostTransaction<D> = Transaction<CostTransactionData<D>>;
+
+impl<D: Clone> CostTransaction<D> {
+    pub(crate) fn from_transaction(transaction: &Transaction<D>) -> Self {
+        let transaction = transaction.clone();
+
+        Self {
+            body: TransactionBody {
+                data: CostTransactionData { inner: transaction.body.data },
+                node_account_ids: transaction.body.node_account_ids,
+                transaction_valid_duration: transaction.body.transaction_valid_duration,
+                max_transaction_fee: transaction.body.max_transaction_fee,
+                transaction_memo: transaction.body.transaction_memo,
+                transaction_id: transaction.body.transaction_id,
+                operator: transaction.body.operator,
+                is_frozen: transaction.body.is_frozen,
+                regenerate_transaction_id: transaction.body.regenerate_transaction_id,
+            },
+            // cost transactions have no signers
+            signers: Vec::new(),
+            sources: transaction.sources,
+        }
+    }
+}
+
+impl<D: Into<AnyTransactionData>> From<CostTransactionData<D>> for AnyTransactionData {
+    fn from(transaction: CostTransactionData<D>) -> Self {
+        transaction.inner.into()
+    }
+}
+
+impl<D: TransactionData> TransactionData for CostTransactionData<D> {
+    #[doc(hidden)]
+    fn for_cost_estimate(&self) -> bool {
+        true
+    }
+}
+
+impl<D: TransactionExecute> TransactionExecute for CostTransactionData<D> {
+    fn execute(
+        &self,
+        channel: Channel,
+        request: services::Transaction,
+    ) -> BoxGrpcFuture<'_, services::TransactionResponse> {
+        self.inner.execute(channel, request)
+    }
+}
+
+impl<D: ValidateChecksums> ValidateChecksums for CostTransactionData<D> {
+    fn validate_checksums(&self, ledger_id: &crate::ledger_id::RefLedgerId) -> crate::Result<()> {
+        self.inner.validate_checksums(ledger_id)
+    }
+}
+
+impl<D: ToTransactionDataProtobuf> ToTransactionDataProtobuf for CostTransactionData<D> {
+    fn to_transaction_data_protobuf(
+        &self,
+        chunk_info: &ChunkInfo,
+    ) -> services::transaction_body::Data {
+        self.inner.to_transaction_data_protobuf(chunk_info)
+    }
+}

--- a/tests/e2e/account/allowance_approve.rs
+++ b/tests/e2e/account/allowance_approve.rs
@@ -158,7 +158,7 @@ async fn missing_nft_allowance_approval_fails() -> anyhow::Result<()> {
         res,
         Err(hedera::Error::ReceiptStatus {
             status: hedera::Status::SpenderDoesNotHaveAllowance,
-            transaction_id: _
+            ..
         })
     );
 

--- a/tests/e2e/account/allowance_delete.rs
+++ b/tests/e2e/account/allowance_delete.rs
@@ -86,7 +86,7 @@ async fn transfer_after_allowance_remove_fails() -> anyhow::Result<()> {
         res,
         Err(hedera::Error::ReceiptStatus {
             status: hedera::Status::SpenderDoesNotHaveAllowance,
-            transaction_id: _
+            ..
         })
     );
 

--- a/tests/e2e/account/create.rs
+++ b/tests/e2e/account/create.rs
@@ -86,10 +86,7 @@ async fn missing_key_error() {
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: hedera::Status::KeyRequired,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: hedera::Status::KeyRequired, .. })
     );
 }
 
@@ -257,10 +254,7 @@ async fn alias_from_admin_key_with_receiver_sig_required_and_no_signature_errors
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: hedera::Status::InvalidSignature,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: hedera::Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -323,10 +317,7 @@ async fn alias_missing_signature_fails() -> anyhow::Result<()> {
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: hedera::Status::InvalidSignature,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: hedera::Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -393,10 +384,7 @@ async fn alias_with_receiver_sig_required_missing_signature_fails() -> anyhow::R
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: hedera::Status::InvalidSignature,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: hedera::Status::InvalidSignature, .. })
     );
 
     Ok(())

--- a/tests/e2e/account/delete.rs
+++ b/tests/e2e/account/delete.rs
@@ -63,10 +63,7 @@ async fn missing_account_id_fails() {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::AccountIdDoesNotExist,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::AccountIdDoesNotExist, .. })
     );
 }
 
@@ -103,7 +100,7 @@ async fn missing_deletee_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())

--- a/tests/e2e/account/info.rs
+++ b/tests/e2e/account/info.rs
@@ -142,10 +142,7 @@ async fn get_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus {
-            status: Status::InsufficientTxFee,
-            transaction_id: _
-        })
+        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     Ok(())

--- a/tests/e2e/account/update.rs
+++ b/tests/e2e/account/update.rs
@@ -78,7 +78,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
         res,
         Err(hedera::Error::TransactionPreCheckStatus {
             status: hedera::Status::AccountIdDoesNotExist,
-            transaction_id: _
+            ..
         })
     );
 

--- a/tests/e2e/contract/create.rs
+++ b/tests/e2e/contract/create.rs
@@ -119,13 +119,11 @@ async fn unset_gas_fails() -> anyhow::Result<()> {
         .bytecode_file_id(file_id)
         .contract_memo("[e2e::ContractCreateTransaction]")
         .execute(&client)
-        .await?
-        .get_receipt(&client)
         .await;
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InsufficientGas, transaction_id: _ })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InsufficientGas, .. })
     );
 
     Ok(())
@@ -155,10 +153,7 @@ async fn constructor_parameters_unset_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::ContractRevertExecuted,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::ContractRevertExecuted, .. })
     );
 
     Ok(())
@@ -181,10 +176,7 @@ async fn bytecode_file_id_unset_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(
-        res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidFileId, transaction_id: _ })
-    );
+    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::InvalidFileId, .. }));
 
     Ok(())
 }

--- a/tests/e2e/contract/create_flow.rs
+++ b/tests/e2e/contract/create_flow.rs
@@ -81,7 +81,7 @@ async fn admin_key_missing_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())

--- a/tests/e2e/contract/delete.rs
+++ b/tests/e2e/contract/delete.rs
@@ -64,10 +64,7 @@ async fn missing_admin_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::ModifyingImmutableContract,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::ModifyingImmutableContract, .. })
     );
 
     Ok(())
@@ -83,10 +80,7 @@ async fn missing_contract_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidContractId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidContractId, .. })
     );
 
     Ok(())

--- a/tests/e2e/contract/execute.rs
+++ b/tests/e2e/contract/execute.rs
@@ -67,10 +67,7 @@ async fn missing_contract_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidContractId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidContractId, .. })
     );
 
     Ok(())
@@ -101,10 +98,7 @@ async fn missing_function_parameters_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::ContractRevertExecuted,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::ContractRevertExecuted, .. })
     );
 
     ContractDeleteTransaction::new()
@@ -144,10 +138,7 @@ async fn missing_gas_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InsufficientGas,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InsufficientGas, .. })
     );
 
     ContractDeleteTransaction::new()

--- a/tests/e2e/contract/info.rs
+++ b/tests/e2e/contract/info.rs
@@ -196,10 +196,7 @@ async fn query_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus {
-            status: Status::InsufficientTxFee,
-            transaction_id: _
-        })
+        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     ContractDeleteTransaction::new()

--- a/tests/e2e/contract/update.rs
+++ b/tests/e2e/contract/update.rs
@@ -68,10 +68,7 @@ async fn missing_contract_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidContractId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidContractId, .. })
     );
 
     Ok(())
@@ -100,10 +97,7 @@ async fn immutable_contract_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::ModifyingImmutableContract,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::ModifyingImmutableContract, .. })
     );
 
     Ok(())

--- a/tests/e2e/file/contents.rs
+++ b/tests/e2e/file/contents.rs
@@ -219,10 +219,7 @@ async fn query_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus {
-            status: Status::InsufficientTxFee,
-            transaction_id: _
-        })
+        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     FileDeleteTransaction::new()

--- a/tests/e2e/file/delete.rs
+++ b/tests/e2e/file/delete.rs
@@ -68,10 +68,7 @@ async fn immutable_file_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(
-        res,
-        Err(hedera::Error::ReceiptStatus { status: Status::Unauthorized, transaction_id: _ })
-    );
+    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::Unauthorized, .. }));
 
     Ok(())
 }

--- a/tests/e2e/file/info.rs
+++ b/tests/e2e/file/info.rs
@@ -199,10 +199,7 @@ async fn query_cost_insufficient_tx_fee() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus {
-            status: Status::InsufficientTxFee,
-            transaction_id: _
-        })
+        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     FileDeleteTransaction::new()

--- a/tests/e2e/file/update.rs
+++ b/tests/e2e/file/update.rs
@@ -86,10 +86,7 @@ async fn immutable_file_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(
-        res,
-        Err(hedera::Error::ReceiptStatus { status: Status::Unauthorized, transaction_id: _ })
-    );
+    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::Unauthorized, .. }));
 
     Ok(())
 }
@@ -104,10 +101,7 @@ async fn missing_file_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidFileId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidFileId, .. })
     );
 
     Ok(())

--- a/tests/e2e/network_version_info.rs
+++ b/tests/e2e/network_version_info.rs
@@ -98,10 +98,7 @@ async fn get_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus {
-            status: Status::InsufficientTxFee,
-            transaction_id: _
-        })
+        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     Ok(())

--- a/tests/e2e/schedule/create.rs
+++ b/tests/e2e/schedule/create.rs
@@ -210,10 +210,7 @@ async fn double_schedule_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::IdenticalScheduleAlreadyCreated,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::IdenticalScheduleAlreadyCreated, .. })
     );
 
     account.delete(&client).await?;

--- a/tests/e2e/schedule/delete.rs
+++ b/tests/e2e/schedule/delete.rs
@@ -78,10 +78,7 @@ async fn missing_admin_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::ScheduleIsImmutable,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::ScheduleIsImmutable, .. })
     );
 
     Ok(())
@@ -130,10 +127,7 @@ async fn double_delete_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::ScheduleAlreadyDeleted,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::ScheduleAlreadyDeleted, .. })
     );
 
     Ok(())
@@ -149,10 +143,7 @@ async fn missing_schedule_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidScheduleId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidScheduleId, .. })
     );
 
     Ok(())

--- a/tests/e2e/schedule/info.rs
+++ b/tests/e2e/schedule/info.rs
@@ -250,10 +250,7 @@ async fn query_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus {
-            status: Status::InsufficientTxFee,
-            transaction_id: _
-        })
+        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     account.delete(&client).await?;

--- a/tests/e2e/token/associate.rs
+++ b/tests/e2e/token/associate.rs
@@ -73,10 +73,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidAccountId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     Ok(())
@@ -100,7 +97,7 @@ async fn missing_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     account.delete(&client).await?;

--- a/tests/e2e/token/burn.rs
+++ b/tests/e2e/token/burn.rs
@@ -63,10 +63,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTokenId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     Ok(())
@@ -125,7 +122,7 @@ async fn missing_supply_key_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     token.delete(&client).await?;
@@ -205,10 +202,7 @@ async fn unowned_nft_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::TreasuryMustOwnBurnedNft,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::TreasuryMustOwnBurnedNft, .. })
     );
 
     TransferTransaction::new()

--- a/tests/e2e/token/create.rs
+++ b/tests/e2e/token/create.rs
@@ -133,7 +133,7 @@ async fn missing_name_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::MissingTokenName, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::MissingTokenName, .. })
     );
 
     account.delete(&client).await?;
@@ -160,7 +160,7 @@ async fn missing_symbol_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::MissingTokenSymbol, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::MissingTokenSymbol, .. })
     );
 
     account.delete(&client).await?;
@@ -183,7 +183,7 @@ async fn missing_treasury_account_id_fails() -> anyhow::Result<()> {
         res,
         Err(hedera::Error::TransactionPreCheckStatus {
             status: Status::InvalidTreasuryAccountForToken,
-            transaction_id: _
+            ..
         })
     );
 
@@ -208,7 +208,7 @@ async fn missing_treasury_account_id_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -237,7 +237,7 @@ async fn missing_admin_key_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     account.delete(&client).await?;
@@ -300,10 +300,7 @@ async fn too_many_custom_fees_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::CustomFeesListTooLong,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::CustomFeesListTooLong, .. })
     );
 
     account.delete(&client).await?;
@@ -408,7 +405,7 @@ async fn fractional_fee_min_bigger_than_max_fails() -> anyhow::Result<()> {
         res,
         Err(hedera::Error::ReceiptStatus {
             status: Status::FractionalFeeMaxAmountLessThanMinAmount,
-            transaction_id: _
+            ..
         })
     );
 
@@ -446,10 +443,7 @@ async fn invalid_fee_collector_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::InvalidCustomFeeCollector,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidCustomFeeCollector, .. })
     );
 
     account.delete(&client).await?;
@@ -486,10 +480,7 @@ async fn negative_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::CustomFeeMustBePositive,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::CustomFeeMustBePositive, .. })
     );
 
     account.delete(&client).await?;
@@ -532,10 +523,7 @@ async fn zero_denominator_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::FractionDividesByZero,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::FractionDividesByZero, .. })
     );
 
     account.delete(&client).await?;

--- a/tests/e2e/token/delete.rs
+++ b/tests/e2e/token/delete.rs
@@ -83,7 +83,7 @@ async fn missing_admin_key_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     token.delete(&client).await?;
@@ -116,7 +116,7 @@ async fn missing_admin_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, .. })
     );
 
     Ok(())
@@ -132,10 +132,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTokenId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     Ok(())

--- a/tests/e2e/token/dissociate.rs
+++ b/tests/e2e/token/dissociate.rs
@@ -82,10 +82,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidAccountId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     Ok(())
@@ -109,7 +106,7 @@ async fn missing_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     account.delete(&client).await?;
@@ -141,10 +138,7 @@ async fn unassociated_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::TokenNotAssociatedToAccount,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/fee_schedule_update.rs
+++ b/tests/e2e/token/fee_schedule_update.rs
@@ -126,7 +126,7 @@ async fn invalid_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())

--- a/tests/e2e/token/freeze.rs
+++ b/tests/e2e/token/freeze.rs
@@ -76,10 +76,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTokenId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     account.delete(&client).await?;
@@ -104,10 +101,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidAccountId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     token.delete(&client).await?;
@@ -140,10 +134,7 @@ async fn non_associated_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::TokenNotAssociatedToAccount,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/grant_kyc.rs
+++ b/tests/e2e/token/grant_kyc.rs
@@ -76,10 +76,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTokenId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     account.delete(&client).await?;
@@ -109,10 +106,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidAccountId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     token.delete(&client).await?;
@@ -145,10 +139,7 @@ async fn non_associated_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::TokenNotAssociatedToAccount,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/info.rs
+++ b/tests/e2e/token/info.rs
@@ -289,10 +289,7 @@ async fn query_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus {
-            status: Status::InsufficientTxFee,
-            transaction_id: _
-        })
+        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/mint.rs
+++ b/tests/e2e/token/mint.rs
@@ -98,10 +98,7 @@ async fn over_supply_limit_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::TokenMaxSupplyReached,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::TokenMaxSupplyReached, .. })
     );
 
     token.delete(&client).await?;
@@ -120,10 +117,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTokenId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     Ok(())
@@ -186,7 +180,7 @@ async fn missing_supply_key_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     token.delete(&client).await?;
@@ -279,10 +273,7 @@ async fn nft_metadata_too_long_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(
-        res,
-        Err(hedera::Error::ReceiptStatus { status: Status::MetadataTooLong, transaction_id: _ })
-    );
+    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::MetadataTooLong, .. }));
 
     token.delete(&client).await?;
     account.delete(&client).await?;

--- a/tests/e2e/token/nft_transfer.rs
+++ b/tests/e2e/token/nft_transfer.rs
@@ -109,10 +109,7 @@ async fn unowned_nfts_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::SenderDoesNotOwnNftSerialNo,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::SenderDoesNotOwnNftSerialNo, .. })
     );
 
     token.burn(&client, serials).await?;

--- a/tests/e2e/token/nft_update.rs
+++ b/tests/e2e/token/nft_update.rs
@@ -144,7 +144,7 @@ async fn cannot_update_without_signed_metadata_key_error() -> anyhow::Result<()>
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -205,10 +205,7 @@ async fn cannot_update_without_set_metadata_key_error() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::TokenHasNoMetadataKey,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::TokenHasNoMetadataKey, .. })
     );
 
     Ok(())

--- a/tests/e2e/token/pause.rs
+++ b/tests/e2e/token/pause.rs
@@ -73,10 +73,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTokenId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     Ok(())
@@ -101,7 +98,7 @@ async fn missing_pause_key_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -126,7 +123,7 @@ async fn missing_pause_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenHasNoPauseKey, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::TokenHasNoPauseKey, .. })
     );
 
     Ok(())

--- a/tests/e2e/token/revoke_kyc.rs
+++ b/tests/e2e/token/revoke_kyc.rs
@@ -76,10 +76,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTokenId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     account.delete(&client).await?;
@@ -104,10 +101,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidAccountId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     token.delete(&client).await?;
@@ -140,10 +134,7 @@ async fn non_associated_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::TokenNotAssociatedToAccount,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/transfer.rs
+++ b/tests/e2e/token/transfer.rs
@@ -166,7 +166,7 @@ async fn insufficient_balance_for_fee_fails() -> anyhow::Result<()> {
         res,
         Err(hedera::Error::ReceiptStatus {
             status: Status::InsufficientSenderAccountBalanceForCustomFee,
-            transaction_id: _
+            ..
         })
     );
 
@@ -222,10 +222,7 @@ async fn unowned_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::InsufficientTokenBalance,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::InsufficientTokenBalance, .. })
     );
 
     token.burn(&client, 10).await?;
@@ -321,10 +318,7 @@ async fn incorrect_decimals_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::UnexpectedTokenDecimals,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::UnexpectedTokenDecimals, .. })
     );
 
     token.burn(&client, 10).await?;

--- a/tests/e2e/token/unfreeze.rs
+++ b/tests/e2e/token/unfreeze.rs
@@ -76,10 +76,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTokenId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     account.delete(&client).await?;
@@ -104,10 +101,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidAccountId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     token.delete(&client).await?;
@@ -140,10 +134,7 @@ async fn non_associated_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::TokenNotAssociatedToAccount,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/unpause.rs
+++ b/tests/e2e/token/unpause.rs
@@ -73,10 +73,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTokenId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     Ok(())
@@ -101,7 +98,7 @@ async fn missing_pause_key_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -126,7 +123,7 @@ async fn missing_pause_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenHasNoPauseKey, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::TokenHasNoPauseKey, .. })
     );
 
     Ok(())

--- a/tests/e2e/token/update.rs
+++ b/tests/e2e/token/update.rs
@@ -98,7 +98,7 @@ async fn immutable_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, .. })
     );
 
     // can't delete the account because the token still exists, can't delete the token because there's no admin key.

--- a/tests/e2e/token/wipe.rs
+++ b/tests/e2e/token/wipe.rs
@@ -172,10 +172,7 @@ async fn unowned_nft_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: Status::AccountDoesNotOwnWipedNft,
-            transaction_id: _
-        })
+        Err(hedera::Error::ReceiptStatus { status: Status::AccountDoesNotOwnWipedNft, .. })
     );
 
     token.burn(&client, serials).await?;
@@ -204,10 +201,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidAccountId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     token.delete(&client).await?;
@@ -228,10 +222,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTokenId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     account.delete(&client).await?;

--- a/tests/e2e/topic/delete.rs
+++ b/tests/e2e/topic/delete.rs
@@ -50,10 +50,7 @@ async fn immutable_fails() -> anyhow::Result<()> {
         .await?
         .get_receipt(&client)
         .await;
-    assert_matches!(
-        res,
-        Err(hedera::Error::ReceiptStatus { status: Status::Unauthorized, transaction_id: _ })
-    );
+    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::Unauthorized, .. }));
 
     Ok(())
 }
@@ -85,7 +82,7 @@ async fn wrong_admin_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())

--- a/tests/e2e/topic/info.rs
+++ b/tests/e2e/topic/info.rs
@@ -122,10 +122,7 @@ async fn query_cost_insufficient_tx_fee() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus {
-            status: Status::InsufficientTxFee,
-            transaction_id: _
-        })
+        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     topic.delete(&client).await?;

--- a/tests/e2e/topic/message_submit.rs
+++ b/tests/e2e/topic/message_submit.rs
@@ -82,10 +82,7 @@ async fn missing_topic_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTopicId,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTopicId, .. })
     );
 
     Ok(())
@@ -103,10 +100,7 @@ async fn missing_message_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: Status::InvalidTopicMessage,
-            transaction_id: _
-        })
+        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTopicMessage, .. })
     );
 
     topic.delete(&client).await?;


### PR DESCRIPTION
Add the `get_cost` method to `Transaction` to estimate the transaction cost.

Running the example

```
 > transfer estimated cost: 0.00092944 ℏ
 > transfer actual cost: 0.00109385 ℏ
```
