### PR TITLE
chore: Update dependabot.yml for additional envs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,12 @@ updates:
           interval: "daily"
       open-pull-requests-limit: 10
     - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      open-pull-requests-limit: 5
     - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,13 @@ updates:
       schedule:
           interval: "daily"
       open-pull-requests-limit: 10
+    - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Update dependabot.yml to include gradle and cargo envs.

Related Issue(s):

Fixes #811