### PR TITLE
fix: Restore transient error detection for canceled hyper requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "hmac",
+ "hyper 0.14.30",
  "hyper 1.4.1",
  "k256",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ hedera-proto = { path = "./protobufs", version = "0.13.0", features = [
 ] }
 hex = "0.4.3"
 hmac = "0.12.1"
+# Dependency of tonic 0.11. Can be removed when tonic is upgraded to 0.12.
+hyper_0 = { package = "hyper", version = "0.14", default-features = false }
+# Dependency of tonic 0.12
+hyper = { version = "1.3.1", default-features = false }
 log = "0.4.17"
 num-bigint = "0.4.3"
 once_cell = "1.10.0"
@@ -52,7 +56,6 @@ parking_lot = "0.12.0"
 serde_json = { version = "1.0.96", optional = true }
 serde = { version = "1.0.163", optional = true }
 serde_derive = { version = "1.0.163", optional = true }
-hyper = { version = "1.3.1", default-features = false }
 pem = "3.0.1"
 cbc = "0.1.2"
 aes = "0.8.3"
@@ -80,7 +83,7 @@ features = ["ecdsa", "precomputed-tables", "std"]
 
 [dependencies.pkcs8]
 version = "0.10.0"
-default_features = false
+default-features = false
 features = ["encryption"]
 
 [dependencies.triomphe]

--- a/src/execute/error.rs
+++ b/src/execute/error.rs
@@ -1,0 +1,69 @@
+/*
+ * ‌
+ * Hedera Rust SDK
+ * ​
+ * Copyright (C) 2022 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+use std::error::Error;
+
+use serde::de::StdError;
+
+/// Punches through all the layers of `tonic::Status` sources to check if this is a `hyper::Error` that is canceled.
+pub(super) fn is_hyper_canceled(status: &tonic::Status) -> bool {
+    let source = status
+        .source()
+        .and_then(|it| it.downcast_ref::<tonic::transport::Error>())
+        .and_then(StdError::source);
+
+    let Some(source) = source else {
+        return false;
+    };
+
+    if let Some(hyper_0) = source.downcast_ref::<hyper_0::Error>() {
+        // tonic 0.11 (current dependency)
+        hyper_0.is_canceled()
+    } else if let Some(hyper_1) = source.downcast_ref::<hyper::Error>() {
+        // tonic 0.12
+        hyper_1.is_canceled()
+    } else {
+        false
+    }
+}
+
+/// Tests some non-detection scenarios.
+///
+/// Because hyper does not expose constructors for its error variants, there is no
+/// reasonable way to construct a test for positive detection of a hyper cancellation.
+#[cfg(test)]
+mod test_is_hyper_canceled {
+    use tonic::Code;
+
+    use super::is_hyper_canceled;
+
+    #[test]
+    fn ignores_tonic_abort() {
+        let input = tonic::Status::new(Code::Aborted, "foo");
+
+        assert!(!is_hyper_canceled(&input));
+    }
+
+    #[test]
+    fn ignores_tonic_cancel() {
+        let input = tonic::Status::new(Code::Cancelled, "foo");
+
+        assert!(!is_hyper_canceled(&input));
+    }
+}


### PR DESCRIPTION
**Description**:

The crate used to, but now fails to, detect gRPC requests that failed with a tonic error wrapping a hyper error where the hyper error was in a "cancelled" state.

This detection mechanism uses `downcast` to inspect a source (inner) error, and broke when `hyper` was upgraded from `0.14.x` to `1.x` on 4/26 in https://github.com/hashgraph/hedera-sdk-rust/commit/2445034b12e4d5b4a5aff486a7856e166221bbb1.

cc @RickyLB / @mehcode 

`tonic 0.11`, the current dependency, and `tonic 0.9`, the previous dependency before that commit, both depend on `hyper 0.14`, and the downcast to a hyper 1.x `Error` type will not return the hyper 0.14.x `Error` type wrapped by tonic.

This PR modifies `is_hyper_canceled` to check for the `Error` type from both versions of hyper.

**Alternatives Considered**

* Simply downgrade back to hyper 0.14. However, when tonic is upgraded from 0.11 to 0.12 it would be easy to forget, and the compiler would not warn you about, that downcast being broken again.
* Add more tests - for positive detection of the canceled error state. This is made excessively difficult by the choice of the `hyper` crate maintainers to not provide public constructors for error variants

Fixes #

**Notes for reviewer**:

This fixes the backoff/retry mechanism in the context of connection failures, such as:

```text
Execution of hedera::ping_query::PingQuery on node at index 4 / node id 0.0.7 failed due to Permanent(GrpcStatus(Status { code: Unknown, message: "transport error", source: Some(tonic::transport::Error(Transport, hyper::Error(Canceled, "connection was not ready"))) }))
```

That error should be retried, but is not, because the hyper error in a canceled state is not detected.

Logs after this PR is applied (and before the broken hyper upgrade linked above was applied):

```
2024-09-08T20:51:48.375888Z DEBUG hedera::execute: Preparing hedera::query::Query<hedera::account::account_balance_query::AccountBalanceQueryData> on node at index 3 / node id 0.0.6    
2024-09-08T20:51:48.375938Z DEBUG hedera::execute: Executing hedera::query::Query<hedera::account::account_balance_query::AccountBalanceQueryData> on node at index 3 / node id 0.0.6    
2024-09-08T20:51:48.377356Z  WARN hedera::execute: Execution of hedera::query::Query<hedera::account::account_balance_query::AccountBalanceQueryData> on node at index 3 / node id 0.0.6 will continue due to GrpcStatus(Status { code: Unknown, message: "transport error", source: Some(tonic::transport::Error(Transport, hyper::Error(Canceled, "connection closed"))) })    
2024-09-08T20:51:48.377530Z DEBUG hedera::execute: Preparing hedera::query::Query<hedera::account::account_balance_query::AccountBalanceQueryData> on node at index 1 / node id 0.0.4    
2024-09-08T20:51:48.377571Z DEBUG hedera::execute: Executing hedera::query::Query<hedera::account::account_balance_query::AccountBalanceQueryData> on node at index 1 / node id 0.0.4    
2024-09-08T20:51:48.463582Z DEBUG hedera::execute: Execution of hedera::query::Query<hedera::account::account_balance_query::AccountBalanceQueryData> on node at index 1 / node id 0.0.4 succeeded
```

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
