### PR TITLE
Add `exchange_rates` to TransactionReceipt

### DIFF
--- a/src/exchange_rates.rs
+++ b/src/exchange_rates.rs
@@ -22,6 +22,7 @@ use hedera_proto::services;
 use time::OffsetDateTime;
 
 use crate::protobuf::FromProtobuf;
+use crate::ToProtobuf;
 
 /// The current and next exchange rates between [`Hbar`](crate::HbarUnit::Hbar) and USD-cents.
 #[derive(Debug, Clone)]
@@ -52,6 +53,17 @@ impl FromProtobuf<services::ExchangeRateSet> for ExchangeRates {
     }
 }
 
+impl ToProtobuf for ExchangeRates {
+    type Protobuf = services::ExchangeRateSet;
+
+    fn to_protobuf(&self) -> Self::Protobuf {
+        services::ExchangeRateSet {
+            current_rate: Some(self.current_rate.to_protobuf()),
+            next_rate: Some(self.next_rate.to_protobuf()),
+        }
+    }
+}
+
 /// Denotes a conversion between Hbars and cents (USD).
 #[derive(Debug, Clone)]
 pub struct ExchangeRate {
@@ -79,6 +91,18 @@ impl FromProtobuf<services::ExchangeRate> for ExchangeRate {
         let cents = pb.cent_equiv as u32;
 
         Ok(Self { hbars, cents, expiration_time: pb_getf!(pb, expiration_time)?.into() })
+    }
+}
+
+impl ToProtobuf for ExchangeRate {
+    type Protobuf = services::ExchangeRate;
+
+    fn to_protobuf(&self) -> Self::Protobuf {
+        services::ExchangeRate {
+            hbar_equiv: self.hbars as i32,
+            cent_equiv: self.cents as i32,
+            expiration_time: Some(self.expiration_time.into()),
+        }
     }
 }
 

--- a/src/snapshots/transaction_record/serialize.txt
+++ b/src/snapshots/transaction_record/serialize.txt
@@ -31,7 +31,32 @@ TransactionRecord {
                     ),
                 },
             ),
-            exchange_rate: None,
+            exchange_rate: Some(
+                ExchangeRateSet {
+                    current_rate: Some(
+                        ExchangeRate {
+                            hbar_equiv: 100,
+                            cent_equiv: 100,
+                            expiration_time: Some(
+                                TimestampSeconds {
+                                    seconds: 1554158542,
+                                },
+                            ),
+                        },
+                    ),
+                    next_rate: Some(
+                        ExchangeRate {
+                            hbar_equiv: 200,
+                            cent_equiv: 200,
+                            expiration_time: Some(
+                                TimestampSeconds {
+                                    seconds: 1554158542,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
             topic_id: Some(
                 TopicId {
                     shard_num: 9,

--- a/src/snapshots/transaction_record/serialize2.txt
+++ b/src/snapshots/transaction_record/serialize2.txt
@@ -31,7 +31,32 @@ TransactionRecord {
                     ),
                 },
             ),
-            exchange_rate: None,
+            exchange_rate: Some(
+                ExchangeRateSet {
+                    current_rate: Some(
+                        ExchangeRate {
+                            hbar_equiv: 100,
+                            cent_equiv: 100,
+                            expiration_time: Some(
+                                TimestampSeconds {
+                                    seconds: 1554158542,
+                                },
+                            ),
+                        },
+                    ),
+                    next_rate: Some(
+                        ExchangeRate {
+                            hbar_equiv: 200,
+                            cent_equiv: 200,
+                            expiration_time: Some(
+                                TimestampSeconds {
+                                    seconds: 1554158542,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
             topic_id: Some(
                 TopicId {
                     shard_num: 9,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR adds the optional field `exchange_rates` (consisting of `current_rate` and `next_rate`) to `TransactionReceipt` responses. Serialization and deserialization of this new field has been tested. 

**Related issue(s)**:
- https://github.com/hashgraph/hedera-sdk-rust/issues/873

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
