### PR TITLE
feat(config): Make gRPC http connections configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea/
 .task/
 target
+
+protobufs/protobufs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,7 +974,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hedera"
-version = "0.32.0"
+version = "0.33.0-alpha"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "hedera"
 readme = "README.md"
 repository = "https://github.com/hashgraph/hedera-sdk-rust"
-version = "0.32.0"
+version = "0.33.0-alpha"
 
 [lib]
 bench = false

--- a/examples/consensus_pub_sub.rs
+++ b/examples/consensus_pub_sub.rs
@@ -30,7 +30,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = dotenvy::dotenv();
     let args = Args::parse();
 
-    let client = Client::for_testnet();
+    let client = Client::for_testnet()?;
 
     client.set_operator(args.operator_account_id, args.operator_key);
 

--- a/examples/create_account.rs
+++ b/examples/create_account.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = dotenvy::dotenv();
     let args = Args::parse();
 
-    let client = Client::for_testnet();
+    let client = Client::for_testnet()?;
 
     client.set_operator(args.operator_account_id, args.operator_key);
 

--- a/examples/create_file.rs
+++ b/examples/create_file.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = dotenvy::dotenv();
     let args = Args::parse();
 
-    let client = Client::for_testnet();
+    let client = Client::for_testnet()?;
 
     client.set_operator(args.operator_account_id, args.operator_key);
 

--- a/examples/create_topic.rs
+++ b/examples/create_topic.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = dotenvy::dotenv();
     let args = Args::parse();
 
-    let client = Client::for_testnet();
+    let client = Client::for_testnet()?;
 
     client.set_operator(args.operator_account_id, args.operator_key);
 

--- a/examples/get_account_balance.rs
+++ b/examples/get_account_balance.rs
@@ -5,7 +5,7 @@ use hedera::{AccountBalanceQuery, AccountId, Client, NodeAddressBookQuery};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // let client = Client::for_mainnet();
-    let client = Client::for_testnet();
+    let client = Client::for_testnet()?;
     dbg!(NodeAddressBookQuery::new()
         .execute(&client)
         .await?

--- a/examples/get_account_info.rs
+++ b/examples/get_account_info.rs
@@ -17,7 +17,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = dotenvy::dotenv();
     let args = Args::parse();
 
-    let client = Client::for_testnet();
+    let client = Client::for_testnet()?;
 
     client.set_operator(args.operator_account_id, args.operator_key);
 

--- a/examples/get_file_contents.rs
+++ b/examples/get_file_contents.rs
@@ -20,7 +20,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = dotenvy::dotenv();
     let args = Args::parse();
 
-    let client = Client::for_testnet();
+    let client = Client::for_testnet()?;
 
     client.set_operator(args.operator_account_id, args.operator_key);
 

--- a/examples/transfer_crypto.rs
+++ b/examples/transfer_crypto.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = dotenvy::dotenv();
     let args = Args::parse();
 
-    let client = Client::for_testnet();
+    let client = Client::for_testnet()?;
 
     client.set_operator(args.operator_account_id, args.operator_key);
 

--- a/examples/transfer_crypto_cost.rs
+++ b/examples/transfer_crypto_cost.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = dotenvy::dotenv();
     let args = Args::parse();
 
-    let client = Client::for_testnet();
+    let client = Client::for_testnet()?;
 
     client.set_operator(args.operator_account_id, args.operator_key);
 

--- a/src/account/account_id.rs
+++ b/src/account/account_id.rs
@@ -351,7 +351,7 @@ mod tests {
         assert_eq!(
             AccountId::from_str("0.0.123")
                 .unwrap()
-                .to_string_with_checksum(&Client::for_testnet())
+                .to_string_with_checksum(&Client::for_testnet().unwrap())
                 .unwrap(),
             "0.0.123-esxsf"
         );
@@ -359,7 +359,7 @@ mod tests {
 
     #[tokio::test]
     async fn bad_checksum_on_previewnet() {
-        let client = Client::for_previewnet();
+        let client = Client::for_previewnet().unwrap();
         let id = AccountId::from_str("0.0.123-ntjli").unwrap();
 
         assert_matches!(

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -2,6 +2,9 @@
 
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::time::Duration;
+
+use tonic::transport::Endpoint;
 
 use crate::signer::AnySigner;
 use crate::{
@@ -78,4 +81,65 @@ pub(super) struct ClientConfig {
     pub(super) operator: Option<super::Operator>,
     pub(super) network: Either<HashMap<String, AccountId>, NetworkName>,
     pub(super) mirror_network: Option<Either<Vec<String>, NetworkName>>,
+}
+
+/// gRPC channel connection configuration. Values which are set will override
+/// the defaults established by tonic, which are typically hyper defaults.
+pub struct EndpointConfig {
+    /// Initial connect timeout
+    pub connect_timeout: Option<Duration>,
+
+    /// HTTP/2 keep alive interval
+    pub http2_keep_alive_interval: Option<Duration>,
+
+    /// HTTP/2 keep alive timeout
+    pub http2_keep_alive_timeout: Option<Duration>,
+
+    /// HTTP/2 keep alive while idle
+    pub http2_keep_alive_while_idle: Option<bool>,
+
+    /// TCP keep alive time threshold
+    pub tcp_keepalive: Option<Duration>,
+}
+
+impl Default for EndpointConfig {
+    fn default() -> Self {
+        Self {
+            connect_timeout: Some(Duration::from_secs(10)),
+            http2_keep_alive_interval: None,
+            http2_keep_alive_timeout: Some(Duration::from_secs(10)),
+            http2_keep_alive_while_idle: Some(true),
+            tcp_keepalive: Some(Duration::from_secs(10)),
+        }
+    }
+}
+
+impl EndpointConfig {
+    pub(crate) fn apply(&self, endpoint: Endpoint) -> Endpoint {
+        let endpoint = if let Some(value) = self.connect_timeout {
+            endpoint.connect_timeout(value)
+        } else {
+            endpoint
+        };
+
+        let endpoint = if let Some(value) = self.http2_keep_alive_interval {
+            endpoint.http2_keep_alive_interval(value)
+        } else {
+            endpoint
+        };
+
+        let endpoint = if let Some(value) = self.http2_keep_alive_timeout {
+            endpoint.keep_alive_timeout(value)
+        } else {
+            endpoint
+        };
+
+        let endpoint = if let Some(value) = self.http2_keep_alive_while_idle {
+            endpoint.keep_alive_while_idle(value)
+        } else {
+            endpoint
+        };
+
+        endpoint.tcp_keepalive(self.tcp_keepalive)
+    }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -26,6 +26,8 @@ use triomphe::Arc;
 use self::network::managed::ManagedNetwork;
 use self::network::mirror::MirrorNetwork;
 pub(crate) use self::network::mirror::MirrorNetworkData;
+pub use crate::client::config::EndpointConfig;
+use crate::client::network::managed::ManagedNetworkBuilder;
 use crate::ping_query::PingQuery;
 use crate::signer::AnySigner;
 use crate::{
@@ -68,9 +70,10 @@ impl Default for ClientBackoff {
     }
 }
 
-// yes, client is complicated enough for this, even if it's only internal.
-struct ClientBuilder {
-    network: ManagedNetwork,
+/// Builder pattern for creating a client
+pub struct ClientBuilder {
+    endpoint_config: Option<EndpointConfig>,
+    network: ManagedNetworkBuilder,
     operator: Option<Operator>,
     max_transaction_fee: Option<NonZeroU64>,
     max_query_payment: Option<NonZeroU64>,
@@ -82,9 +85,40 @@ struct ClientBuilder {
 }
 
 impl ClientBuilder {
+    /// Construct a client with the given nodes configured.
+    ///
+    /// Note that this disables network auto-updating.
+    pub fn for_addresses(addresses: HashMap<String, AccountId>) -> Self {
+        let network = ManagedNetworkBuilder::Addresses(addresses);
+
+        ClientBuilder::new(network).disable_network_updating()
+    }
+
+    /// Set defaults for a mainnet client
+    pub fn for_mainnet() -> Self {
+        ClientBuilder::new(ManagedNetworkBuilder::Mainnet).ledger_id(Some(LedgerId::mainnet()))
+    }
+
+    /// Set defaults for a previewnet client
+    pub fn for_previewnet() -> Self {
+        ClientBuilder::new(ManagedNetworkBuilder::Previewnet)
+            .ledger_id(Some(LedgerId::previewnet()))
+    }
+
+    /// Set defaults for a testnet client
+    pub fn for_testnet() -> Self {
+        ClientBuilder::new(ManagedNetworkBuilder::Testnet).ledger_id(Some(LedgerId::testnet()))
+    }
+
+    /// Set non-default endpoint configuration
+    pub fn endpoint_config(self, endpoint_config: EndpointConfig) -> Self {
+        Self { endpoint_config: Some(endpoint_config), ..self }
+    }
+
     #[must_use]
-    fn new(network: ManagedNetwork) -> Self {
+    fn new(network: ManagedNetworkBuilder) -> Self {
         Self {
+            endpoint_config: None,
             network,
             operator: None,
             max_transaction_fee: None,
@@ -105,8 +139,10 @@ impl ClientBuilder {
         Self { ledger_id, ..self }
     }
 
-    fn build(self) -> Client {
+    /// Build configured client
+    pub fn build(self) -> crate::Result<Client> {
         let Self {
+            endpoint_config,
             network,
             operator,
             max_transaction_fee,
@@ -118,6 +154,10 @@ impl ClientBuilder {
             backoff,
         } = self;
 
+        let endpoint_config = endpoint_config.unwrap_or_default();
+
+        let network = network.build(endpoint_config)?;
+
         let network_update_tx = match update_network {
             true => network::managed::spawn_network_update(
                 network.clone(),
@@ -127,7 +167,7 @@ impl ClientBuilder {
             false => watch::channel(None).0,
         };
 
-        Client(Arc::new(ClientInner {
+        let client = Client(Arc::new(ClientInner {
             network,
             operator: ArcSwapOption::new(operator.map(Arc::new)),
             max_transaction_fee_tinybar: AtomicU64::new(
@@ -139,7 +179,9 @@ impl ClientBuilder {
             regenerate_transaction_ids: AtomicBool::new(regenerate_transaction_ids),
             network_update_tx,
             backoff: RwLock::new(backoff),
-        }))
+        }));
+
+        Ok(client)
     }
 }
 
@@ -175,9 +217,9 @@ impl Client {
         let client = match network {
             config::Either::Left(network) => Client::for_network(network)?,
             config::Either::Right(it) => match it {
-                config::NetworkName::Mainnet => Client::for_mainnet(),
-                config::NetworkName::Testnet => Client::for_testnet(),
-                config::NetworkName::Previewnet => Client::for_previewnet(),
+                config::NetworkName::Mainnet => Client::for_mainnet()?,
+                config::NetworkName::Testnet => Client::for_testnet()?,
+                config::NetworkName::Previewnet => Client::for_previewnet()?,
             },
         };
 
@@ -234,7 +276,7 @@ impl Client {
     /// # async fn main() {
     /// use hedera::Client;
     ///
-    /// let client = Client::for_testnet();
+    /// let client = Client::for_testnet().unwrap();
     ///
     /// // note: This isn't *guaranteed* in a semver sense, but this is the current result.
     /// let expected = Vec::from(["testnet.mirrornode.hedera.com:443".to_owned()]);
@@ -264,23 +306,21 @@ impl Client {
     /// # Errors
     /// - [`Error::BasicParse`] if an error occurs parsing the configuration.
     // allowed for API compatibility.
-    #[allow(clippy::needless_pass_by_value)]
     pub fn for_network(network: HashMap<String, AccountId>) -> crate::Result<Self> {
-        let network =
-            ManagedNetwork::new(Network::from_addresses(&network)?, MirrorNetwork::default());
-
-        Ok(ClientBuilder::new(network).disable_network_updating().build())
+        ClientBuilder::for_addresses(network).build()
     }
 
     /// Construct a client from a select mirror network
     pub async fn for_mirror_network(mirror_networks: Vec<String>) -> crate::Result<Self> {
         let network_addresses: HashMap<String, AccountId> = HashMap::new();
         let network = ManagedNetwork::new(
-            Network::from_addresses(&network_addresses)?,
+            Network::from_addresses(EndpointConfig::default(), &network_addresses)?,
             MirrorNetwork::from_addresses(mirror_networks.into_iter().map(Cow::Owned).collect()),
         );
 
-        let client = ClientBuilder::new(network).build();
+        let network_builder = ManagedNetworkBuilder::Network(network);
+
+        let client = ClientBuilder::new(network_builder).build()?;
         let address_book = NodeAddressBookQuery::default().execute(&client).await?;
 
         client.set_network_from_address_book(address_book);
@@ -289,23 +329,18 @@ impl Client {
     }
 
     /// Construct a Hiero client pre-configured for mainnet access.
-    #[must_use]
-    pub fn for_mainnet() -> Self {
-        ClientBuilder::new(ManagedNetwork::mainnet()).ledger_id(Some(LedgerId::mainnet())).build()
+    pub fn for_mainnet() -> crate::Result<Self> {
+        ClientBuilder::for_mainnet().build()
     }
 
     /// Construct a Hiero client pre-configured for testnet access.
-    #[must_use]
-    pub fn for_testnet() -> Self {
-        ClientBuilder::new(ManagedNetwork::testnet()).ledger_id(Some(LedgerId::testnet())).build()
+    pub fn for_testnet() -> crate::Result<Self> {
+        ClientBuilder::for_testnet().build()
     }
 
     /// Construct a Hiero client pre-configured for previewnet access.
-    #[must_use]
-    pub fn for_previewnet() -> Self {
-        ClientBuilder::new(ManagedNetwork::previewnet())
-            .ledger_id(Some(LedgerId::previewnet()))
-            .build()
+    pub fn for_previewnet() -> crate::Result<Self> {
+        ClientBuilder::for_previewnet().build()
     }
 
     /// Updates the network to use the given address book.
@@ -381,9 +416,9 @@ impl Client {
     /// - [`Error::BasicParse`] if the network name is not a supported network name.
     pub fn for_name(name: &str) -> crate::Result<Self> {
         match name {
-            "mainnet" => Ok(Self::for_mainnet()),
-            "testnet" => Ok(Self::for_testnet()),
-            "previewnet" => Ok(Self::for_previewnet()),
+            "mainnet" => Ok(Self::for_mainnet()?),
+            "testnet" => Ok(Self::for_testnet()?),
+            "previewnet" => Ok(Self::for_previewnet()?),
             "localhost" => {
                 let mut network: HashMap<String, AccountId> = HashMap::new();
                 network.insert("127.0.0.1:50211".to_string(), AccountId::new(0, 0, 3));

--- a/src/client/network/managed.rs
+++ b/src/client/network/managed.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use rand::Rng;
@@ -6,7 +7,37 @@ use triomphe::Arc;
 
 use super::mirror::MirrorNetwork;
 use super::Network;
-use crate::NodeAddressBookQuery;
+use crate::client::config::EndpointConfig;
+use crate::{
+    AccountId,
+    NodeAddressBookQuery,
+};
+
+pub(crate) enum ManagedNetworkBuilder {
+    Addresses(HashMap<String, AccountId>),
+    Network(ManagedNetwork),
+    Mainnet,
+    Previewnet,
+    Testnet,
+}
+
+impl ManagedNetworkBuilder {
+    pub(crate) fn build(self, endpoint_config: EndpointConfig) -> crate::Result<ManagedNetwork> {
+        let managed = match self {
+            Self::Addresses(addresses) => {
+                let network = Network::from_addresses(endpoint_config, &addresses)?;
+
+                ManagedNetwork::new(network, MirrorNetwork::default())
+            }
+            Self::Network(network) => network,
+            Self::Mainnet => ManagedNetwork::mainnet(endpoint_config),
+            Self::Previewnet => ManagedNetwork::previewnet(endpoint_config),
+            Self::Testnet => ManagedNetwork::testnet(endpoint_config),
+        };
+
+        Ok(managed)
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct ManagedNetwork(Arc<ManagedNetworkInner>);
@@ -23,16 +54,16 @@ impl ManagedNetwork {
         Self(Arc::new(ManagedNetworkInner { primary, mirror }))
     }
 
-    pub(crate) fn mainnet() -> Self {
-        Self::new(Network::mainnet(), MirrorNetwork::mainnet())
+    pub(crate) fn mainnet(endpoint_config: EndpointConfig) -> Self {
+        Self::new(Network::mainnet(endpoint_config), MirrorNetwork::mainnet())
     }
 
-    pub(crate) fn testnet() -> Self {
-        Self::new(Network::testnet(), MirrorNetwork::testnet())
+    pub(crate) fn testnet(endpoint_config: EndpointConfig) -> Self {
+        Self::new(Network::testnet(endpoint_config), MirrorNetwork::testnet())
     }
 
-    pub(crate) fn previewnet() -> Self {
-        Self::new(Network::previewnet(), MirrorNetwork::previewnet())
+    pub(crate) fn previewnet(endpoint_config: EndpointConfig) -> Self {
+        Self::new(Network::previewnet(endpoint_config), MirrorNetwork::previewnet())
     }
 }
 

--- a/src/client/network/mod.rs
+++ b/src/client/network/mod.rs
@@ -27,6 +27,7 @@ use tonic::transport::{
 };
 use triomphe::Arc;
 
+use crate::client::config::EndpointConfig;
 use crate::{
     AccountId,
     ArcSwap,
@@ -90,20 +91,23 @@ pub(crate) const PREVIEWNET: &[(u64, &[&str])] = &[
 pub(crate) struct Network(pub(crate) ArcSwap<NetworkData>);
 
 impl Network {
-    pub(super) fn mainnet() -> Self {
-        NetworkData::from_static(MAINNET).into()
+    pub(super) fn mainnet(endpoint_config: EndpointConfig) -> Self {
+        NetworkData::from_static(endpoint_config, MAINNET).into()
     }
 
-    pub(super) fn testnet() -> Self {
-        NetworkData::from_static(TESTNET).into()
+    pub(super) fn testnet(endpoint_config: EndpointConfig) -> Self {
+        NetworkData::from_static(endpoint_config, TESTNET).into()
     }
 
-    pub(super) fn previewnet() -> Self {
-        NetworkData::from_static(PREVIEWNET).into()
+    pub(super) fn previewnet(endpoint_config: EndpointConfig) -> Self {
+        NetworkData::from_static(endpoint_config, PREVIEWNET).into()
     }
 
-    pub(super) fn from_addresses(addresses: &HashMap<String, AccountId>) -> crate::Result<Self> {
-        Ok(NetworkData::from_addresses(addresses)?.into())
+    pub(super) fn from_addresses(
+        endpoint_config: EndpointConfig,
+        addresses: &HashMap<String, AccountId>,
+    ) -> crate::Result<Self> {
+        Ok(NetworkData::from_addresses(endpoint_config, addresses)?.into())
     }
 
     fn try_rcu<T: Into<Arc<NetworkData>>, E, F: FnMut(&Arc<NetworkData>) -> Result<T, E>>(
@@ -155,9 +159,9 @@ impl From<NetworkData> for Network {
     }
 }
 
-// note: `Default` here is mostly only useful so that we don't need to implement `from_addresses` twice, notably this doesn't allocate.
 #[derive(Default)]
 pub(crate) struct NetworkData {
+    endpoint_config: Arc<EndpointConfig>,
     map: HashMap<AccountId, usize>,
     node_ids: Box<[AccountId]>,
     backoff: RwLock<NodeBackoff>,
@@ -167,11 +171,31 @@ pub(crate) struct NetworkData {
 }
 
 impl NetworkData {
-    pub(crate) fn from_addresses(addresses: &HashMap<String, AccountId>) -> crate::Result<Self> {
-        Self::default().with_addresses(addresses)
+    fn empty(endpoint_config: EndpointConfig) -> Self {
+        Self {
+            endpoint_config: Arc::new(endpoint_config),
+            map: Default::default(),
+            node_ids: Default::default(),
+            backoff: Default::default(),
+            health: Default::default(),
+            connections: Default::default(),
+        }
     }
 
-    pub(crate) fn from_static(network: &'static [(u64, &'static [&'static str])]) -> Self {
+    pub(crate) fn from_addresses(
+        endpoint_config: EndpointConfig,
+        addresses: &HashMap<String, AccountId>,
+    ) -> crate::Result<Self> {
+        let this = Self::empty(endpoint_config);
+
+        this.with_addresses(addresses)
+    }
+
+    pub(crate) fn from_static(
+        endpoint_config: EndpointConfig,
+        network: &'static [(u64, &'static [&'static str])],
+    ) -> Self {
+        let endpoint_config = Arc::new(endpoint_config);
         let mut map = HashMap::with_capacity(network.len());
         let mut node_ids = Vec::with_capacity(network.len());
         let mut connections = Vec::with_capacity(network.len());
@@ -183,10 +207,11 @@ impl NetworkData {
             map.insert(node_account_id, i);
             node_ids.push(node_account_id);
             health.push(Arc::default());
-            connections.push(NodeConnection::new_static(address));
+            connections.push(NodeConnection::new_static(endpoint_config.clone(), address));
         }
 
         Self {
+            endpoint_config,
             map,
             node_ids: node_ids.into_boxed_slice(),
             health: health.into_boxed_slice(),
@@ -211,24 +236,29 @@ impl NetworkData {
                 .map(|it| (*it.ip()).into())
                 .collect();
 
+            let config = old.endpoint_config.clone();
+
             // if the node is the exact same we want to reuse everything (namely the connections and `healthy`).
             // if the node has different routes then we still want to reuse `healthy` but replace the channel with a new channel.
             // if the node just flat out doesn't exist in `old`, we want to add the new node.
             // and, last but not least, if the node doesn't exist in `new` we want to get rid of it.
             let upsert = match old.map.get(&address.node_account_id) {
                 Some(&account) => {
-                    let connection =
-                        match old.connections[account].addresses.symmetric_difference(&new).count()
-                        {
-                            0 => old.connections[account].clone(),
-                            _ => NodeConnection { addresses: new, channel: OnceCell::new() },
-                        };
+                    let connection = match old.connections[account]
+                        .addresses
+                        .symmetric_difference(&new)
+                        .count()
+                    {
+                        0 => old.connections[account].clone(),
+                        _ => NodeConnection { config, addresses: new, channel: OnceCell::new() },
+                    };
 
                     (old.health[account].clone(), connection)
                 }
-                None => {
-                    (Arc::default(), NodeConnection { addresses: new, channel: OnceCell::new() })
-                }
+                None => (
+                    Arc::default(),
+                    NodeConnection { config, addresses: new, channel: OnceCell::new() },
+                ),
             };
 
             map.insert(address.node_account_id, i);
@@ -238,6 +268,7 @@ impl NetworkData {
         }
 
         Self {
+            endpoint_config: old.endpoint_config.clone(),
             map,
             node_ids: node_ids.into_boxed_slice(),
             health: health.into_boxed_slice(),
@@ -267,6 +298,7 @@ impl NetworkData {
                     node_ids.push(*node);
                     // fixme: keep the channel around more.
                     connections.push(NodeConnection {
+                        config: self.endpoint_config.clone(),
                         addresses: BTreeSet::from([address]),
                         channel: OnceCell::new(),
                     });
@@ -280,6 +312,7 @@ impl NetworkData {
         }
 
         Ok(Self {
+            endpoint_config: self.endpoint_config.clone(),
             map,
             node_ids: node_ids.into_boxed_slice(),
             health: health.into_boxed_slice(),
@@ -553,6 +586,7 @@ impl From<Ipv4Addr> for HostAndPort {
 
 #[derive(Clone)]
 struct NodeConnection {
+    config: Arc<EndpointConfig>,
     addresses: BTreeSet<HostAndPort>,
     channel: OnceCell<Channel>,
 }
@@ -560,8 +594,9 @@ struct NodeConnection {
 impl NodeConnection {
     const PLAINTEXT_PORT: u16 = 50211;
 
-    fn new_static(addresses: &[&'static str]) -> NodeConnection {
+    fn new_static(config: Arc<EndpointConfig>, addresses: &[&'static str]) -> NodeConnection {
         Self {
+            config,
             addresses: addresses.iter().copied().map(HostAndPort::from_static).collect(),
             channel: OnceCell::default(),
         }
@@ -572,12 +607,9 @@ impl NodeConnection {
             .channel
             .get_or_init(|| {
                 let addresses = self.addresses.iter().map(|it| {
-                    Endpoint::from_shared(format!("tcp://{it}"))
-                        .unwrap()
-                        .keep_alive_timeout(Duration::from_secs(10))
-                        .keep_alive_while_idle(true)
-                        .tcp_keepalive(Some(Duration::from_secs(10)))
-                        .connect_timeout(Duration::from_secs(10))
+                    let endpoint = Endpoint::from_shared(format!("tcp://{it}")).unwrap();
+
+                    self.config.apply(endpoint)
                 });
 
                 Channel::balance_list(addresses)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,8 +171,12 @@ pub use address_book::{
     NodeDeleteTransaction,
     NodeUpdateTransaction,
 };
-pub use client::Client;
 pub(crate) use client::Operator;
+pub use client::{
+    Client,
+    ClientBuilder,
+    EndpointConfig,
+};
 pub use contract::{
     ContractBytecodeQuery,
     ContractCallQuery,

--- a/src/transaction/tests.rs
+++ b/src/transaction/tests.rs
@@ -95,7 +95,7 @@ fn from_bytes_sign_to_bytes() -> crate::Result<()> {
 
 #[tokio::test]
 async fn chunked_to_from_bytes() -> crate::Result<()> {
-    let client = Client::for_testnet();
+    let client = Client::for_testnet()?;
     client.set_operator(0.into(), PrivateKey::generate_ed25519());
 
     let bytes = TopicMessageSubmitTransaction::new()

--- a/tests/e2e/common/mod.rs
+++ b/tests/e2e/common/mod.rs
@@ -31,9 +31,9 @@ fn client() -> Client {
     let config = &*CONFIG;
 
     let client = match &*config.network_name {
-        "mainnet" => Client::for_mainnet(),
-        "testnet" => Client::for_testnet(),
-        "previewnet" => Client::for_previewnet(),
+        "mainnet" => Client::for_mainnet().unwrap(),
+        "testnet" => Client::for_testnet().unwrap(),
+        "previewnet" => Client::for_previewnet().unwrap(),
         "localhost" => for_local_node(),
         _ => {
             // to ensure we don't spam the logs with `Error creating client: ...`,
@@ -48,7 +48,7 @@ fn client() -> Client {
                 );
             }
 
-            Client::for_testnet()
+            Client::for_testnet().unwrap()
         }
     };
 


### PR DESCRIPTION
**Description**:
Make characteristics of the gRPC connections,  such as keep alives and timeouts, configurable via `ClientBuilder`.

* Add a new `EndpointConfig` struct with configuration values for the `tonic` `Endpoint` instances that will be created later
* Add a new `endpoint_config` method on `ClientBuilder` to override the default configuration
* Make `ClientBuilder` public
* Add a new private `ManagedNetworkBuilder` enum which is accepted by `ClientBuilder` instead of `ManagedNetwork` - allowing construction of `ManagedNetwork` to be delayed until `ClientBuilder::build` is called, since `ManagedNetwork` requires `EndpointConfig`

All of the `Client` constructor methods now return `Result<Self, _>` instead of simply `Self` - this is due to the delayed parsing of the keys of `HashMap<String, AccountId>` into `HostPort`, and could be avoided if usage of `HashMap<String, AccountId>` were replaced with `HashMap<HostPort, AccountId>` (or `HashMap<HostPort, EntityId>`).

**Related issue(s)**:

https://github.com/hashgraph/hedera-sdk-rust/issues/833
https://github.com/hashgraph/hedera-sdk-rust/issues/834

**Notes for reviewer**:

The node endpoint configuration capability is applicable to any combination of network nodes - both the preconfigured networks (mainnet, testnet, and previewnet), and custom networks. It would be possible, but inconvenient, to add a means to set endpoint configuration on either a `Client` instance or on one of the `Client` constructor methods.

Instead, this PR makes `ClientBuilder` public and adds a method to the builder to override the default endpoint configuration.

Tonic's `Endpoint` instances are setup when `NodeConnection` creates a channel:

https://github.com/hashgraph/hedera-sdk-rust/blob/40cc835628347772ca1cc71b9d860e2a4c3b1214/src/client/network/mod.rs#L587-L598

Each `NodeConnection` is created in either `NetworkData::from_addresses` or `NetworkData::with_address_book`

_Constructor call sites_

`NetworkData::from_addresses` is typically called during initial creation of a `Client` via a constructor method on `Client`

Example: https://github.com/hashgraph/hedera-sdk-rust/blob/40cc835628347772ca1cc71b9d860e2a4c3b1214/src/client/mod.rs#L285-L290

_Dynamic network update call sites_

`NetworkData::with_address_book` is a part of the dynamic network update process where a client can periodically alter its preferred choice of nodes, though it can also be called via `Client::set_network_from_address_book` on a client instance.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
