### PR TITLE
ops: Adjust log level of Error::Transient/EmptyTransient to Level::Warn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ features = ["ecdsa", "precomputed-tables", "std"]
 
 [dependencies.pkcs8]
 version = "0.10.0"
-default_features = false
+default-features = false
 features = ["encryption"]
 
 [dependencies.triomphe]

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -274,7 +274,12 @@ where
                     match &tmp {
                         Ok(ControlFlow::Break(_)) => log::Level::Debug,
                         Ok(ControlFlow::Continue(_)) => log::Level::Warn,
-                        Err(_) => log::Level::Error,
+                        Err(e) =>
+                            if e.is_transient() {
+                                log::Level::Warn
+                            } else {
+                                log::Level::Error
+                            },
                     },
                     "Execution of {} on node at index {node_index} / node id {} {}",
                     type_name::<E>(),

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -13,6 +13,16 @@ pub(crate) enum Error {
     EmptyTransient,
 }
 
+impl Error {
+    pub(crate) fn is_transient(&self) -> bool {
+        match self {
+            Error::Transient(_) => true,
+            Error::Permanent(_) => false,
+            Error::EmptyTransient => true,
+        }
+    }
+}
+
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 /// Durably retry some function according to the `backoff` until the backoff expires.


### PR DESCRIPTION
**Description**:

Within `execute_inner` and `execute_single` an error classified with `ControlFlow::Continue` will be considered transient, logged with `Level::Warn`, and retried. Errors classified with `hedera::retry::Error::Transient` (and `::EmptyTransient`) are also retried with the same backoff strategy, but logged as `Level::Error`.

Change `execute_inner` to log `hedera::retry::Error::Transient` and `hedera::retry::Error::EmptyTransient` as warnings but continue logging `hedera::retry::Error::Permanent` as an error.

**Related issue(s)**:

n/a

**Notes for reviewer**:

No changes are made to which responses are classified as transient; this only changes how they are logged.

Example log entry that will be reclassified as a warning instead of an error:

```text
Execution of hedera::query::Query<hedera::transaction_receipt_query::TransactionReceiptQueryData> on node at index 13 / node id 0.0.21 failed due to Transient(QueryPreCheckStatus { status: Ok, transaction_id: "0.0.3296704@1725752916.437806799" })
```

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
