### PR TITLE
ci: update workflows to use latitude.sh based runners

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   format:
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: client-sdk-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
@@ -39,7 +39,7 @@ jobs:
           cargo +nightly fmt --check
   
   check:
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: client-sdk-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
@@ -81,7 +81,7 @@ jobs:
   
   test:
     needs: ['check']
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: client-sdk-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the CI workflows `runs-on` labels to use the new Latitude.sh based runners.

### Related Issues

- Closes #828   