### PR TITLE
ci: add dual publishing for rust SDK

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -75,6 +75,7 @@ jobs:
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Setup GCC and OpenSSL
         run: |
@@ -118,7 +118,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start the local node
-        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
+        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.63.7
 
       - name: "Create env file"
         run: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -118,7 +118,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start the local node
-        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.63.7
+        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
 
       - name: "Create env file"
         run: |

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -178,8 +178,8 @@ jobs:
             exit 1
           fi
           
-          if [[ "${{ steps.sdk-tag.outputs.prerelease }}" != "production" && "${{ steps.sdk-tag.outputs.prerelease }}" != "beta" ]]; then
-            echo "::error title=Invalid Prerelease Type::The prerelease type '${{ steps.sdk-tag.outputs.prerelease }}' is not valid. Expected 'production' or 'beta'."
+          if [[ "${{ steps.sdk-tag.outputs.type }}" != "production" && "${{ steps.sdk-tag.outputs.type }}" != "beta" ]]; then
+            echo "::error title=Invalid Prerelease Type::The prerelease type '${{ steps.sdk-tag.outputs.type }}' is not valid. Expected 'production' or 'beta'."
             exit 1
           fi
 

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -79,8 +79,8 @@ jobs:
       - name: Extract Cargo.toml Versions
         id: cargo-versions
         run: |
-          SDK_PACKAGE_VERSION="$(toml get Cargo.toml package.version --raw)"
-          SDK_PROTO_VERSION="$(toml get protobufs/Cargo.toml package.version --raw)"
+          SDK_PACKAGE_VERSION="$(toml get Cargo.toml package.version)"
+          SDK_PROTO_VERSION="$(toml get protobufs/Cargo.toml package.version)"
           
           echo "sdk-version=${SDK_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "sdk-proto-version=${SDK_PROTO_VERSION}" >>"${GITHUB_OUTPUT}"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -29,11 +29,24 @@ jobs:
 
     outputs:
       # Project tag
-      tag: ${{ steps.tag.outputs.name }}
+      tag: ${{ steps.sdk-tag.outputs.name }}
+
       # main package
-      sdk-version: ${{ steps.tag.outputs.version }}
-      sdk-prerelease: ${{ steps.tag.outputs.prerelease }}
-      sdk-type: ${{ steps.tag.outputs.type }}
+      sdk-version: ${{ steps.sdk-tag.outputs.version }}
+      sdk-prerelease: ${{ steps.sdk-tag.outputs.prerelease }}
+      sdk-type: ${{ steps.sdk-tag.outputs.type }}
+
+      # proto subpackage
+      proto-version: ${{ steps.cargo-versions.outputs.sdk-proto-version }}
+      proto-prerelease: ${{ steps.proto-tag.outputs.prerelease }}
+      proto-type: ${{ steps.proto-tag.outputs.type }}
+      proto-publish-required: ${{ steps.proto-required.outputs.proto-publish-required }}
+
+      # tck subpackage
+      tck-version: ${{ steps.cargo-versions.outputs.sdk-tck-version }}
+      tck-prerelease: ${{ steps.tck-tag.outputs.prerelease }}
+      tck-type: ${{ steps.tck-tag.outputs.type }}
+      tck-publish-required: ${{ steps.tck-required.outputs.tck-publish-required }}
 
     steps:
       - name: Harden Runner
@@ -89,8 +102,17 @@ jobs:
           done
           echo "proto-publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
 
+      - name: TCK Subpackage Publish Required
+        id: tck-required
+        run: |
+          PUBLISH_REQUIRED="false"
+          if ! curl -sSLf "https://crates.io/api/v1/crates/hiero-sdk-tck/${{ steps.cargo-versions.outputs.sdk-tck-version }}" >/dev/null 2>&1;
+            PUBLISH_REQUIRED="true"
+          fi
+          echo "tck-publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
+
       - name: Extract SDK Tag Information
-        id: tag
+        id: sdk-tag
         run: |
           REF_NAME="$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))"
           IS_VALID_SEMVER="$(semver validate "${REF_NAME}")"
@@ -98,9 +120,11 @@ jobs:
             echo "::error title=Invalid Tag::The tag '${REF_NAME}' is not a valid SemVer tag."
             exit 1
           fi
+
           RELEASE_VERSION="$(semver get release "${REF_NAME}")"
           PREREL_VERSION="$(semver get prerel "${REF_NAME}")"
           PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
+
           IS_PRERELEASE="false"
           [[ -n "${PREREL_VERSION}" ]] && IS_PRERELEASE="true"
           PREREL_TYPE="unknown"
@@ -113,13 +137,124 @@ jobs:
           else
             PREREL_TYPE="production"
           fi
+
           FINAL_VERSION="${RELEASE_VERSION}"
           [[ -n "${PREREL_VERSION}" ]] && FINAL_VERSION="${RELEASE_VERSION}-${PREREL_VERSION}"
+
           TAG_NAME="v${FINAL_VERSION}"
-          echo "name=${TAG_NAME}" >>"${GITHUB_OUTPUT}"
-          echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
+          
+          echo "name=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "version=${FINAL_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "prerelease=${IS_PRERELEASE}" >> "${GITHUB_OUTPUT}"
+          echo "type=${PREREL_TYPE}" >> "${GITHUB_OUTPUT}"
+          
+          echo "## Release Information" >> "${GITHUB_STEP_SUMMARY}"
+          echo "SDK_VERSION=${FINAL_VERSION}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Extract Proto Subpackage Information
+        id: proto-tag
+        run: |
+          IS_VALID_SEMVER="$(semver validate "${{ steps.cargo-versions.outputs.sdk-proto-version }}")"
+          
+          if [[ "${IS_VALID_SEMVER}" != "valid" ]]; then
+            echo "::error title=Invalid Proto Tag::The proto version '${{ steps.cargo-versions.outputs.sdk-proto-version }}' is not a valid SemVer tag."
+            exit 1
+          fi
+          
+          PREREL_VERSION="$(semver get prerel '${{ steps.cargo-versions.outputs.sdk-proto-version }}')"
+          PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
+          
+          IS_PRERELEASE="false"
+          [[ -n "${PREREL_VERSION}" ]] && IS_PRERELEASE="true"
+          
+          PREREL_TYPE="unknown"
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            if [[ "${PREREL_VERSION_LC}" =~ "beta" ]]; then
+              PREREL_TYPE="beta"
+            else
+              PREREL_TYPE="unknown"
+            fi
+          else
+            PREREL_TYPE="production"
+          fi
+
           echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
           echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
+          
+          echo "## Proto Subpackage Release Information" >> "${GITHUB_STEP_SUMMARY}"
+          echo "SDK_PROTO_VERSION=${{ steps.cargo-versions.outputs.sdk-proto-version }}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Extract TCK Subpackage Information
+        id: tck-tag
+        run: |
+          IS_VALID_SEMVER="$(semver validate "${{ steps.cargo-versions.outputs.sdk-tck-version }}")"
+          
+          if [[ "${IS_VALID_SEMVER}" != "valid" ]]; then
+            echo "::error title=Invalid TCK Tag::The proto version '${{ steps.cargo-versions.outputs.sdk-tck-version }}' is not a valid SemVer tag."
+            exit 1
+          fi
+          
+          PREREL_VERSION="$(semver get prerel '${{ steps.cargo-versions.outputs.sdk-tck-version }}')"
+          PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
+          
+          IS_PRERELEASE="false"
+          [[ -n "${PREREL_VERSION}" ]] && IS_PRERELEASE="true"
+          
+          PREREL_TYPE="unknown"
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            if [[ "${PREREL_VERSION_LC}" =~ "beta" ]]; then
+              PREREL_TYPE="beta"
+            else
+              PREREL_TYPE="unknown"
+            fi
+          else
+            PREREL_TYPE="production"
+          fi
+
+          echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
+          echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
+          
+          echo "## TCK Subpackage Release Information" >> "${GITHUB_STEP_SUMMARY}"
+          echo "SDK_TCK_VERSION=${{ steps.cargo-versions.outputs.sdk-tck-version }}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Validate Tag and Cargo.toml Versions
+        run: |
+          COMPARISON_RESULT="$(semver compare "${{ steps.cargo-versions.outputs.sdk-version }}" "{{ steps.sdk-tag.outputs.version }}")"
+          if [[ "${COMPARISON_RESULT}" -ne 0 ]]; then
+            echo "::error title=Version Mismatch::The Cargo.toml version '${{ steps.cargo-versions.outputs.sdk-version }}' does not match the tag version '${{ steps.sdk-tag.outputs.version }}'."
+            exit 1
+          fi
+          
+          if [[ "${{ steps.sdk-tag.outputs.prerelease }}" != "production" && "{{ steps.sdk-tag.outputs.prerelease }}" != "beta" ]]; then
+            echo "::error title=Invalid Prerelease Type::The prerelease type '${{ steps.sdk-tag.outputs.prerelease }}' is not valid. Expected 'production' or 'beta'."
+            exit 1
+          fi
+
+  run-safety-checks:
+    name: Safety Checks
+    runs-on: hiero-client-sdk-linux-medium
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.inputs.tag || '' }}
+          submodules: recursive
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
+        with:
+          toolchain: 1.88.0
+
+      - name: Run Safety Checks
+        run: |
+          echo "::group::Run Safety Checks"
+          cargo check
+          echo "::endgroup::"
 
   publish:
     name: Publish SDK to crates.io

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -317,37 +317,18 @@ jobs:
           toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
           # Update the dependencies in the main Cargo.toml
-          # TODO: Remove the path dependency on the protobufs package after hiero-sdk-proto is published
-          toml set Cargo.toml dependencies.hiero-sdk-proto.path "protobufs" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          toml set Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          toml set Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          toml set Cargo.toml dependencies.hiero-sdk-proto.features "['time_0_3', 'fraction']" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          
-          # Convert features from string to array format
-          sed -i "s/features = \"\['time_0_3', 'fraction'\]\"/features = [\"time_0_3\", \"fraction\"]/g" Cargo.toml
-          
-          # Remove the hedera-proto dependency from the main Cargo.toml
-          sed '/hedera-proto.*/d' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          sed -i "s/hedera-proto/hiero-sdk-proto/g" Cargo.toml
+
           echo "::endgroup::"
           
           echo "::group::Update TCK Cargo.toml with new dependencies"
           # Update the dependencies in the tck/Cargo.toml
-          # TODO: Remove the path dependency on the protobufs package after hiero-sdk-proto is published
-          toml set tck/Cargo.toml dependencies.hiero-sdk-proto.path "../protobufs" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
-          toml set tck/Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
-          toml set tck/Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
-          toml set tck/Cargo.toml dependencies.hiero-sdk-proto.features "['time_0_3', 'fraction']" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
+          sed -i "s/hedera/hiero-sdk/g" tck/Cargo.toml
+          echo "::endgroup::"
           
-          # Update the hedera dependency in the tck/Cargo.toml
-          toml set tck/Cargo.toml dependencies.hiero-sdk.package "hiero-sdk" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
-          toml set tck/Cargo.toml dependencies.hiero-sdk.path "../." > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
-          
-          # Convert features from string to array format
-          sed -i "s/features = \"\['time_0_3', 'fraction'\]\"/features = [\"time_0_3\", \"fraction\"]/g" tck/Cargo.toml
-          
-          # Remove the hedera-proto and hedera dependencies from the tck Cargo.toml file
-          sed '/hedera-proto.*/d' tck/Cargo.toml > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
-          sed '/hedera.*/d' tck/Cargo.toml > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
+          echo "::group::Update files with new names"
+          find . -type f -name "*.rs" -exec sed -i "s/hedera_proto/hiero_sdk_proto/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/hedera/hiero_sdk/g" {} +
           echo "::endgroup::"
           
           echo "group::Verify Cargo.toml changes"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -84,11 +84,11 @@ jobs:
         run: |
           SDK_PACKAGE_VERSION="$(toml get Cargo.toml package.version --raw)"
           SDK_PROTO_VERSION="$(toml get protobufs/Cargo.toml package.version --raw)"
-#          SDK_TCK_VERSION="$(toml get tck/Cargo.toml package.version --raw)"
+          # SDK_TCK_VERSION="$(toml get tck/Cargo.toml package.version --raw)"
           
           echo "sdk-version=${SDK_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "sdk-proto-version=${SDK_PROTO_VERSION}" >>"${GITHUB_OUTPUT}"
-#          echo "sdk-tck-version=${SDK_TCK_VERSION}" >>"${GITHUB_OUTPUT}"
+          # echo "sdk-tck-version=${SDK_TCK_VERSION}" >>"${GITHUB_OUTPUT}"
       
       - name: Proto Subpackage Publish Required
         id: proto-required

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -42,12 +42,6 @@ jobs:
       proto-type: ${{ steps.proto-tag.outputs.type }}
       proto-publish-required: ${{ steps.proto-required.outputs.proto-publish-required }}
 
-      # tck subpackage
-#      tck-version: ${{ steps.cargo-versions.outputs.sdk-tck-version }}
-#      tck-prerelease: ${{ steps.tck-tag.outputs.prerelease }}
-#      tck-type: ${{ steps.tck-tag.outputs.type }}
-#      tck-publish-required: ${{ steps.tck-required.outputs.tck-publish-required }}
-
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
@@ -77,19 +71,17 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: 1.88.0
-          components: toml-cli
+          components: toml-cli, openssl-sys
     
       - name: Extract Cargo.toml Versions
         id: cargo-versions
         run: |
           SDK_PACKAGE_VERSION="$(toml get Cargo.toml package.version --raw)"
           SDK_PROTO_VERSION="$(toml get protobufs/Cargo.toml package.version --raw)"
-          # SDK_TCK_VERSION="$(toml get tck/Cargo.toml package.version --raw)"
           
           echo "sdk-version=${SDK_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "sdk-proto-version=${SDK_PROTO_VERSION}" >>"${GITHUB_OUTPUT}"
-          # echo "sdk-tck-version=${SDK_TCK_VERSION}" >>"${GITHUB_OUTPUT}"
-      
+
       - name: Proto Subpackage Publish Required
         id: proto-required
         run: |
@@ -101,15 +93,6 @@ jobs:
             fi
           done
           echo "proto-publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
-
-#      - name: TCK Subpackage Publish Required
-#        id: tck-required
-#        run: |
-#          PUBLISH_REQUIRED="false"
-#          if ! curl -sSLf "https://crates.io/api/v1/crates/hiero-sdk-tck/${{ steps.cargo-versions.outputs.sdk-tck-version }}" >/dev/null 2>&1;
-#            PUBLISH_REQUIRED="true"
-#          fi
-#          echo "tck-publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
 
       - name: Extract SDK Tag Information
         id: sdk-tag
@@ -184,39 +167,6 @@ jobs:
           echo "## Proto Subpackage Release Information" >> "${GITHUB_STEP_SUMMARY}"
           echo "SDK_PROTO_VERSION=${{ steps.cargo-versions.outputs.sdk-proto-version }}" >> "${GITHUB_STEP_SUMMARY}"
 
-#      - name: Extract TCK Subpackage Information
-#        id: tck-tag
-#        run: |
-#          IS_VALID_SEMVER="$(semver validate "${{ steps.cargo-versions.outputs.sdk-tck-version }}")"
-#
-#          if [[ "${IS_VALID_SEMVER}" != "valid" ]]; then
-#            echo "::error title=Invalid TCK Tag::The proto version '${{ steps.cargo-versions.outputs.sdk-tck-version }}' is not a valid SemVer tag."
-#            exit 1
-#          fi
-#
-#          PREREL_VERSION="$(semver get prerel '${{ steps.cargo-versions.outputs.sdk-tck-version }}')"
-#          PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
-#
-#          IS_PRERELEASE="false"
-#          [[ -n "${PREREL_VERSION}" ]] && IS_PRERELEASE="true"
-#
-#          PREREL_TYPE="unknown"
-#          if [[ "${IS_PRERELEASE}" == "true" ]]; then
-#            if [[ "${PREREL_VERSION_LC}" =~ "beta" ]]; then
-#              PREREL_TYPE="beta"
-#            else
-#              PREREL_TYPE="unknown"
-#            fi
-#          else
-#            PREREL_TYPE="production"
-#          fi
-#
-#          echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
-#          echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
-#
-#          echo "## TCK Subpackage Release Information" >> "${GITHUB_STEP_SUMMARY}"
-#          echo "SDK_TCK_VERSION=${{ steps.cargo-versions.outputs.sdk-tck-version }}" >> "${GITHUB_STEP_SUMMARY}"
-
       - name: Validate Tag and Cargo.toml Versions
         run: |
           COMPARISON_RESULT="$(semver compare "${{ steps.cargo-versions.outputs.sdk-version }}" "{{ steps.sdk-tag.outputs.version }}")"
@@ -289,16 +239,6 @@ jobs:
           [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
           
           echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
-      
-#      - name: Calculate TCK Subpackage Publish Arguments
-#        id: tck-publish-args
-#        working-directory: tck
-#        if: ${{ needs.validate-release.outputs.tck-publish-required == 'true' && !cancelled() && !failure() }}
-#        run: |
-#          PUBLISH_ARGS="--locked"
-#          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
-#
-#          echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
 
       - name: Calculate SDK Publish Arguments
         id: sdk-publish-args
@@ -373,14 +313,3 @@ jobs:
           mv Cargo.toml.bak Cargo.toml
           mv Cargo.lock.bak Cargo.lock
           echo "::endgroup::"
-
-      # Publish the hiero-sdk-tck package which depends on hiero-sdk and hiero-sdk-proto
-#      - name: Publish TCK Subpackage to crates.io
-#        env:
-#          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
-#        working-directory: tck
-#        if: ${{ needs.validate-release.outputs.tck-publish-required == 'true' && !cancelled() && !failure() }}
-#        run: |
-#          echo "::group::Publish hedera-tck to crates.io"
-#          cargo publish ${{ steps.tck-publish-args.outputs.args }}
-#          echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -331,9 +331,17 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Update Cargo.toml with new name"
+          # Update the package name in protobufs/Cargo.toml
           toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          
+          # Update the dependencies in the main Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.package "hedera-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          toml set Cargo.toml dependencies.hiero-sdk-proto.features "["time_0_3","fraction",]" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          
+          # Remove the hedera-proto dependency from the main Cargo.toml
+          toml remove Cargo.toml dependencies.hedera-proto > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          
           cargo generate-lockfile
           echo "::endgroup::"
           

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -294,6 +294,9 @@ jobs:
           toml set Cargo.toml package.name "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set ../Cargo.toml dependencies.hiero-sdk-proto.package "hedera-proto" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
           toml set ../Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
+          toml set ../Cargo.toml dependencies.hiero-sdk-proto.features "["time_0_3","fraction",]" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
+          sed -i '/^hedera-proto\s*=.*/d' ../Cargo.toml
+          cargo check
           echo "::endgroup::"
           
           echo "::group::Publish hiero-sdk-proto to crates.io"
@@ -340,8 +343,9 @@ jobs:
           toml set Cargo.toml dependencies.hiero-sdk-proto.features "["time_0_3","fraction",]" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
           # Remove the hedera-proto dependency from the main Cargo.toml
-          toml remove Cargo.toml dependencies.hedera-proto > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          sed -i '/^hedera-proto\s*=.*/d' Cargo.toml
           
+          cargo check
           cargo generate-lockfile
           echo "::endgroup::"
           

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -395,18 +395,45 @@ jobs:
           fi
         working-directory: protobufs
 
-      # TODO: Remove this step once the hiero-sdk-proto is published
+      # TODO<BEGIN>: Remove this group of steps after the hiero-sdk-proto package is published
+      - name: Stop the local node (hiero-sdk-proto)
+        run: |
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            npx @hashgraph/hedera-local stop
+          fi
+
+      - name: Reset the workspace
+        if: ${{ !cancelled() && always() }}
+        run: |
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            echo "::group::Reset Workspace"
+            git reset --hard
+            git clean -fdx
+            echo "::endgroup::"
+          fi
+
+      - name: Start the local node (hiero-sdk)
+        run: |
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
+          fi
+
+      - name: Create env file (hiero-sdk)
+        run: |
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            touch .env
+            echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
+            echo TEST_OPERATOR_ID="0.0.1022" >> .env
+            echo TEST_NETWORK_NAME="localhost" >> .env
+            echo TEST_RUN_NONFREE="1" >> .env
+          fi
+
       - name: Set up Cargo files for SDK Dual publish
         if: ${{ !cancelled() && always() }}
         run: |
           files=("Cargo.toml" "tck/Cargo.toml" "Cargo.lock" "tck/Cargo.lock")
           
           if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            echo "::group::Reset Workspace"
-            git reset --hard
-            git clean -fdx
-            echo "::endgroup::"
-  
             echo "::group::Back up Cargo files"
             for file in "${files[@]}"; do
               if [[ -f "${file}" ]]; then
@@ -436,6 +463,7 @@ jobs:
             cargo generate-lockfile
             echo "::endgroup::"
           fi
+      # TODO<END>: Remove this group of steps after the hiero-sdk-proto package is published
 
       - name: Stop the local node
         run: |

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -433,3 +433,13 @@ jobs:
             fi
             echo "::endgroup::"
           fi
+
+      - name: Generate Github Release
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
+        if: ${{ inputs.dry-run-enabled != 'true' }}
+        with:
+          tag: ${{ needs.validate-release.outputs.tag }}
+          prerelease: ${{ needs.validate-release.outputs.prerelease == 'true' }}
+          draft: false
+          generateReleaseNotes: true
+          skipIfReleaseExists: true

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -214,14 +214,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
 
+      - name: Prepare Hiero Solo
+        id: solo
+        uses: hiero-ledger/hiero-solo-action@a39acf8cfbaa2feb195a86530d0ab643a45aa541 # v0.10
+        with:
+          installMirrorNode: true
+          hieroVersion: v0.63.7
+
+      - name: Set Operator Account
+        run: |
+          touch .env
+          echo "TEST_OPERATOR_KEY=${{ steps.solo.outputs.ed25519PrivateKey }}" >> .env
+          echo "TEST_OPERATOR_ID=${{ steps.solo.outputs.ed25519AccountId }}" >> .env
+          echo "TEST_NETWORK_NAME=local-node" >> .env
+          echo "TEST_RUN_NONFREE=1" >> .env
+
       - name: Run Safety Checks
-        env:
-          OPERATOR_ID: ${{ secrets.TEST_OPERATOR_ID }}
-          OPERATOR_KEY: ${{ secrets.TEST_OPERATOR_KEY }}
         run: |
           echo "::group::Run Safety Checks"
           cargo check
-          cargo test
+          cargo test --workspace
           echo "::endgroup::"
 
   publish:
@@ -255,6 +267,21 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
           cargo install toml-cli
+
+      - name: Prepare Hiero Solo
+        id: solo
+        uses: hiero-ledger/hiero-solo-action@a39acf8cfbaa2feb195a86530d0ab643a45aa541 # v0.10
+        with:
+          installMirrorNode: true
+          hieroVersion: v0.63.7
+
+      - name: Set Operator Account
+        run: |
+          touch .env
+          echo "TEST_OPERATOR_KEY=${{ steps.solo.outputs.ed25519PrivateKey }}" >> .env
+          echo "TEST_OPERATOR_ID=${{ steps.solo.outputs.ed25519AccountId }}" >> .env
+          echo "TEST_NETWORK_NAME=local-node" >> .env
+          echo "TEST_RUN_NONFREE=1" >> .env
 
       - name: Calculate Proto Subpackage Publish Arguments
         id: proto-publish-args
@@ -339,7 +366,7 @@ jobs:
             
             echo "::group::Verify Cargo.toml changes"
             cargo check
-            cargo test
+            cargo test --workspace
             cargo generate-lockfile
             echo "::endgroup::"
           fi
@@ -392,7 +419,7 @@ jobs:
             
             echo "::group::Verify Cargo.toml changes"
             cargo check
-            cargo test
+            cargo test --workspace
             cargo generate-lockfile
             echo "::endgroup::"
           fi

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -75,8 +75,7 @@ jobs:
       - name: Install components
         run: |
           cargo install toml-cli
-          cargo install openssl-sys
-    
+
       - name: Extract Cargo.toml Versions
         id: cargo-versions
         run: |

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -311,6 +311,7 @@ jobs:
           toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
           # Update the dependencies in the main Cargo.toml
+          toml set Cargo.toml dependencies.hiero-sdk-proto.path "protobufs" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.features "['time_0_3', 'fraction']" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
@@ -324,6 +325,7 @@ jobs:
           
           echo "::group::Update TCK Cargo.toml with new dependencies"
           # Update the dependencies in the tck/Cargo.toml
+          toml set tck/Cargo.toml dependencies.hiero-sdk-proto.path "../protobufs" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
           toml set tck/Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
           toml set tck/Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
           toml set tck/Cargo.toml dependencies.hiero-sdk-proto.features "['time_0_3', 'fraction']" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -336,7 +336,7 @@ jobs:
           sed -i "s/features = \"\['time_0_3', 'fraction'\]\"/features = [\"time_0_3\", \"fraction\"]/g" tck/Cargo.toml
           
           # Remove the hedera-proto and hedera dependencies from the tck Cargo.toml file
-          sed '/hedera-proto.*/d' /tck/Cargo.toml > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
+          sed '/hedera-proto.*/d' tck/Cargo.toml > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
           sed '/hedera.*/d' tck/Cargo.toml > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
           echo "::endgroup::"
           

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -346,7 +346,7 @@ jobs:
         working-directory: protobufs
 
       # TODO: Remove this step once the hiero-sdk-proto is published
-      - name: Set up Cargo files for sdk Dual publish
+      - name: Set up Cargo files for SDK Dual publish
         if: ${{ inputs.dual-publish-enabled == true && always() }}
         run: |
           echo "::group::Reset Workspace"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -317,7 +317,7 @@ jobs:
         with:
           node-version: 22
 
-      - name: Start the local node (hiero-sdk-proto)
+      - name: Start the local node
         run: |
           if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
             npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
@@ -385,12 +385,6 @@ jobs:
             echo "::endgroup::"
           fi
 
-      - name: Stop the local node (hiero-sdk-proto)
-        run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            npx @hashgraph/hedera-local stop
-          fi
-
       - name: Publish proto to crates.io (hiero-sdk-proto)
         if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' }}
         env:
@@ -400,12 +394,6 @@ jobs:
             cargo publish ${{ steps.proto-publish-args.outputs.args }}
           fi
         working-directory: protobufs
-
-      - name: Start the local node (hiero-sdk)
-        run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
-          fi
 
       # TODO: Remove this step once the hiero-sdk-proto is published
       - name: Set up Cargo files for SDK Dual publish
@@ -449,7 +437,7 @@ jobs:
             echo "::endgroup::"
           fi
 
-      - name: Stop the local node (hiero-sdk)
+      - name: Stop the local node
         run: |
           if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
             npx @hashgraph/hedera-local stop

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -256,7 +256,7 @@ jobs:
         id: proto-publish-args
         if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' }}
         env:
-          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled }}
+          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled || 'false' }}
         run: |
           PUBLISH_ARGS="--locked --allow-dirty"
           [[ "${DRY_RUN_ENABLED}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
@@ -267,7 +267,7 @@ jobs:
       - name: Calculate SDK Publish Arguments
         id: sdk-publish-args
         env:
-          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled }}
+          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled || 'false' }}
         run: |
           PUBLISH_ARGS="--locked --allow-dirty"
           [[ "${DRY_RUN_ENABLED}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -280,7 +280,10 @@ jobs:
           node-version: 22
 
       - name: Start the local node
-        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
+        run: |
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
+          fi
 
       - name: Create env file
         run: |
@@ -436,7 +439,10 @@ jobs:
           fi
 
       - name: Stop the local node
-        run: npx @hashgraph/hedera-local stop
+        run: |
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            npx @hashgraph/hedera-local stop
+          fi
 
       - name: Publish SDK to crates.io (hiero-sdk)
         env:

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -239,6 +239,8 @@ jobs:
 
       - name: Install components
         run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
           cargo install toml-cli
 
       - name: Calculate Proto Subpackage Publish Arguments

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -91,7 +91,7 @@ jobs:
           PUBLISH_REQUIRED="false"
           CRATES=("hedera-proto" "hiero-sdk-proto")
           for CRATE in "${CRATES[@]}"; do
-            if ! curl -sSLf "https://crates.io/api/v1/crates/${CRATE}/${{ steps.cargo-versions.outputs.sdk-proto-version }}" >/dev/null 2>&1;
+            if ! curl -sSLf "https://crates.io/api/v1/crates/${CRATE}/${{ steps.cargo-versions.outputs.sdk-proto-version }}" >/dev/null 2>&1; then
                 PUBLISH_REQUIRED="true"
             fi
           done
@@ -231,7 +231,10 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: 1.88.0
-          components: toml-cli
+
+      - name: Install components
+        run: |
+          cargo install toml-cli
 
       - name: Calculate Proto Subpackage Publish Arguments
         id: proto-publish-args

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -263,71 +263,23 @@ jobs:
           echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
 
       # Publish the hiero-sdk-proto package
-      - name: Publish Proto Subpackage to crates.io
+      - name: Publish Proto Subpackage to crates.io (hedera-proto)
         working-directory: protobufs
         env:
-          CARGO_HG_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
-          CARGO_HL_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
         if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
-        run: |
-          echo "::group::Back up Cargo files"
-          if [[ -f "Cargo.toml" ]]; then
-            cp Cargo.toml Cargo.toml.bak
-          fi
-          if [[ -f "Cargo.lock" ]]; then
-            cp Cargo.lock Cargo.lock.bak
-          fi
-          if [[ -f "Cargo.toml" ]]; then
-            cp ../Cargo.toml ../Cargo.toml.bak
-          fi
-          if [[ -f "Cargo.lock" ]]; then
-            cp ../Cargo.lock ../Cargo.lock.bak
-          fi
-          echo "::endgroup::"
-          
-          echo "::group::Publish hedera-proto to crates.io"
-          export CARGO_REGISTRY_TOKEN="${CARGO_HG_TOKEN}"
+        run: |         
           cargo publish ${{ steps.proto-publish-args.outputs.args }}
-          echo "::endgroup::"
-          
-          echo "::group::Update Cargo.toml with new name"
-          # Update the package name in protobufs/Cargo.toml
-          toml set Cargo.toml package.name "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          
-          # Update the dependencies in the main Cargo.toml
-          toml set ../Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
-          toml set ../Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
-          toml set ../Cargo.toml dependencies.hiero-sdk-proto.features "['time_0_3', 'fraction']" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
-          
-          # Convert features from string to array format
-          sed -i "s/features = \"\['time_0_3', 'fraction'\]\"/features = [\"time_0_3\", \"fraction\"]/g" Cargo.toml
-          
-          # Remove the hedera-proto dependency from the main Cargo.toml
-          sed '/hedera-proto\s*=.*/d' ../Cargo.toml > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
-          
-          # Ensure the Cargo.toml is valid
-          cargo check
-          echo "::endgroup::"
-          
-          echo "::group::Publish hiero-sdk-proto to crates.io"
-          export CARGO_REGISTRY_TOKEN="${CARGO_HL_TOKEN}"
-          cargo publish ${{ steps.proto-publish-args.outputs.args }}
-          echo "::endgroup::"
-          
-          echo "::group::Restore Cargo files"
-          if [[ -f "Cargo.toml.bak" ]]; then
-            mv Cargo.toml.bak Cargo.toml
-          fi
-          if [[ -f "Cargo.lock.bak" ]]; then
-            mv Cargo.lock.bak Cargo.lock
-          fi
-          echo "::endgroup::"
 
-      # Hiero SDK depends on the hiero-sdk-proto package
-      - name: Publish SDK to crates.io
+      # Publish the main SDK package
+      - name: Publish SDK to crates.io (hedera)
         env:
-          CARGO_HG_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
-          CARGO_HL_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
+        run: |
+          cargo publish ${{ steps.sdk-publish-args.outputs.args }}
+
+      # Update the Cargo.toml files for the hiero-sdk-* packages
+      - name: Update Cargo.toml for hiero publishing
         run: |
           echo "::group::Back up Cargo files"
           if [[ -f "Cargo.toml" ]]; then
@@ -339,22 +291,27 @@ jobs:
           if [[ -f "protobufs/Cargo.toml" ]]; then
             cp protobufs/Cargo.toml protobufs/Cargo.toml.bak
           fi
+          if [[ -f "protobufs/Cargo.lock" ]]; then
+            cp protobufs/Cargo.lock protobufs/Cargo.lock.bak
+          fi
+          if [[ -f "tck/Cargo.toml" ]]; then
+            cp tck/Cargo.toml tck/Cargo.toml.bak
+          fi
+          if [[ -f "tck/Cargo.lock" ]]; then
+            cp tck/Cargo.lock tck/Cargo.lock.bak
+          fi
           echo "::endgroup::"
           
-          echo "::group::Publish hedera to crates.io"
-          export CARGO_REGISTRY_TOKEN="${CARGO_HG_TOKEN}"
-          cargo publish ${{ steps.sdk-publish-args.outputs.args }}
-          echo "::endgroup::"
-          
-          echo "::group::Update Cargo.toml with new name"
-          # Update the package name in protobufs/Cargo.toml
-          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          
+          echo "::group::Update protobufs/Cargo.toml with new name"       
           # Update the dependencies in the protobugs/Cargo.toml
           toml set protobufs/Cargo.toml package.name "hiero-sdk-proto" > protobufs/Cargo.toml.tmp && mv protobufs/Cargo.toml.tmp protobufs/Cargo.toml
+          echo "::endgroup::"
+          
+          echo "::group::Update main Cargo.toml with new name and dependencies"
+          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
           # Update the dependencies in the main Cargo.toml
-          toml set Cargo.toml dependencies.hiero-sdk-proto.package "hedera-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          toml set Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.features "['time_0_3', 'fraction']" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
@@ -362,22 +319,65 @@ jobs:
           sed -i "s/features = \"\['time_0_3', 'fraction'\]\"/features = [\"time_0_3\", \"fraction\"]/g" Cargo.toml
           
           # Remove the hedera-proto dependency from the main Cargo.toml
-          sed '/hedera-proto\s*=.*/d' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          sed '/hedera-proto.*/d' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          echo "::endgroup::"
           
+          echo "::group::Update TCK Cargo.toml with new dependencies"
+          # Update the dependencies in the tck/Cargo.toml
+          toml set tck/Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
+          toml set tck/Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
+          toml set tck/Cargo.toml dependencies.hiero-sdk-proto.features "['time_0_3', 'fraction']" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
+          
+          # Update the hedera dependency in the tck/Cargo.toml
+          toml set tck/Cargo.toml dependencies.hiero-sdk.package "hiero-sdk" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
+          toml set tck/Cargo.toml dependencies.hiero-sdk.path "../." > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
+          
+          # Convert features from string to array format
+          sed -i "s/features = \"\['time_0_3', 'fraction'\]\"/features = [\"time_0_3\", \"fraction\"]/g" tck/Cargo.toml
+          
+          # Remove the hedera-proto and hedera dependencies from the tck Cargo.toml file
+          sed '/hedera-proto.*/d' /tck/Cargo.toml > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
+          sed '/hedera.*/d' tck/Cargo.toml > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
+          echo "::endgroup::"
+          
+          echo "group::Verify Cargo.toml changes"
           cargo check
           cargo generate-lockfile
           echo "::endgroup::"
-          
-          echo "::group::Publish hiero-sdk to crates.io"
-          export CARGO_REGISTRY_TOKEN="${CARGO_HL_TOKEN}"
+
+      - name: Publish proto to crates.io (hiero-sdk-proto)
+        working-directory: protobufs
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
+        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
+        run: |
+          cargo publish ${{ steps.proto-publish-args.outputs.args }}
+
+      - name: Publish hiero-sdk-proto to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
+        run: |
           cargo publish ${{ steps.sdk-publish-args.outputs.args }}
-          echo "::endgroup::"
-          
+
+      - name: Restore Cargo files
+        run: |
           echo "::group::Restore Cargo files"
           if [[ -f "Cargo.toml.bak" ]]; then
             mv Cargo.toml.bak Cargo.toml
           fi
           if [[ -f "Cargo.lock.bak" ]]; then
             mv Cargo.lock.bak Cargo.lock
+          fi
+          if [[ -f "protobufs/Cargo.toml.bak" ]]; then
+            mv protobufs/Cargo.toml.bak protobufs/Cargo.toml
+          fi
+          if [[ -f "protobufs/Cargo.lock.bak" ]]; then
+            mv protobufs/Cargo.lock.bak protobufs/Cargo.lock
+          fi
+          if [[ -f "tck/Cargo.toml.bak" ]]; then
+            mv tck/Cargo.toml.bak tck/Cargo.toml
+          fi
+          if [[ -f "tck/Cargo.lock.bak" ]]; then
+            mv tck/Cargo.lock.bak tck/Cargo.lock
           fi
           echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -332,7 +332,7 @@ jobs:
           find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
           echo "::endgroup::"
           
-          echo "group::Verify Cargo.toml changes"
+          echo "::group::Verify Cargo.toml changes"
           cargo check
           cargo generate-lockfile
           echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -67,7 +67,7 @@ jobs:
             sudo curl -L -o /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/master
             echo "::endgroup::"
             echo "::group::Change SemVer Binary Permissions"
-            sudo chmod +x /usr/local/bin/semver
+            sudo chmod -v +x /usr/local/bin/semver
             echo "::endgroup::"
             echo "::group::Show SemVer Binary Version Info"
             semver --version

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -317,6 +317,7 @@ jobs:
           toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
           # Update the dependencies in the main Cargo.toml
+          # TODO: Remove the path dependency on the protobufs package after hiero-sdk-proto is published
           toml set Cargo.toml dependencies.hiero-sdk-proto.path "protobufs" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
@@ -331,6 +332,7 @@ jobs:
           
           echo "::group::Update TCK Cargo.toml with new dependencies"
           # Update the dependencies in the tck/Cargo.toml
+          # TODO: Remove the path dependency on the protobufs package after hiero-sdk-proto is published
           toml set tck/Cargo.toml dependencies.hiero-sdk-proto.path "../protobufs" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
           toml set tck/Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
           toml set tck/Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > tck/Cargo.toml.tmp && mv tck/Cargo.toml.tmp tck/Cargo.toml
@@ -361,7 +363,7 @@ jobs:
           cargo publish ${{ steps.proto-publish-args.outputs.args }}
         working-directory: protobufs
 
-      - name: Publish hiero-sdk-proto to crates.io
+      - name: Publish SDK to crates.io (hiero-sdk)
         if: ${{ inputs.dual-publish-enabled == true }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -285,7 +285,7 @@ jobs:
 
       # Update the Cargo.toml files for the hiero-sdk-* packages
       - name: Update Cargo.toml for hiero publishing
-        if: ${{ dual-publish-enabled == true }}
+        if: ${{ inputs.dual-publish-enabled == true }}
         run: |
           echo "::group::Back up Cargo files"
           if [[ -f "Cargo.toml" ]]; then

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -287,11 +287,13 @@ jobs:
 
       - name: Create env file
         run: |
-          touch .env
-          echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
-          echo TEST_OPERATOR_ID="0.0.1022" >> .env
-          echo TEST_NETWORK_NAME="localhost" >> .env
-          echo TEST_RUN_NONFREE="1" >> .env
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            touch .env
+            echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
+            echo TEST_OPERATOR_ID="0.0.1022" >> .env
+            echo TEST_NETWORK_NAME="localhost" >> .env
+            echo TEST_RUN_NONFREE="1" >> .env
+          fi
 
       - name: Calculate Proto Subpackage Publish Arguments
         id: proto-publish-args

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -234,8 +234,13 @@ jobs:
         run: |
           echo "::group::Run Safety Checks"
           cargo check
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . $HOME/.cargo/env
           cargo test --workspace
           echo "::endgroup::"
+
+      - name: Stop the local node
+        run: npx @hashgraph/hedera-local stop
 
   publish:
     name: Publish SDK to crates.io
@@ -275,7 +280,7 @@ jobs:
           node-version: 22
 
       - name: Start the local node
-        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.63.7
+        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
 
       - name: Create env file
         run: |
@@ -368,6 +373,8 @@ jobs:
             
             echo "::group::Verify Cargo.toml changes"
             cargo check
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            . $HOME/.cargo/env
             cargo test --workspace
             cargo generate-lockfile
             echo "::endgroup::"
@@ -421,10 +428,15 @@ jobs:
             
             echo "::group::Verify Cargo.toml changes"
             cargo check
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            . $HOME/.cargo/env
             cargo test --workspace
             cargo generate-lockfile
             echo "::endgroup::"
           fi
+
+      - name: Stop the local node
+        run: npx @hashgraph/hedera-local stop
 
       - name: Publish SDK to crates.io (hiero-sdk)
         env:

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -215,6 +215,9 @@ jobs:
           sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
 
       - name: Run Safety Checks
+        env:
+          OPERATOR_ID: ${{ secrets.TEST_OPERATOR_ID }}
+          OPERATOR_KEY: ${{ secrets.TEST_OPERATOR_KEY }}
         run: |
           echo "::group::Run Safety Checks"
           cargo check
@@ -293,6 +296,9 @@ jobs:
 
       # Update the Cargo.toml files for the hiero-sdk-* packages
       - name: Update Cargo.toml for hiero publishing
+        env:
+          OPERATOR_ID: ${{ secrets.TEST_OPERATOR_ID }}
+          OPERATOR_KEY: ${{ secrets.TEST_OPERATOR_KEY }}
         run: |
           files=("Cargo.toml" "protobufs/Cargo.toml" "tck/Cargo.toml" \
           "Cargo.lock" "protobufs/Cargo.lock" "tck/Cargo.lock")
@@ -351,6 +357,9 @@ jobs:
       # TODO: Remove this step once the hiero-sdk-proto is published
       - name: Set up Cargo files for SDK Dual publish
         if: ${{ !cancelled() && always() }}
+        env:
+          OPERATOR_ID: ${{ secrets.TEST_OPERATOR_ID }}
+          OPERATOR_KEY: ${{ secrets.TEST_OPERATOR_KEY }}
         run: |
           files=("Cargo.toml" "tck/Cargo.toml" "Cargo.lock" "tck/Cargo.lock")
           
@@ -383,7 +392,7 @@ jobs:
             
             echo "::group::Verify Cargo.toml changes"
             cargo check
-            cargo test --test e2e
+            cargo test
             cargo generate-lockfile
             echo "::endgroup::"
           fi

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -57,15 +57,15 @@ jobs:
 
       - name: Install Semantic Version Tools
         run: |
-            echo "::group::Download Semver Binary"
-            sudo curl -L -o /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/master
-            echo "::endgroup::"
-            echo "::group::Change SemVer Binary Permissions"
-            sudo chmod -v +x /usr/local/bin/semver
-            echo "::endgroup::"
-            echo "::group::Show SemVer Binary Version Info"
-            semver --version
-            echo "::endgroup::"
+          echo "::group::Download SemVer Binary"
+          sudo curl -L -o /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
+          echo "::endgroup::"
+          echo "::group::Change SemVer Binary Permissions"
+          sudo chmod -v +x /usr/local/bin/semver
+          echo "::endgroup::"
+          echo "::group::Show SemVer Binary Version Info"
+          semver --version
+          echo "::endgroup::"
             
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -79,8 +79,8 @@ jobs:
       - name: Extract Cargo.toml Versions
         id: cargo-versions
         run: |
-          SDK_PACKAGE_VERSION="$(toml get Cargo.toml package.version)"
-          SDK_PROTO_VERSION="$(toml get protobufs/Cargo.toml package.version)"
+          SDK_PACKAGE_VERSION="$(toml get Cargo.toml package.version --raw)"
+          SDK_PROTO_VERSION="$(toml get protobufs/Cargo.toml package.version --raw)"
           
           echo "sdk-version=${SDK_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "sdk-proto-version=${SDK_PROTO_VERSION}" >>"${GITHUB_OUTPUT}"
@@ -206,7 +206,7 @@ jobs:
       - name: Install components
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev
+          sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
 
       - name: Run Safety Checks
         run: |

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -286,8 +286,6 @@ jobs:
           
           echo "::group::Update Cargo.toml with new name"
           toml set Cargo.toml package.name "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          toml set Cargo.toml dependencies.hedera-proto.hiero-sdk-proto "{ version = "${{ needs.validate-release.outputs.sdk-version }}" }" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          cargo generate-lockfile
           echo "::endgroup::"
           
           echo "::group::Publish hiero-sdk-proto to crates.io"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -72,7 +72,10 @@ jobs:
         with:
           toolchain: 1.88.0
 
-
+      - name: Install components
+        run: |
+          cargo install toml-cli
+          cargo install openssl-sys
     
       - name: Extract Cargo.toml Versions
         id: cargo-versions

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -71,7 +71,8 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: 1.88.0
-          components: toml-cli, openssl-sys
+
+
     
       - name: Extract Cargo.toml Versions
         id: cargo-versions

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.inputs.tag || '' }}
+          ref: ${{ inputs.tag || '' }}
           fetch-depth: 0
           submodules: recursive
 
@@ -200,7 +200,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.inputs.tag || '' }}
+          ref: ${{ inputs.tag || '' }}
           submodules: recursive
 
       - name: Set up Rust
@@ -234,7 +234,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.inputs.tag || '' }}
+          ref: ${{ inputs.tag || '' }}
           submodules: recursive
 
       - name: Set up Rust
@@ -250,20 +250,23 @@ jobs:
 
       - name: Calculate Proto Subpackage Publish Arguments
         id: proto-publish-args
-        working-directory: protobufs
-        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
+        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' }}
+        env:
+          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled }}
         run: |
           PUBLISH_ARGS="--locked --allow-dirty"
-          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
+          [[ "${DRY_RUN_ENABLED}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
           
           echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
+        working-directory: protobufs
 
       - name: Calculate SDK Publish Arguments
         id: sdk-publish-args
-        if: ${{ !cancelled() && !failure() }}
+        env:
+          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled }}
         run: |
           PUBLISH_ARGS="--locked --allow-dirty"
-          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
+          [[ "${DRY_RUN_ENABLED}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
           
           echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -48,6 +48,47 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Install Semantic Version Tools
+        run: |
+            echo "::group::Download Semver Binary"
+            sudo curl -L -o /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/master
+            echo "::endgroup::"
+            echo "::group::Change SemVer Binary Permissions"
+            sudo chmod +x /usr/local/bin/semver
+            echo "::endgroup::"
+            echo "::group::Show SemVer Binary Version Info"
+            semver --version
+            echo "::endgroup::"
+            
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
+        with:
+          toolchain: 1.88.0
+          components: rustfmt, toml-cli, cargo-info
+    
+      - name: Extract Cargo.toml Versions
+        id: cargo-versions
+        run: |
+          SDK_PACKAGE_VERSION="$(toml get Cargo.toml package.version --raw)"
+          SDK_PROTO_VERSION="$(toml get protobufs/Cargo.toml package.version --raw)"
+          SDK_TCK_VERSION="$(toml get tck/Cargo.toml package.version --raw)"
+          
+          echo "sdk-version=${SDK_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
+          echo "sdk-proto-version=${SDK_PROTO_VERSION}" >>"${GITHUB_OUTPUT}"
+          echo "sdk-tck-version=${SDK_TCK_VERSION}" >>"${GITHUB_OUTPUT}"
+      
+      - name: Proto Subpackage Publish Required
+        id: proto-required
+        run: |
+          PUBLISH_REQUIRED="false"
+          CRATES=("hedera-proto" "hiero-sdk-proto")
+          for CRATE in "${CRATES[@]}"; do
+            if ! curl -sSLf "https://crates.io/api/v1/crates/${CRATE}/${{ steps.cargo-versions.outputs.sdk-proto-version }}" >/dev/null 2>&1;
+                PUBLISH_REQUIRED="true"
+            fi
+          done
+          echo "proto-publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
+
       - name: Extract SDK Tag Information
         id: tag
         run: |
@@ -81,7 +122,7 @@ jobs:
           echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
 
   publish:
-    name: Publish to crates.io
+    name: Publish SDK to crates.io
     needs:
       - validate-release
     runs-on: hiero-client-sdk-linux-medium
@@ -98,11 +139,14 @@ jobs:
           submodules: recursive
 
       - name: Set up Rust
-        uses: actions/setup-rust@v1
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
-          rust-version: stable
+          toolchain: 1.88.0
+          components: rustfmt, toml-cli
 
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: cargo publish --locked
+          CARGO_HG_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
+        run: |
+          export CARGO_REGISTRY_TOKEN="${CARGO_HG_TOKEN}"
+          cargo publish --locked

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -386,7 +386,6 @@ jobs:
             echo "::group::Update TCK Cargo.toml with new dependencies"
             # Update the dependencies in the tck/Cargo.toml
             sed -i "s/hedera =/hiero-sdk =/g" tck/Cargo.toml
-            cat tck/Cargo.toml
             echo "::endgroup::"
             
             echo "::group::Update files with new names"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -327,8 +327,9 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Update files with new names"
-          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera_proto\b/use hiero_sdk_proto/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\bhedera_proto\b/hiero_sdk_proto/g" {} +
           find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
           echo "::endgroup::"
           
           echo "group::Verify Cargo.toml changes"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -218,6 +218,7 @@ jobs:
         run: |
           echo "::group::Run Safety Checks"
           cargo check
+          cargo test
           echo "::endgroup::"
 
   publish:
@@ -293,26 +294,17 @@ jobs:
       # Update the Cargo.toml files for the hiero-sdk-* packages
       - name: Update Cargo.toml for hiero publishing
         run: |
+          files=("Cargo.toml" "protobufs/Cargo.toml" "tck/Cargo.toml" \
+          "Cargo.lock" "protobufs/Cargo.lock" "tck/Cargo.lock")
+          
           if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
             echo "::group::Back up Cargo files"
-            if [[ -f "Cargo.toml" ]]; then
-              cp Cargo.toml Cargo.toml.bak
-            fi
-            if [[ -f "Cargo.lock" ]]; then
-              cp Cargo.lock Cargo.lock.bak
-            fi
-            if [[ -f "protobufs/Cargo.toml" ]]; then
-              cp protobufs/Cargo.toml protobufs/Cargo.toml.bak
-            fi
-            if [[ -f "protobufs/Cargo.lock" ]]; then
-              cp protobufs/Cargo.lock protobufs/Cargo.lock.bak
-            fi
-            if [[ -f "tck/Cargo.toml" ]]; then
-              cp tck/Cargo.toml tck/Cargo.toml.bak
-            fi
-            if [[ -f "tck/Cargo.lock" ]]; then
-              cp tck/Cargo.lock tck/Cargo.lock.bak
-            fi
+          
+            for file in "${files[@]}"; do
+              if [[ -f "${file}" ]]; then
+                cp "${file}" "${file}.bak"
+              fi
+            done
             echo "::endgroup::"
             
             echo "::group::Update protobufs/Cargo.toml with new name"       
@@ -341,6 +333,7 @@ jobs:
             
             echo "::group::Verify Cargo.toml changes"
             cargo check
+            cargo test
             cargo generate-lockfile
             echo "::endgroup::"
           fi
@@ -359,6 +352,8 @@ jobs:
       - name: Set up Cargo files for SDK Dual publish
         if: ${{ !cancelled() && always() }}
         run: |
+          files=("Cargo.toml" "tck/Cargo.toml" "Cargo.lock" "tck/Cargo.lock")
+          
           if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
             echo "::group::Reset Workspace"
             git reset --hard
@@ -366,18 +361,11 @@ jobs:
             echo "::endgroup::"
   
             echo "::group::Back up Cargo files"
-            if [[ -f "Cargo.toml" ]]; then
-              cp Cargo.toml Cargo.toml.bak
-            fi
-            if [[ -f "Cargo.lock" ]]; then
-              cp Cargo.lock Cargo.lock.bak
-            fi
-            if [[ -f "tck/Cargo.toml" ]]; then
-              cp tck/Cargo.toml tck/Cargo.toml.bak
-            fi
-            if [[ -f "tck/Cargo.lock" ]]; then
-              cp tck/Cargo.lock tck/Cargo.lock.bak
-            fi
+            for file in "${files[@]}"; do
+              if [[ -f "${file}" ]]; then
+                cp "${file}" "${file}.bak"
+              fi
+            done
             echo "::endgroup::"
             
             echo "::group::Update main Cargo.toml with new name and dependencies"
@@ -395,6 +383,7 @@ jobs:
             
             echo "::group::Verify Cargo.toml changes"
             cargo check
+            cargo test
             cargo generate-lockfile
             echo "::endgroup::"
           fi
@@ -410,26 +399,16 @@ jobs:
       - name: Restore Cargo files
         if: ${{ !cancelled() && always() }}
         run: |
+          files=("Cargo.toml" "protobufs/Cargo.toml" "tck/Cargo.toml" \
+          "Cargo.lock" "protobufs/Cargo.lock" "tck/Cargo.lock")
+          
           if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
             echo "::group::Restore Cargo files"
-            if [[ -f "Cargo.toml.bak" ]]; then
-              mv Cargo.toml.bak Cargo.toml
-            fi
-            if [[ -f "Cargo.lock.bak" ]]; then
-              mv Cargo.lock.bak Cargo.lock
-            fi
-            if [[ -f "protobufs/Cargo.toml.bak" ]]; then
-              mv protobufs/Cargo.toml.bak protobufs/Cargo.toml
-            fi
-            if [[ -f "protobufs/Cargo.lock.bak" ]]; then
-              mv protobufs/Cargo.lock.bak protobufs/Cargo.lock
-            fi
-            if [[ -f "tck/Cargo.toml.bak" ]]; then
-              mv tck/Cargo.toml.bak tck/Cargo.toml
-            fi
-            if [[ -f "tck/Cargo.lock.bak" ]]; then
-              mv tck/Cargo.lock.bak tck/Cargo.lock
-            fi
+            for file in "${files[@]}"; do
+              if [[ -f "${file}.bak" ]]; then
+                mv "${file}.bak" "${file}"
+              fi
+            done
             echo "::endgroup::"
           fi
 

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -383,7 +383,7 @@ jobs:
             
             echo "::group::Verify Cargo.toml changes"
             cargo check
-            cargo test
+            cargo test --test e2e
             cargo generate-lockfile
             echo "::endgroup::"
           fi

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -326,6 +326,9 @@ jobs:
           if [[ -f "Cargo.lock" ]]; then
             cp Cargo.lock Cargo.lock.bak
           fi
+          if [[ -f "protobufs/Cargo.toml" ]]; then
+            cp protobufs/Cargo.toml protobufs/Cargo.toml.bak
+          fi
           echo "::endgroup::"
           
           echo "::group::Publish hedera to crates.io"
@@ -338,6 +341,7 @@ jobs:
           toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
           # Update the dependencies in the main Cargo.toml
+          toml set protobufs/Cargo.toml package.name "hiero-sdk-proto" > protobufs/Cargo.toml.tmp && mv protobufs/Cargo.toml.tmp protobufs/Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.package "hedera-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.features "["time_0_3","fraction",]" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -11,6 +11,11 @@ on:
         type: boolean
         required: false
         default: false
+      dual-publish-enabled:
+        description: "Dual Publish Enabled"
+        type: boolean
+        required: false
+        default: false
   push:
     tags:
       - "v*.*.*"
@@ -264,12 +269,12 @@ jobs:
 
       # Publish the hiero-sdk-proto package
       - name: Publish Proto Subpackage to crates.io (hedera-proto)
-        working-directory: protobufs
+        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true'}}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
-        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
         run: |         
           cargo publish ${{ steps.proto-publish-args.outputs.args }}
+        working-directory: protobufs
 
       # Publish the main SDK package
       - name: Publish SDK to crates.io (hedera)
@@ -280,6 +285,7 @@ jobs:
 
       # Update the Cargo.toml files for the hiero-sdk-* packages
       - name: Update Cargo.toml for hiero publishing
+        if: ${{ dual-publish-enabled == true }}
         run: |
           echo "::group::Back up Cargo files"
           if [[ -f "Cargo.toml" ]]; then
@@ -348,21 +354,22 @@ jobs:
           echo "::endgroup::"
 
       - name: Publish proto to crates.io (hiero-sdk-proto)
-        working-directory: protobufs
+        if: ${{ inputs.dual-publish-enabled == true && needs.validate-release.outputs.proto-publish-required == 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
-        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
         run: |
           cargo publish ${{ steps.proto-publish-args.outputs.args }}
+        working-directory: protobufs
 
       - name: Publish hiero-sdk-proto to crates.io
+        if: ${{ inputs.dual-publish-enabled == true }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
         run: |
           cargo publish ${{ steps.sdk-publish-args.outputs.args }}
 
       - name: Restore Cargo files
-        if: ${{ always() }}
+        if: ${{ inputs.dual-publish-enabled == true && always() }}
         run: |
           echo "::group::Restore Cargo files"
           if [[ -f "Cargo.toml.bak" ]]; then

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -172,13 +172,13 @@ jobs:
 
       - name: Validate Tag and Cargo.toml Versions
         run: |
-          COMPARISON_RESULT="$(semver compare "${{ steps.cargo-versions.outputs.sdk-version }}" "{{ steps.sdk-tag.outputs.version }}")"
+          COMPARISON_RESULT="$(semver compare "${{ steps.cargo-versions.outputs.sdk-version }}" "${{ steps.sdk-tag.outputs.version }}")"
           if [[ "${COMPARISON_RESULT}" -ne 0 ]]; then
             echo "::error title=Version Mismatch::The Cargo.toml version '${{ steps.cargo-versions.outputs.sdk-version }}' does not match the tag version '${{ steps.sdk-tag.outputs.version }}'."
             exit 1
           fi
           
-          if [[ "${{ steps.sdk-tag.outputs.prerelease }}" != "production" && "{{ steps.sdk-tag.outputs.prerelease }}" != "beta" ]]; then
+          if [[ "${{ steps.sdk-tag.outputs.prerelease }}" != "production" && "${{ steps.sdk-tag.outputs.prerelease }}" != "beta" ]]; then
             echo "::error title=Invalid Prerelease Type::The prerelease type '${{ steps.sdk-tag.outputs.prerelease }}' is not valid. Expected 'production' or 'beta'."
             exit 1
           fi

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -1,0 +1,108 @@
+name: "Publish Release"
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing Tag to Publish (eg: v3.7.0)"
+        type: string
+        required: true
+      dry-run-enabled:
+        description: "Dry Run Enabled"
+        type: boolean
+        required: false
+        default: false
+  push:
+    tags:
+      - "v*.*.*"
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+
+jobs:
+  validate-release:
+    name: Validate Release
+    runs-on: hiero-client-sdk-linux-medium
+
+    outputs:
+      # Project tag
+      tag: ${{ steps.tag.outputs.name }}
+      # main package
+      sdk-version: ${{ steps.tag.outputs.version }}
+      sdk-prerelease: ${{ steps.tag.outputs.prerelease }}
+      sdk-type: ${{ steps.tag.outputs.type }}
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.inputs.tag || '' }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Extract SDK Tag Information
+        id: tag
+        run: |
+          REF_NAME="$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))"
+          IS_VALID_SEMVER="$(semver validate "${REF_NAME}")"
+          if [[ "${IS_VALID_SEMVER}" != "valid" ]]; then
+            echo "::error title=Invalid Tag::The tag '${REF_NAME}' is not a valid SemVer tag."
+            exit 1
+          fi
+          RELEASE_VERSION="$(semver get release "${REF_NAME}")"
+          PREREL_VERSION="$(semver get prerel "${REF_NAME}")"
+          PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
+          IS_PRERELEASE="false"
+          [[ -n "${PREREL_VERSION}" ]] && IS_PRERELEASE="true"
+          PREREL_TYPE="unknown"
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            if [[ "${PREREL_VERSION_LC}" =~ "beta" ]]; then
+              PREREL_TYPE="beta"
+            else
+              PREREL_TYPE="unknown"
+            fi
+          else
+            PREREL_TYPE="production"
+          fi
+          FINAL_VERSION="${RELEASE_VERSION}"
+          [[ -n "${PREREL_VERSION}" ]] && FINAL_VERSION="${RELEASE_VERSION}-${PREREL_VERSION}"
+          TAG_NAME="v${FINAL_VERSION}"
+          echo "name=${TAG_NAME}" >>"${GITHUB_OUTPUT}"
+          echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
+          echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
+          echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
+
+  publish:
+    name: Publish to crates.io
+    needs:
+      - validate-release
+    runs-on: hiero-client-sdk-linux-medium
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.inputs.tag || '' }}
+          submodules: recursive
+
+      - name: Set up Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish --locked

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -32,7 +32,8 @@ jobs:
   validate-release:
     name: Validate Release
     runs-on: hiero-client-sdk-linux-medium
-
+    env:
+      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || 'false' }}
     outputs:
       # Project tag
       tag: ${{ steps.sdk-tag.outputs.name }}
@@ -41,12 +42,15 @@ jobs:
       sdk-version: ${{ steps.sdk-tag.outputs.version }}
       sdk-prerelease: ${{ steps.sdk-tag.outputs.prerelease }}
       sdk-type: ${{ steps.sdk-tag.outputs.type }}
+      hedera-publish-required: ${{ steps.hedera-sdk-required.outputs.hedera-publish-required }}
+      hiero-publish-required: ${{ steps.hiero-sdk-required.outputs.hiero-publish-required }}
 
       # proto subpackage
       proto-version: ${{ steps.cargo-versions.outputs.sdk-proto-version }}
       proto-prerelease: ${{ steps.proto-tag.outputs.prerelease }}
       proto-type: ${{ steps.proto-tag.outputs.type }}
-      proto-publish-required: ${{ steps.proto-required.outputs.proto-publish-required }}
+      hedera-proto-publish-required: ${{ steps.hedera-proto-required.outputs.hedera-proto-publish-required }}
+      hiero-proto-publish-required: ${{ steps.hiero-sdk-proto-required.outputs.hiero-proto-publish-required }}
 
     steps:
       - name: Harden Runner
@@ -88,25 +92,52 @@ jobs:
           SDK_PACKAGE_VERSION="$(toml get Cargo.toml package.version --raw)"
           SDK_PROTO_VERSION="$(toml get protobufs/Cargo.toml package.version --raw)"
           
-          echo "sdk-version=${SDK_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
-          echo "sdk-proto-version=${SDK_PROTO_VERSION}" >>"${GITHUB_OUTPUT}"
+          echo "sdk-version=${SDK_PACKAGE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "sdk-proto-version=${SDK_PROTO_VERSION}" >> "${GITHUB_OUTPUT}"
 
-      - name: Proto Subpackage Publish Required
-        id: proto-required
+      - name: Hedera Proto Subpackage Publish Required
+        id: hedera-proto-required
         run: |
-          PUBLISH_REQUIRED="false"
-          CRATES=("hedera-proto" "hiero-sdk-proto")
-          for CRATE in "${CRATES[@]}"; do
-            if ! curl -sSLf "https://crates.io/api/v1/crates/${CRATE}/${{ steps.cargo-versions.outputs.sdk-proto-version }}" >/dev/null 2>&1; then
-                PUBLISH_REQUIRED="true"
-            fi
-          done
-          echo "proto-publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
+          HEDERA_PROTO_PUBLISH_REQUIRED="false"
+          if ! curl -sSLf "https://crates.io/api/v1/crates/hedera-proto/${{ steps.cargo-versions.outputs.sdk-proto-version }}" >/dev/null 2>&1; then
+            HEDERA_PROTO_PUBLISH_REQUIRED="true"
+          fi
+          echo "hedera-proto-publish-required=${HEDERA_PROTO_PUBLISH_REQUIRED}" >> "${GITHUB_OUTPUT}"
+
+      - name: Hiero SDK Proto Subpackage Publish Required
+        id: hiero-sdk-proto-required
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
+        run: |
+          HIERO_SDK_PROTO_PUBLISH_REQUIRED="false"
+          if ! curl -sSLf "https://crates.io/api/v1/crates/hiero-sdk-proto/${{ steps.cargo-versions.outputs.sdk-proto-version }}" >/dev/null 2>&1; then
+            HIERO_SDK_PROTO_PUBLISH_REQUIRED="true"
+          fi
+          echo "hiero-proto-publish-required=${HIERO_SDK_PROTO_PUBLISH_REQUIRED}" >> "${GITHUB_OUTPUT}"
+
+      - name: Hedera SDK Publish Required
+        id: hedera-sdk-required
+        run: |
+          HEDERA_SDK_PUBLISH_REQUIRED="false"
+          if ! curl -sSLf "https://crates.io/api/v1/crates/hedera/${{ steps.cargo-versions.outputs.sdk-version }}" >/dev/null 2>&1; then
+            HEDERA_SDK_PUBLISH_REQUIRED="true"
+          fi
+          echo "hedera-publish-required=${HEDERA_SDK_PUBLISH_REQUIRED}" >> "${GITHUB_OUTPUT}"
+
+      - name: Hiero SDK Publish Required
+        id: hiero-sdk-required
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
+        run: |
+          HIERO_SDK_PUBLISH_REQUIRED="false"
+          if ! curl -sSLf "https://crates.io/api/v1/crates/hiero-sdk/${{ steps.cargo-versions.outputs.sdk-version }}" >/dev/null 2>&1; then
+            HIERO_SDK_PUBLISH_REQUIRED="true"
+          fi
+          echo "hiero-publish-required=${HIERO_SDK_PUBLISH_REQUIRED}" >> "${GITHUB_OUTPUT}"
 
       - name: Extract SDK Tag Information
         id: sdk-tag
+        env:
+          REF_NAME: ${{ inputs.tag || steps.cargo-versions.outputs.sdk-version }}
         run: |
-          REF_NAME="$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))"
           IS_VALID_SEMVER="$(semver validate "${REF_NAME}")"
           if [[ "${IS_VALID_SEMVER}" != "valid" ]]; then
             echo "::error title=Invalid Tag::The tag '${REF_NAME}' is not a valid SemVer tag."
@@ -251,6 +282,7 @@ jobs:
     env:
       # Set the default to 'true' when the dual-publishing period is active
       DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || 'false' }}
+      DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled || 'false' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
@@ -277,8 +309,6 @@ jobs:
       - name: Calculate Proto Subpackage Publish Arguments
         id: proto-publish-args
         if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' }}
-        env:
-          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled || 'false' }}
         run: |
           PUBLISH_ARGS="--locked --allow-dirty"
           [[ "${DRY_RUN_ENABLED}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
@@ -288,8 +318,6 @@ jobs:
 
       - name: Calculate SDK Publish Arguments
         id: sdk-publish-args
-        env:
-          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled || 'false' }}
         run: |
           PUBLISH_ARGS="--locked --allow-dirty"
           [[ "${DRY_RUN_ENABLED}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
@@ -298,19 +326,18 @@ jobs:
 
       # Publish the hedera-proto package
       - name: Publish Proto Subpackage to crates.io (hedera-proto)
-        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true'}}
+        if: ${{ needs.validate-release.outputs.hedera-proto-publish-required == 'true'}}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
-        run: |         
-          cargo publish ${{ steps.proto-publish-args.outputs.args }}
+        run: cargo publish ${{ steps.proto-publish-args.outputs.args }}
         working-directory: protobufs
 
       # Publish the main SDK package (hedera)
       - name: Publish SDK to crates.io (hedera)
+        if: ${{ needs.validate-release.outputs.hedera-publish-required == 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
-        run: |
-          cargo publish ${{ steps.sdk-publish-args.outputs.args }}
+        run: cargo publish ${{ steps.sdk-publish-args.outputs.args }}
 
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -318,186 +345,138 @@ jobs:
           node-version: 22
 
       - name: Start the local node
-        run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
-          fi
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
+        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
 
       - name: Create env file
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
         run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            touch .env
-            echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
-            echo TEST_OPERATOR_ID="0.0.1022" >> .env
-            echo TEST_NETWORK_NAME="localhost" >> .env
-            echo TEST_RUN_NONFREE="1" >> .env
-          fi
+          touch .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
+          echo TEST_OPERATOR_ID="0.0.1022" >> .env
+          echo TEST_NETWORK_NAME="localhost" >> .env
+          echo TEST_RUN_NONFREE="1" >> .env
 
       # Update the Cargo.toml files for the hiero-sdk-* packages
       - name: Update Cargo.toml for hiero publishing
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
           OPERATOR_ID: ${{ secrets.TEST_OPERATOR_ID }}
           OPERATOR_KEY: ${{ secrets.TEST_OPERATOR_KEY }}
-        run: |
-          files=("Cargo.toml" "protobufs/Cargo.toml" "tck/Cargo.toml" \
-          "Cargo.lock" "protobufs/Cargo.lock" "tck/Cargo.lock")
+        run: |         
+          echo "::group::Update protobufs/Cargo.toml with new name"       
+          # Update the dependencies in the protobugs/Cargo.toml
+          toml set protobufs/Cargo.toml package.name "hiero-sdk-proto" > protobufs/Cargo.toml.tmp && mv protobufs/Cargo.toml.tmp protobufs/Cargo.toml
+          echo "::endgroup::"
           
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            echo "::group::Back up Cargo files"
+          echo "::group::Update main Cargo.toml with new name and dependencies"
+          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
-            for file in "${files[@]}"; do
-              if [[ -f "${file}" ]]; then
-                cp "${file}" "${file}.bak"
-              fi
-            done
-            echo "::endgroup::"
-            
-            echo "::group::Update protobufs/Cargo.toml with new name"       
-            # Update the dependencies in the protobugs/Cargo.toml
-            toml set protobufs/Cargo.toml package.name "hiero-sdk-proto" > protobufs/Cargo.toml.tmp && mv protobufs/Cargo.toml.tmp protobufs/Cargo.toml
-            echo "::endgroup::"
-            
-            echo "::group::Update main Cargo.toml with new name and dependencies"
-            toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-            
-            # Update the dependencies in the main Cargo.toml
-            sed -i "s/hedera-proto/hiero-sdk-proto/g" Cargo.toml
-  
-            echo "::endgroup::"
-            
-            echo "::group::Update TCK Cargo.toml with new dependencies"
-            # Update the dependencies in the tck/Cargo.toml
-            sed -i "s/hedera/hiero-sdk/g" tck/Cargo.toml
-            echo "::endgroup::"
-            
-            echo "::group::Update files with new names"
-            find . -type f -name "*.rs" -exec sed -i "s/\bhedera_proto\b/hiero_sdk_proto/g" {} +
-            find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
-            find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
-            echo "::endgroup::"
-            
-            echo "::group::Verify Cargo.toml changes"
-            cargo check
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            . $HOME/.cargo/env
-            cargo test --workspace
-            cargo generate-lockfile
-            echo "::endgroup::"
-          fi
+          # Update the dependencies in the main Cargo.toml
+          sed -i "s/hedera-proto/hiero-sdk-proto/g" Cargo.toml
+
+          echo "::endgroup::"
+          
+          echo "::group::Update TCK Cargo.toml with new dependencies"
+          # Update the dependencies in the tck/Cargo.toml
+          sed -i "s/hedera/hiero-sdk/g" tck/Cargo.toml
+          echo "::endgroup::"
+          
+          echo "::group::Update files with new names"
+          find . -type f -name "*.rs" -exec sed -i "s/\bhedera_proto\b/hiero_sdk_proto/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
+          echo "::endgroup::"
+          
+          echo "::group::Verify Cargo.toml changes"
+          cargo check
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . $HOME/.cargo/env
+          cargo test --workspace
+          cargo generate-lockfile
+          echo "::endgroup::"
 
       - name: Publish proto to crates.io (hiero-sdk-proto)
-        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' }}
+        if: ${{ needs.validate-release.outputs.hiero-proto-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
-        run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            cargo publish ${{ steps.proto-publish-args.outputs.args }}
-          fi
+        run: cargo publish ${{ steps.proto-publish-args.outputs.args }}
         working-directory: protobufs
 
       # TODO<BEGIN>: Remove this group of steps after the hiero-sdk-proto package is published
       - name: Stop the local node (hiero-sdk-proto)
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
         run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            npx @hashgraph/hedera-local stop
-          fi
+          npx @hashgraph/hedera-local stop
 
       - name: Reset the workspace
-        if: ${{ !cancelled() && always() }}
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' && !cancelled() && always() }}
         run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            echo "::group::Reset Workspace"
-            git reset --hard
-            git clean -fdx
-            echo "::endgroup::"
-          fi
+          echo "::group::Reset Workspace"
+          git reset --hard
+          git clean -fdx
+          echo "::endgroup::"
 
       - name: Start the local node (hiero-sdk)
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
         run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
-          fi
+          npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
 
       - name: Create env file (hiero-sdk)
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
         run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            touch .env
-            echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
-            echo TEST_OPERATOR_ID="0.0.1022" >> .env
-            echo TEST_NETWORK_NAME="localhost" >> .env
-            echo TEST_RUN_NONFREE="1" >> .env
-          fi
+          touch .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
+          echo TEST_OPERATOR_ID="0.0.1022" >> .env
+          echo TEST_NETWORK_NAME="localhost" >> .env
+          echo TEST_RUN_NONFREE="1" >> .env
 
       - name: Set up Cargo files for SDK Dual publish
-        if: ${{ !cancelled() && always() }}
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' && !cancelled() && always() }}
         run: |
-          files=("Cargo.toml" "tck/Cargo.toml" "Cargo.lock" "tck/Cargo.lock")
+          echo "::group::Update main Cargo.toml with new name and dependencies"
+          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            echo "::group::Back up Cargo files"
-            for file in "${files[@]}"; do
-              if [[ -f "${file}" ]]; then
-                cp "${file}" "${file}.bak"
-              fi
-            done
-            echo "::endgroup::"
-            
-            echo "::group::Update main Cargo.toml with new name and dependencies"
-            toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-            
-            echo "::group::Update TCK Cargo.toml with new dependencies"
-            # Update the dependencies in the tck/Cargo.toml
-            sed -i "s/hedera =/hiero-sdk =/g" tck/Cargo.toml
-            echo "::endgroup::"
-            
-            echo "::group::Update files with new names"
-            find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
-            find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
-            echo "::endgroup::"
-            
-            echo "::group::Verify Cargo.toml changes"
-            cargo check
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            . $HOME/.cargo/env
-            cargo test --workspace
-            cargo generate-lockfile
-            echo "::endgroup::"
-          fi
+          echo "::group::Update TCK Cargo.toml with new dependencies"
+          # Update the dependencies in the tck/Cargo.toml
+          sed -i "s/hedera =/hiero-sdk =/g" tck/Cargo.toml
+          echo "::endgroup::"
+          
+          echo "::group::Update files with new names"
+          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
+          echo "::endgroup::"
+          
+          echo "::group::Verify Cargo.toml changes"
+          cargo check
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . $HOME/.cargo/env
+          cargo test --workspace
+          cargo generate-lockfile
+          echo "::endgroup::"
       # TODO<END>: Remove this group of steps after the hiero-sdk-proto package is published
 
       - name: Stop the local node
-        run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            npx @hashgraph/hedera-local stop
-          fi
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
+        run: npx @hashgraph/hedera-local stop
 
       - name: Publish SDK to crates.io (hiero-sdk)
+        if: ${{ needs.validate-release.outputs.hiero-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
-        run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            cargo publish ${{ steps.sdk-publish-args.outputs.args }}
-          fi
+        run: cargo publish ${{ steps.sdk-publish-args.outputs.args }}
 
-      - name: Restore Cargo files
-        if: ${{ !cancelled() && always() }}
+      - name: Reset the workspace
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && !cancelled() && always() }}
         run: |
-          files=("Cargo.toml" "protobufs/Cargo.toml" "tck/Cargo.toml" \
-          "Cargo.lock" "protobufs/Cargo.lock" "tck/Cargo.lock")
-          
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            echo "::group::Restore Cargo files"
-            for file in "${files[@]}"; do
-              if [[ -f "${file}.bak" ]]; then
-                mv "${file}.bak" "${file}"
-              fi
-            done
-            echo "::endgroup::"
-          fi
+          echo "::group::Reset Workspace"
+          git reset --hard
+          git clean -fdx
+          echo "::endgroup::"
 
       - name: Generate Github Release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
-        if: ${{ github.event.inputs.dry-run-enabled != 'true' }}
+        if: ${{ env.DRY_RUN_ENABLED != 'true' }}
         with:
           tag: ${{ needs.validate-release.outputs.tag }}
           prerelease: ${{ needs.validate-release.outputs.prerelease == 'true' }}

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -286,6 +286,7 @@ jobs:
           
           echo "::group::Update Cargo.toml with new name"
           toml set Cargo.toml package.name "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          toml set Cargo.toml dependencies.hedera-proto.hiero-sdk-proto "{ version = "${{ needs.validate-release.outputs.sdk-version }}" }" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           cargo generate-lockfile
           echo "::endgroup::"
           
@@ -325,7 +326,8 @@ jobs:
           
           echo "::group::Update Cargo.toml with new name"
           toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          toml set Cargo.toml dependencies.hedera-proto.hiero-sdk-proto "{ version = "${{ needs.validate-release.outputs.sdk-version }}" }" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          toml set Cargo.toml dependencies.hiero-sdk-proto.package "hedera-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          toml set Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           cargo generate-lockfile
           echo "::endgroup::"
           

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -214,20 +214,21 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
 
-      - name: Prepare Hiero Solo
-        id: solo
-        uses: hiero-ledger/hiero-solo-action@a39acf8cfbaa2feb195a86530d0ab643a45aa541 # v0.10
+      - name: Setup NodeJS
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          installMirrorNode: true
-          hieroVersion: v0.63.7
+          node-version: 22
 
-      - name: Set Operator Account
+      - name: Start the local node
+        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.63.7
+
+      - name: Create env file
         run: |
           touch .env
-          echo "TEST_OPERATOR_KEY=${{ steps.solo.outputs.ed25519PrivateKey }}" >> .env
-          echo "TEST_OPERATOR_ID=${{ steps.solo.outputs.ed25519AccountId }}" >> .env
-          echo "TEST_NETWORK_NAME=local-node" >> .env
-          echo "TEST_RUN_NONFREE=1" >> .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
+          echo TEST_OPERATOR_ID="0.0.1022" >> .env
+          echo TEST_NETWORK_NAME="localhost" >> .env
+          echo TEST_RUN_NONFREE="1" >> .env
 
       - name: Run Safety Checks
         run: |
@@ -268,20 +269,21 @@ jobs:
           sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
           cargo install toml-cli
 
-      - name: Prepare Hiero Solo
-        id: solo
-        uses: hiero-ledger/hiero-solo-action@a39acf8cfbaa2feb195a86530d0ab643a45aa541 # v0.10
+      - name: Setup NodeJS
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          installMirrorNode: true
-          hieroVersion: v0.63.7
+          node-version: 22
 
-      - name: Set Operator Account
+      - name: Start the local node
+        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.63.7
+
+      - name: Create env file
         run: |
           touch .env
-          echo "TEST_OPERATOR_KEY=${{ steps.solo.outputs.ed25519PrivateKey }}" >> .env
-          echo "TEST_OPERATOR_ID=${{ steps.solo.outputs.ed25519AccountId }}" >> .env
-          echo "TEST_NETWORK_NAME=local-node" >> .env
-          echo "TEST_RUN_NONFREE=1" >> .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
+          echo TEST_OPERATOR_ID="0.0.1022" >> .env
+          echo TEST_NETWORK_NAME="localhost" >> .env
+          echo TEST_RUN_NONFREE="1" >> .env
 
       - name: Calculate Proto Subpackage Publish Arguments
         id: proto-publish-args

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -385,6 +385,12 @@ jobs:
             echo "::endgroup::"
           fi
 
+      - name: Stop the local node (hiero-sdk-proto)
+        run: |
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            npx @hashgraph/hedera-local stop
+          fi
+
       - name: Publish proto to crates.io (hiero-sdk-proto)
         if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' }}
         env:
@@ -395,12 +401,6 @@ jobs:
           fi
         working-directory: protobufs
 
-      - name: Stop the local node (hiero-sdk-proto)
-        run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            npx @hashgraph/hedera-local stop
-          fi
-
       - name: Start the local node (hiero-sdk)
         run: |
           if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
@@ -410,9 +410,6 @@ jobs:
       # TODO: Remove this step once the hiero-sdk-proto is published
       - name: Set up Cargo files for SDK Dual publish
         if: ${{ !cancelled() && always() }}
-        env:
-          OPERATOR_ID: ${{ secrets.TEST_OPERATOR_ID }}
-          OPERATOR_KEY: ${{ secrets.TEST_OPERATOR_KEY }}
         run: |
           files=("Cargo.toml" "tck/Cargo.toml" "Cargo.lock" "tck/Cargo.lock")
           

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -269,8 +269,12 @@ jobs:
         if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
         run: |
           echo "::group::Back up Cargo files"
-          cp Cargo.toml Cargo.toml.bak
-          cp Cargo.lock Cargo.lock.bak
+          if [[ -f "Cargo.toml" ]]; then
+            cp Cargo.toml Cargo.toml.bak
+          fi
+          if [[ -f "Cargo.lock" ]]; then
+            cp Cargo.lock Cargo.lock.bak
+          fi
           echo "::endgroup::"
           
           echo "::group::Publish hedera-proto to crates.io"
@@ -289,8 +293,12 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Restore Cargo files"
-          mv Cargo.toml.bak Cargo.toml
-          mv Cargo.lock.bak Cargo.lock
+          if [[ -f "Cargo.toml.bak" ]]; then
+            mv Cargo.toml.bak Cargo.toml
+          fi
+          if [[ -f "Cargo.lock.bak" ]]; then
+            mv Cargo.lock.bak Cargo.lock
+          fi
           echo "::endgroup::"
 
       # Hiero SDK depends on the hiero-sdk-proto package
@@ -300,8 +308,12 @@ jobs:
           CARGO_HL_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
         run: |
           echo "::group::Back up Cargo files"
-          cp Cargo.toml Cargo.toml.bak
-          cp Cargo.lock Cargo.lock.bak
+          if [[ -f "Cargo.toml" ]]; then
+            cp Cargo.toml Cargo.toml.bak
+          fi
+          if [[ -f "Cargo.lock" ]]; then
+            cp Cargo.lock Cargo.lock.bak
+          fi
           echo "::endgroup::"
           
           echo "::group::Publish hedera to crates.io"
@@ -321,6 +333,10 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Restore Cargo files"
-          mv Cargo.toml.bak Cargo.toml
-          mv Cargo.lock.bak Cargo.lock
+          if [[ -f "Cargo.toml.bak" ]]; then
+            mv Cargo.toml.bak Cargo.toml
+          fi
+          if [[ -f "Cargo.lock.bak" ]]; then
+            mv Cargo.lock.bak Cargo.lock
+          fi
           echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -12,6 +12,7 @@ on:
         required: false
         default: false
       dual-publish-enabled:
+        # default to true when dual-publishing period is active
         description: "Dual Publish Enabled"
         type: boolean
         required: false
@@ -225,6 +226,9 @@ jobs:
       - validate-release
       - run-safety-checks
     runs-on: hiero-client-sdk-linux-medium
+    env:
+      # Set the default to 'true' when the dual-publishing period is active
+      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || 'false' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
@@ -288,136 +292,144 @@ jobs:
 
       # Update the Cargo.toml files for the hiero-sdk-* packages
       - name: Update Cargo.toml for hiero publishing
-        if: ${{ inputs.dual-publish-enabled == true }}
         run: |
-          echo "::group::Back up Cargo files"
-          if [[ -f "Cargo.toml" ]]; then
-            cp Cargo.toml Cargo.toml.bak
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            echo "::group::Back up Cargo files"
+            if [[ -f "Cargo.toml" ]]; then
+              cp Cargo.toml Cargo.toml.bak
+            fi
+            if [[ -f "Cargo.lock" ]]; then
+              cp Cargo.lock Cargo.lock.bak
+            fi
+            if [[ -f "protobufs/Cargo.toml" ]]; then
+              cp protobufs/Cargo.toml protobufs/Cargo.toml.bak
+            fi
+            if [[ -f "protobufs/Cargo.lock" ]]; then
+              cp protobufs/Cargo.lock protobufs/Cargo.lock.bak
+            fi
+            if [[ -f "tck/Cargo.toml" ]]; then
+              cp tck/Cargo.toml tck/Cargo.toml.bak
+            fi
+            if [[ -f "tck/Cargo.lock" ]]; then
+              cp tck/Cargo.lock tck/Cargo.lock.bak
+            fi
+            echo "::endgroup::"
+            
+            echo "::group::Update protobufs/Cargo.toml with new name"       
+            # Update the dependencies in the protobugs/Cargo.toml
+            toml set protobufs/Cargo.toml package.name "hiero-sdk-proto" > protobufs/Cargo.toml.tmp && mv protobufs/Cargo.toml.tmp protobufs/Cargo.toml
+            echo "::endgroup::"
+            
+            echo "::group::Update main Cargo.toml with new name and dependencies"
+            toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+            
+            # Update the dependencies in the main Cargo.toml
+            sed -i "s/hedera-proto/hiero-sdk-proto/g" Cargo.toml
+  
+            echo "::endgroup::"
+            
+            echo "::group::Update TCK Cargo.toml with new dependencies"
+            # Update the dependencies in the tck/Cargo.toml
+            sed -i "s/hedera/hiero-sdk/g" tck/Cargo.toml
+            echo "::endgroup::"
+            
+            echo "::group::Update files with new names"
+            find . -type f -name "*.rs" -exec sed -i "s/\bhedera_proto\b/hiero_sdk_proto/g" {} +
+            find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
+            find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
+            echo "::endgroup::"
+            
+            echo "::group::Verify Cargo.toml changes"
+            cargo check
+            cargo generate-lockfile
+            echo "::endgroup::"
           fi
-          if [[ -f "Cargo.lock" ]]; then
-            cp Cargo.lock Cargo.lock.bak
-          fi
-          if [[ -f "protobufs/Cargo.toml" ]]; then
-            cp protobufs/Cargo.toml protobufs/Cargo.toml.bak
-          fi
-          if [[ -f "protobufs/Cargo.lock" ]]; then
-            cp protobufs/Cargo.lock protobufs/Cargo.lock.bak
-          fi
-          if [[ -f "tck/Cargo.toml" ]]; then
-            cp tck/Cargo.toml tck/Cargo.toml.bak
-          fi
-          if [[ -f "tck/Cargo.lock" ]]; then
-            cp tck/Cargo.lock tck/Cargo.lock.bak
-          fi
-          echo "::endgroup::"
-          
-          echo "::group::Update protobufs/Cargo.toml with new name"       
-          # Update the dependencies in the protobugs/Cargo.toml
-          toml set protobufs/Cargo.toml package.name "hiero-sdk-proto" > protobufs/Cargo.toml.tmp && mv protobufs/Cargo.toml.tmp protobufs/Cargo.toml
-          echo "::endgroup::"
-          
-          echo "::group::Update main Cargo.toml with new name and dependencies"
-          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          
-          # Update the dependencies in the main Cargo.toml
-          sed -i "s/hedera-proto/hiero-sdk-proto/g" Cargo.toml
-
-          echo "::endgroup::"
-          
-          echo "::group::Update TCK Cargo.toml with new dependencies"
-          # Update the dependencies in the tck/Cargo.toml
-          sed -i "s/hedera/hiero-sdk/g" tck/Cargo.toml
-          echo "::endgroup::"
-          
-          echo "::group::Update files with new names"
-          find . -type f -name "*.rs" -exec sed -i "s/\bhedera_proto\b/hiero_sdk_proto/g" {} +
-          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
-          find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
-          echo "::endgroup::"
-          
-          echo "::group::Verify Cargo.toml changes"
-          cargo check
-          cargo generate-lockfile
-          echo "::endgroup::"
 
       - name: Publish proto to crates.io (hiero-sdk-proto)
-        if: ${{ inputs.dual-publish-enabled == true && needs.validate-release.outputs.proto-publish-required == 'true' }}
+        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
         run: |
-          cargo publish ${{ steps.proto-publish-args.outputs.args }}
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            cargo publish ${{ steps.proto-publish-args.outputs.args }}
+          fi
         working-directory: protobufs
 
       # TODO: Remove this step once the hiero-sdk-proto is published
       - name: Set up Cargo files for SDK Dual publish
-        if: ${{ inputs.dual-publish-enabled == true && always() }}
+        if: ${{ !cancelled() && always() }}
         run: |
-          echo "::group::Reset Workspace"
-          git reset --hard
-          git clean -fdx
-          echo "::endgroup::"
-
-          echo "::group::Back up Cargo files"
-          if [[ -f "Cargo.toml" ]]; then
-            cp Cargo.toml Cargo.toml.bak
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            echo "::group::Reset Workspace"
+            git reset --hard
+            git clean -fdx
+            echo "::endgroup::"
+  
+            echo "::group::Back up Cargo files"
+            if [[ -f "Cargo.toml" ]]; then
+              cp Cargo.toml Cargo.toml.bak
+            fi
+            if [[ -f "Cargo.lock" ]]; then
+              cp Cargo.lock Cargo.lock.bak
+            fi
+            if [[ -f "tck/Cargo.toml" ]]; then
+              cp tck/Cargo.toml tck/Cargo.toml.bak
+            fi
+            if [[ -f "tck/Cargo.lock" ]]; then
+              cp tck/Cargo.lock tck/Cargo.lock.bak
+            fi
+            echo "::endgroup::"
+            
+            echo "::group::Update main Cargo.toml with new name and dependencies"
+            toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+            
+            echo "::group::Update TCK Cargo.toml with new dependencies"
+            # Update the dependencies in the tck/Cargo.toml
+            sed -i "s/hedera =/hiero-sdk =/g" tck/Cargo.toml
+            cat tck/Cargo.toml
+            echo "::endgroup::"
+            
+            echo "::group::Update files with new names"
+            find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
+            find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
+            echo "::endgroup::"
+            
+            echo "::group::Verify Cargo.toml changes"
+            cargo check
+            cargo generate-lockfile
+            echo "::endgroup::"
           fi
-          if [[ -f "Cargo.lock" ]]; then
-            cp Cargo.lock Cargo.lock.bak
-          fi
-          if [[ -f "tck/Cargo.toml" ]]; then
-            cp tck/Cargo.toml tck/Cargo.toml.bak
-          fi
-          if [[ -f "tck/Cargo.lock" ]]; then
-            cp tck/Cargo.lock tck/Cargo.lock.bak
-          fi
-          echo "::endgroup::"
-          
-          echo "::group::Update main Cargo.toml with new name and dependencies"
-          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          
-          echo "::group::Update TCK Cargo.toml with new dependencies"
-          # Update the dependencies in the tck/Cargo.toml
-          sed -i "s/hedera =/hiero-sdk =/g" tck/Cargo.toml
-          cat tck/Cargo.toml
-          echo "::endgroup::"
-          
-          echo "::group::Update files with new names"
-          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
-          find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
-          echo "::endgroup::"
-          
-          echo "::group::Verify Cargo.toml changes"
-          cargo check
-          cargo generate-lockfile
-          echo "::endgroup::"
 
       - name: Publish SDK to crates.io (hiero-sdk)
-        if: ${{ inputs.dual-publish-enabled == true }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
         run: |
-          cargo publish ${{ steps.sdk-publish-args.outputs.args }}
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            cargo publish ${{ steps.sdk-publish-args.outputs.args }}
+          fi
 
       - name: Restore Cargo files
-        if: ${{ inputs.dual-publish-enabled == true && always() }}
+        if: ${{ !cancelled() && always() }}
         run: |
-          echo "::group::Restore Cargo files"
-          if [[ -f "Cargo.toml.bak" ]]; then
-            mv Cargo.toml.bak Cargo.toml
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            echo "::group::Restore Cargo files"
+            if [[ -f "Cargo.toml.bak" ]]; then
+              mv Cargo.toml.bak Cargo.toml
+            fi
+            if [[ -f "Cargo.lock.bak" ]]; then
+              mv Cargo.lock.bak Cargo.lock
+            fi
+            if [[ -f "protobufs/Cargo.toml.bak" ]]; then
+              mv protobufs/Cargo.toml.bak protobufs/Cargo.toml
+            fi
+            if [[ -f "protobufs/Cargo.lock.bak" ]]; then
+              mv protobufs/Cargo.lock.bak protobufs/Cargo.lock
+            fi
+            if [[ -f "tck/Cargo.toml.bak" ]]; then
+              mv tck/Cargo.toml.bak tck/Cargo.toml
+            fi
+            if [[ -f "tck/Cargo.lock.bak" ]]; then
+              mv tck/Cargo.lock.bak tck/Cargo.lock
+            fi
+            echo "::endgroup::"
           fi
-          if [[ -f "Cargo.lock.bak" ]]; then
-            mv Cargo.lock.bak Cargo.lock
-          fi
-          if [[ -f "protobufs/Cargo.toml.bak" ]]; then
-            mv protobufs/Cargo.toml.bak protobufs/Cargo.toml
-          fi
-          if [[ -f "protobufs/Cargo.lock.bak" ]]; then
-            mv protobufs/Cargo.lock.bak protobufs/Cargo.lock
-          fi
-          if [[ -f "tck/Cargo.toml.bak" ]]; then
-            mv tck/Cargo.toml.bak tck/Cargo.toml
-          fi
-          if [[ -f "tck/Cargo.lock.bak" ]]; then
-            mv tck/Cargo.lock.bak tck/Cargo.lock
-          fi
-          echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -345,6 +345,48 @@ jobs:
           cargo publish ${{ steps.proto-publish-args.outputs.args }}
         working-directory: protobufs
 
+      # TODO: Remove this step once the hiero-sdk-proto is published
+      - name: Set up Cargo files for sdk Dual publish
+        if: ${{ inputs.dual-publish-enabled == true && always() }}
+        run: |
+          echo "::group::Reset Workspace"
+          git reset --hard
+          git clean -fdx
+          echo "::endgroup::"
+
+          echo "::group::Back up Cargo files"
+          if [[ -f "Cargo.toml" ]]; then
+            cp Cargo.toml Cargo.toml.bak
+          fi
+          if [[ -f "Cargo.lock" ]]; then
+            cp Cargo.lock Cargo.lock.bak
+          fi
+          if [[ -f "tck/Cargo.toml" ]]; then
+            cp tck/Cargo.toml tck/Cargo.toml.bak
+          fi
+          if [[ -f "tck/Cargo.lock" ]]; then
+            cp tck/Cargo.lock tck/Cargo.lock.bak
+          fi
+          echo "::endgroup::"
+          
+          echo "::group::Update main Cargo.toml with new name and dependencies"
+          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          
+          echo "::group::Update TCK Cargo.toml with new dependencies"
+          # Update the dependencies in the tck/Cargo.toml
+          sed -i "s/\bhedera\b/hiero-sdk/g" tck/Cargo.toml
+          echo "::endgroup::"
+          
+          echo "::group::Update files with new names"
+          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
+          echo "::endgroup::"
+          
+          echo "::group::Verify Cargo.toml changes"
+          cargo check
+          cargo generate-lockfile
+          echo "::endgroup::"
+
       - name: Publish SDK to crates.io (hiero-sdk)
         if: ${{ inputs.dual-publish-enabled == true }}
         env:

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -1,6 +1,5 @@
 name: "Publish Release"
 on:
-  INTENTIONALLY BREAK FLOW
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -327,8 +327,8 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Update files with new names"
-          find . -type f -name "*.rs" -exec sed -i "s/hedera_proto/hiero_sdk_proto/g" {} +
-          find . -type f -name "*.rs" -exec sed -i "s/hedera/hiero_sdk/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera_proto\b/use hiero_sdk_proto/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
           echo "::endgroup::"
           
           echo "group::Verify Cargo.toml changes"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -246,7 +246,7 @@ jobs:
         working-directory: protobufs
         if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
         run: |
-          PUBLISH_ARGS="--locked"
+          PUBLISH_ARGS="--locked --allow-dirty"
           [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
           
           echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
@@ -255,7 +255,7 @@ jobs:
         id: sdk-publish-args
         if: ${{ !cancelled() && !failure() }}
         run: |
-          PUBLISH_ARGS="--locked"
+          PUBLISH_ARGS="--locked --allow-dirty"
           [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
           
           echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -303,7 +303,7 @@ jobs:
           sed -i "s/features = \"\['time_0_3', 'fraction'\]\"/features = [\"time_0_3\", \"fraction\"]/g" Cargo.toml
           
           # Remove the hedera-proto dependency from the main Cargo.toml
-          sed -i '/^hedera-proto\s*=.*/d' ../Cargo.toml
+          sed '/hedera-proto\s*=.*/d' ../Cargo.toml > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
           
           # Ensure the Cargo.toml is valid
           cargo check
@@ -362,7 +362,7 @@ jobs:
           sed -i "s/features = \"\['time_0_3', 'fraction'\]\"/features = [\"time_0_3\", \"fraction\"]/g" Cargo.toml
           
           # Remove the hedera-proto dependency from the main Cargo.toml
-          sed -i '/^hedera-proto\s*=.*/d' Cargo.toml
+          sed '/hedera-proto\s*=.*/d' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
           cargo check
           cargo generate-lockfile

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -374,7 +374,8 @@ jobs:
           
           echo "::group::Update TCK Cargo.toml with new dependencies"
           # Update the dependencies in the tck/Cargo.toml
-          sed -i "s/\bhedera\b/hiero-sdk/g" tck/Cargo.toml
+          sed -i "s/\bhedera =\b/hiero-sdk =/g" tck/Cargo.toml
+          cat tck/Cargo.toml
           echo "::endgroup::"
           
           echo "::group::Update files with new names"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -374,7 +374,7 @@ jobs:
           
           echo "::group::Update TCK Cargo.toml with new dependencies"
           # Update the dependencies in the tck/Cargo.toml
-          sed -i "s/\bhedera =\b/hiero-sdk =/g" tck/Cargo.toml
+          sed -i "s/hedera =/hiero-sdk =/g" tck/Cargo.toml
           cat tck/Cargo.toml
           echo "::endgroup::"
           

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -43,10 +43,10 @@ jobs:
       proto-publish-required: ${{ steps.proto-required.outputs.proto-publish-required }}
 
       # tck subpackage
-      tck-version: ${{ steps.cargo-versions.outputs.sdk-tck-version }}
-      tck-prerelease: ${{ steps.tck-tag.outputs.prerelease }}
-      tck-type: ${{ steps.tck-tag.outputs.type }}
-      tck-publish-required: ${{ steps.tck-required.outputs.tck-publish-required }}
+#      tck-version: ${{ steps.cargo-versions.outputs.sdk-tck-version }}
+#      tck-prerelease: ${{ steps.tck-tag.outputs.prerelease }}
+#      tck-type: ${{ steps.tck-tag.outputs.type }}
+#      tck-publish-required: ${{ steps.tck-required.outputs.tck-publish-required }}
 
     steps:
       - name: Harden Runner
@@ -77,18 +77,18 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: 1.88.0
-          components: rustfmt, toml-cli, cargo-info
+          components: toml-cli
     
       - name: Extract Cargo.toml Versions
         id: cargo-versions
         run: |
           SDK_PACKAGE_VERSION="$(toml get Cargo.toml package.version --raw)"
           SDK_PROTO_VERSION="$(toml get protobufs/Cargo.toml package.version --raw)"
-          SDK_TCK_VERSION="$(toml get tck/Cargo.toml package.version --raw)"
+#          SDK_TCK_VERSION="$(toml get tck/Cargo.toml package.version --raw)"
           
           echo "sdk-version=${SDK_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "sdk-proto-version=${SDK_PROTO_VERSION}" >>"${GITHUB_OUTPUT}"
-          echo "sdk-tck-version=${SDK_TCK_VERSION}" >>"${GITHUB_OUTPUT}"
+#          echo "sdk-tck-version=${SDK_TCK_VERSION}" >>"${GITHUB_OUTPUT}"
       
       - name: Proto Subpackage Publish Required
         id: proto-required
@@ -102,14 +102,14 @@ jobs:
           done
           echo "proto-publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
 
-      - name: TCK Subpackage Publish Required
-        id: tck-required
-        run: |
-          PUBLISH_REQUIRED="false"
-          if ! curl -sSLf "https://crates.io/api/v1/crates/hiero-sdk-tck/${{ steps.cargo-versions.outputs.sdk-tck-version }}" >/dev/null 2>&1;
-            PUBLISH_REQUIRED="true"
-          fi
-          echo "tck-publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
+#      - name: TCK Subpackage Publish Required
+#        id: tck-required
+#        run: |
+#          PUBLISH_REQUIRED="false"
+#          if ! curl -sSLf "https://crates.io/api/v1/crates/hiero-sdk-tck/${{ steps.cargo-versions.outputs.sdk-tck-version }}" >/dev/null 2>&1;
+#            PUBLISH_REQUIRED="true"
+#          fi
+#          echo "tck-publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
 
       - name: Extract SDK Tag Information
         id: sdk-tag
@@ -184,38 +184,38 @@ jobs:
           echo "## Proto Subpackage Release Information" >> "${GITHUB_STEP_SUMMARY}"
           echo "SDK_PROTO_VERSION=${{ steps.cargo-versions.outputs.sdk-proto-version }}" >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Extract TCK Subpackage Information
-        id: tck-tag
-        run: |
-          IS_VALID_SEMVER="$(semver validate "${{ steps.cargo-versions.outputs.sdk-tck-version }}")"
-          
-          if [[ "${IS_VALID_SEMVER}" != "valid" ]]; then
-            echo "::error title=Invalid TCK Tag::The proto version '${{ steps.cargo-versions.outputs.sdk-tck-version }}' is not a valid SemVer tag."
-            exit 1
-          fi
-          
-          PREREL_VERSION="$(semver get prerel '${{ steps.cargo-versions.outputs.sdk-tck-version }}')"
-          PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
-          
-          IS_PRERELEASE="false"
-          [[ -n "${PREREL_VERSION}" ]] && IS_PRERELEASE="true"
-          
-          PREREL_TYPE="unknown"
-          if [[ "${IS_PRERELEASE}" == "true" ]]; then
-            if [[ "${PREREL_VERSION_LC}" =~ "beta" ]]; then
-              PREREL_TYPE="beta"
-            else
-              PREREL_TYPE="unknown"
-            fi
-          else
-            PREREL_TYPE="production"
-          fi
-
-          echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
-          echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
-          
-          echo "## TCK Subpackage Release Information" >> "${GITHUB_STEP_SUMMARY}"
-          echo "SDK_TCK_VERSION=${{ steps.cargo-versions.outputs.sdk-tck-version }}" >> "${GITHUB_STEP_SUMMARY}"
+#      - name: Extract TCK Subpackage Information
+#        id: tck-tag
+#        run: |
+#          IS_VALID_SEMVER="$(semver validate "${{ steps.cargo-versions.outputs.sdk-tck-version }}")"
+#
+#          if [[ "${IS_VALID_SEMVER}" != "valid" ]]; then
+#            echo "::error title=Invalid TCK Tag::The proto version '${{ steps.cargo-versions.outputs.sdk-tck-version }}' is not a valid SemVer tag."
+#            exit 1
+#          fi
+#
+#          PREREL_VERSION="$(semver get prerel '${{ steps.cargo-versions.outputs.sdk-tck-version }}')"
+#          PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
+#
+#          IS_PRERELEASE="false"
+#          [[ -n "${PREREL_VERSION}" ]] && IS_PRERELEASE="true"
+#
+#          PREREL_TYPE="unknown"
+#          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+#            if [[ "${PREREL_VERSION_LC}" =~ "beta" ]]; then
+#              PREREL_TYPE="beta"
+#            else
+#              PREREL_TYPE="unknown"
+#            fi
+#          else
+#            PREREL_TYPE="production"
+#          fi
+#
+#          echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
+#          echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
+#
+#          echo "## TCK Subpackage Release Information" >> "${GITHUB_STEP_SUMMARY}"
+#          echo "SDK_TCK_VERSION=${{ steps.cargo-versions.outputs.sdk-tck-version }}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Validate Tag and Cargo.toml Versions
         run: |
@@ -260,6 +260,7 @@ jobs:
     name: Publish SDK to crates.io
     needs:
       - validate-release
+      - run-safety-checks
     runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner
@@ -277,11 +278,109 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: 1.88.0
-          components: rustfmt, toml-cli
+          components: toml-cli
 
-      - name: Publish to crates.io
+      - name: Calculate Proto Subpackage Publish Arguments
+        id: proto-publish-args
+        working-directory: protobufs
+        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
+        run: |
+          PUBLISH_ARGS="--locked"
+          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
+          
+          echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
+      
+#      - name: Calculate TCK Subpackage Publish Arguments
+#        id: tck-publish-args
+#        working-directory: tck
+#        if: ${{ needs.validate-release.outputs.tck-publish-required == 'true' && !cancelled() && !failure() }}
+#        run: |
+#          PUBLISH_ARGS="--locked"
+#          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
+#
+#          echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
+
+      - name: Calculate SDK Publish Arguments
+        id: sdk-publish-args
+        if: ${{ !cancelled() && !failure() }}
+        run: |
+          PUBLISH_ARGS="--locked"
+          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
+          
+          echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
+
+      # Publish the hiero-sdk-proto package
+      - name: Publish Proto Subpackage to crates.io
+        working-directory: protobufs
         env:
           CARGO_HG_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
+          CARGO_HL_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
+        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
         run: |
+          echo "::group::Back up Cargo files"
+          cp Cargo.toml Cargo.toml.bak
+          cp Cargo.lock Cargo.lock.bak
+          echo "::endgroup::"
+          
+          echo "::group::Publish hedera-proto to crates.io"
           export CARGO_REGISTRY_TOKEN="${CARGO_HG_TOKEN}"
-          cargo publish --locked
+          cargo publish ${{ steps.proto-publish-args.outputs.args }}
+          echo "::endgroup::"
+          
+          echo "::group::Update Cargo.toml with new name"
+          toml set Cargo.toml package.name "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          cargo generate-lockfile
+          echo "::endgroup::"
+          
+          echo "::group::Publish hiero-sdk-proto to crates.io"
+          export CARGO_REGISTRY_TOKEN="${CARGO_HL_TOKEN}"
+          cargo publish ${{ steps.proto-publish-args.outputs.args }}
+          echo "::endgroup::"
+          
+          echo "::group::Restore Cargo files"
+          mv Cargo.toml.bak Cargo.toml
+          mv Cargo.lock.bak Cargo.lock
+          echo "::endgroup::"
+
+      # Hiero SDK depends on the hiero-sdk-proto package
+      - name: Publish SDK to crates.io
+        env:
+          CARGO_HG_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
+          CARGO_HL_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
+        run: |
+          echo "::group::Back up Cargo files"
+          cp Cargo.toml Cargo.toml.bak
+          cp Cargo.lock Cargo.lock.bak
+          echo "::endgroup::"
+          
+          echo "::group::Publish hedera to crates.io"
+          export CARGO_REGISTRY_TOKEN="${CARGO_HG_TOKEN}"
+          cargo publish ${{ steps.sdk-publish-args.outputs.args }}
+          echo "::endgroup::"
+          
+          echo "::group::Update Cargo.toml with new name"
+          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          toml set Cargo.toml dependencies.hedera-proto.hiero-sdk-proto "{ version = "${{ needs.validate-release.outputs.sdk-version }}" }" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          cargo generate-lockfile
+          echo "::endgroup::"
+          
+          echo "::group::Publish hiero-sdk to crates.io"
+          export CARGO_REGISTRY_TOKEN="${CARGO_HL_TOKEN}"
+          cargo publish ${{ steps.sdk-publish-args.outputs.args }}
+          echo "::endgroup::"
+          
+          echo "::group::Restore Cargo files"
+          mv Cargo.toml.bak Cargo.toml
+          mv Cargo.lock.bak Cargo.lock
+          echo "::endgroup::"
+
+      # Publish the hiero-sdk-tck package which depends on hiero-sdk and hiero-sdk-proto
+#      - name: Publish TCK Subpackage to crates.io
+#        env:
+#          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
+#        working-directory: tck
+#        if: ${{ needs.validate-release.outputs.tck-publish-required == 'true' && !cancelled() && !failure() }}
+#        run: |
+#          echo "::group::Publish hedera-tck to crates.io"
+#          cargo publish ${{ steps.tck-publish-args.outputs.args }}
+#          echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -274,27 +274,6 @@ jobs:
           sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
           cargo install toml-cli
 
-      - name: Setup NodeJS
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22
-
-      - name: Start the local node
-        run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
-          fi
-
-      - name: Create env file
-        run: |
-          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
-            touch .env
-            echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
-            echo TEST_OPERATOR_ID="0.0.1022" >> .env
-            echo TEST_NETWORK_NAME="localhost" >> .env
-            echo TEST_RUN_NONFREE="1" >> .env
-          fi
-
       - name: Calculate Proto Subpackage Publish Arguments
         id: proto-publish-args
         if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' }}
@@ -317,7 +296,7 @@ jobs:
           
           echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
 
-      # Publish the hiero-sdk-proto package
+      # Publish the hedera-proto package
       - name: Publish Proto Subpackage to crates.io (hedera-proto)
         if: ${{ needs.validate-release.outputs.proto-publish-required == 'true'}}
         env:
@@ -326,12 +305,33 @@ jobs:
           cargo publish ${{ steps.proto-publish-args.outputs.args }}
         working-directory: protobufs
 
-      # Publish the main SDK package
+      # Publish the main SDK package (hedera)
       - name: Publish SDK to crates.io (hedera)
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
         run: |
           cargo publish ${{ steps.sdk-publish-args.outputs.args }}
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Start the local node (hiero-sdk-proto)
+        run: |
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
+          fi
+
+      - name: Create env file
+        run: |
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            touch .env
+            echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
+            echo TEST_OPERATOR_ID="0.0.1022" >> .env
+            echo TEST_NETWORK_NAME="localhost" >> .env
+            echo TEST_RUN_NONFREE="1" >> .env
+          fi
 
       # Update the Cargo.toml files for the hiero-sdk-* packages
       - name: Update Cargo.toml for hiero publishing
@@ -395,6 +395,18 @@ jobs:
           fi
         working-directory: protobufs
 
+      - name: Stop the local node (hiero-sdk-proto)
+        run: |
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            npx @hashgraph/hedera-local stop
+          fi
+
+      - name: Start the local node (hiero-sdk)
+        run: |
+          if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
+            npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
+          fi
+
       # TODO: Remove this step once the hiero-sdk-proto is published
       - name: Set up Cargo files for SDK Dual publish
         if: ${{ !cancelled() && always() }}
@@ -440,7 +452,7 @@ jobs:
             echo "::endgroup::"
           fi
 
-      - name: Stop the local node
+      - name: Stop the local node (hiero-sdk)
         run: |
           if [[ "${DUAL_PUBLISH_ENABLED}" == "true" ]]; then
             npx @hashgraph/hedera-local stop

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -292,7 +292,7 @@ jobs:
           
           echo "::group::Update Cargo.toml with new name"
           toml set Cargo.toml package.name "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          toml set ../Cargo.toml dependencies.hiero-sdk-proto.package "hedera-proto" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
+          toml set ../Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
           toml set ../Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
           toml set ../Cargo.toml dependencies.hiero-sdk-proto.features '["time_0_3","fraction"]' > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
           sed -i '/^hedera-proto\s*=.*/d' ../Cargo.toml

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -291,11 +291,21 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Update Cargo.toml with new name"
+          # Update the package name in protobufs/Cargo.toml
           toml set Cargo.toml package.name "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          
+          # Update the dependencies in the main Cargo.toml
           toml set ../Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
           toml set ../Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
-          toml set ../Cargo.toml dependencies.hiero-sdk-proto.features '["time_0_3","fraction"]' > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
+          toml set ../Cargo.toml dependencies.hiero-sdk-proto.features "[time_0_3, fraction]" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
+          
+          # Convert features from string to array format
+          sed -i -e 's/features = "\[\([^"]*\)\]"/features = [\1]/' -e 's/\([^", \[]\+\)/"\1"/g' ../Cargo.toml
+          
+          # Remove the hedera-proto dependency from the main Cargo.toml
           sed -i '/^hedera-proto\s*=.*/d' ../Cargo.toml
+          
+          # Ensure the Cargo.toml is valid
           cargo check
           echo "::endgroup::"
           
@@ -340,11 +350,16 @@ jobs:
           # Update the package name in protobufs/Cargo.toml
           toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
-          # Update the dependencies in the main Cargo.toml
+          # Update the dependencies in the protobugs/Cargo.toml
           toml set protobufs/Cargo.toml package.name "hiero-sdk-proto" > protobufs/Cargo.toml.tmp && mv protobufs/Cargo.toml.tmp protobufs/Cargo.toml
+          
+          # Update the dependencies in the main Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.package "hedera-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          toml set Cargo.toml dependencies.hiero-sdk-proto.features "["time_0_3","fraction",]" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          toml set Cargo.toml dependencies.hiero-sdk-proto.features "[time_0_3, fraction]" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          
+          # Convert features from string to array format
+          sed -i -e 's/features = "\[\([^"]*\)\]"/features = [\1]/' -e 's/\([^", \[]\+\)/"\1"/g' Cargo.toml
           
           # Remove the hedera-proto dependency from the main Cargo.toml
           sed -i '/^hedera-proto\s*=.*/d' Cargo.toml

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -297,10 +297,10 @@ jobs:
           # Update the dependencies in the main Cargo.toml
           toml set ../Cargo.toml dependencies.hiero-sdk-proto.package "hiero-sdk-proto" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
           toml set ../Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
-          toml set ../Cargo.toml dependencies.hiero-sdk-proto.features "[time_0_3, fraction]" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
+          toml set ../Cargo.toml dependencies.hiero-sdk-proto.features "['time_0_3', 'fraction']" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
           
           # Convert features from string to array format
-          sed -i -e 's/features = "\[\([^"]*\)\]"/features = [\1]/' -e 's/\([^", \[]\+\)/"\1"/g' ../Cargo.toml
+          sed -i "s/features = \"\['time_0_3', 'fraction'\]\"/features = [\"time_0_3\", \"fraction\"]/g" Cargo.toml
           
           # Remove the hedera-proto dependency from the main Cargo.toml
           sed -i '/^hedera-proto\s*=.*/d' ../Cargo.toml
@@ -356,10 +356,10 @@ jobs:
           # Update the dependencies in the main Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.package "hedera-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          toml set Cargo.toml dependencies.hiero-sdk-proto.features "[time_0_3, fraction]" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          toml set Cargo.toml dependencies.hiero-sdk-proto.features "['time_0_3', 'fraction']" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
           # Convert features from string to array format
-          sed -i -e 's/features = "\[\([^"]*\)\]"/features = [\1]/' -e 's/\([^", \[]\+\)/"\1"/g' Cargo.toml
+          sed -i "s/features = \"\['time_0_3', 'fraction'\]\"/features = [\"time_0_3\", \"fraction\"]/g" Cargo.toml
           
           # Remove the hedera-proto dependency from the main Cargo.toml
           sed -i '/^hedera-proto\s*=.*/d' Cargo.toml

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -1,5 +1,6 @@
 name: "Publish Release"
 on:
+  INTENTIONALLY BREAK FLOW
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -203,6 +203,11 @@ jobs:
         with:
           toolchain: 1.88.0
 
+      - name: Install components
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev
+
       - name: Run Safety Checks
         run: |
           echo "::group::Run Safety Checks"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -470,7 +470,7 @@ jobs:
 
       - name: Generate Github Release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
-        if: ${{ inputs.dry-run-enabled != 'true' }}
+        if: ${{ github.event.inputs.dry-run-enabled != 'true' }}
         with:
           tag: ${{ needs.validate-release.outputs.tag }}
           prerelease: ${{ needs.validate-release.outputs.prerelease == 'true' }}

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -277,6 +277,12 @@ jobs:
           if [[ -f "Cargo.lock" ]]; then
             cp Cargo.lock Cargo.lock.bak
           fi
+          if [[ -f "Cargo.toml" ]]; then
+            cp ../Cargo.toml ../Cargo.toml.bak
+          fi
+          if [[ -f "Cargo.lock" ]]; then
+            cp ../Cargo.lock ../Cargo.lock.bak
+          fi
           echo "::endgroup::"
           
           echo "::group::Publish hedera-proto to crates.io"
@@ -286,6 +292,8 @@ jobs:
           
           echo "::group::Update Cargo.toml with new name"
           toml set Cargo.toml package.name "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          toml set ../Cargo.toml dependencies.hiero-sdk-proto.package "hedera-proto" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
+          toml set ../Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
           echo "::endgroup::"
           
           echo "::group::Publish hiero-sdk-proto to crates.io"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -308,7 +308,8 @@ jobs:
 
       - name: Calculate Proto Subpackage Publish Arguments
         id: proto-publish-args
-        if: ${{ needs.validate-release.outputs.proto-publish-required == 'true' }}
+        if: ${{ needs.validate-release.outputs.hedera-proto-publish-required == 'true' || 
+              needs.validate-release.outputs.hiero-proto-publish-required == 'true' }}
         run: |
           PUBLISH_ARGS="--locked --allow-dirty"
           [[ "${DRY_RUN_ENABLED}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
@@ -317,6 +318,8 @@ jobs:
         working-directory: protobufs
 
       - name: Calculate SDK Publish Arguments
+        if: ${{ needs.validate-release.outputs.hedera-publish-required == 'true' ||
+                needs.validate-release.outputs.hiero-publish-required == 'true' }}
         id: sdk-publish-args
         run: |
           PUBLISH_ARGS="--locked --allow-dirty"
@@ -400,7 +403,9 @@ jobs:
         if: ${{ needs.validate-release.outputs.hiero-proto-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
-        run: cargo publish ${{ steps.proto-publish-args.outputs.args }}
+        run: | 
+          echo "cargo publish ${{ steps.proto-publish-args.outputs.args }}"
+          cargo publish ${{ steps.proto-publish-args.outputs.args }}
         working-directory: protobufs
 
       # TODO<BEGIN>: Remove this group of steps after the hiero-sdk-proto package is published

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -362,6 +362,7 @@ jobs:
           cargo publish ${{ steps.sdk-publish-args.outputs.args }}
 
       - name: Restore Cargo files
+        if: ${{ always() }}
         run: |
           echo "::group::Restore Cargo files"
           if [[ -f "Cargo.toml.bak" ]]; then

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -294,7 +294,7 @@ jobs:
           toml set Cargo.toml package.name "hiero-sdk-proto" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           toml set ../Cargo.toml dependencies.hiero-sdk-proto.package "hedera-proto" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
           toml set ../Cargo.toml dependencies.hiero-sdk-proto.version "${{ needs.validate-release.outputs.sdk-version }}" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
-          toml set ../Cargo.toml dependencies.hiero-sdk-proto.features "["time_0_3","fraction",]" > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
+          toml set ../Cargo.toml dependencies.hiero-sdk-proto.features '["time_0_3","fraction"]' > ../Cargo.toml.tmp && mv ../Cargo.toml.tmp ../Cargo.toml
           sed -i '/^hedera-proto\s*=.*/d' ../Cargo.toml
           cargo check
           echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -220,7 +220,7 @@ jobs:
           node-version: 22
 
       - name: Start the local node
-        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.63.7
+        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
 
       - name: Create env file
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea/
 .task/
 target
+**/Cargo.toml.bak
+**/Cargo.lock.bak

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
+name = "hiero-sdk-tck"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures-util",
+ "hedera",
+ "hedera-proto",
+ "hex",
+ "hex-literal",
+ "hyper",
+ "jsonrpsee",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tower 0.4.13",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,30 +2489,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tck"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures-util",
- "hedera",
- "hedera-proto",
- "hex",
- "hex-literal",
- "hyper",
- "jsonrpsee",
- "once_cell",
- "serde",
- "serde_json",
- "time",
- "tokio",
- "tower 0.4.13",
- "tower-http",
- "tracing",
- "tracing-subscriber",
-]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,7 @@ fraction = { version = "0.15.1", default-features = false }
 futures-core = "0.3.31"
 # Transitive dependency of tonic 0.12
 h2 = "0.4.11"
-hedera-proto = { path = "./protobufs", version = "0.17.0", features = [
-  "time_0_3",
-  "fraction",
-] }
+hedera-proto = { path = "./protobufs", version = "0.17.0", features = ["time_0_3","fraction"] }
 hex = "0.4.3"
 hmac = "0.12.1"
 # Dependency of tonic 0.12

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "hedera"
 readme = "README.md"
-repository = "https://github.com/hashgraph/hedera-sdk-rust"
+repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
 version = "0.36.0"
 
 [lib]
@@ -65,7 +65,6 @@ tower = { version = "0.5.2", features = ["util"] }
 openssl = "0.10.72"
 hyper-util = "0.1.14"
 hyper-openssl = {version = "0.10.2", features = ["client-legacy"]}
-
 
 [dependencies.futures-util]
 version = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ fraction = { version = "0.15.1", default-features = false }
 futures-core = "0.3.31"
 # Transitive dependency of tonic 0.12
 h2 = "0.4.11"
-hedera-proto = { path = "./protobufs", version = "0.17.0", features = ["time_0_3","fraction"] }
+hedera-proto = { path = "./protobufs", version = "0.17.0", features = ["time_0_3", "fraction"] }
 hex = "0.4.3"
 hmac = "0.12.1"
 # Dependency of tonic 0.12

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@
 
 ## Release
 
-In the main directory, use the the following steps to publish to [hedera](https://crates.io/crates/hedera): 
+In the main directory, use the following steps to publish to [hedera](https://crates.io/crates/hedera): 
 
 1. Create a new git branch: `release/vX.Y.Z`.
 2. Run all tests against [hiero-local-node](https://github.com/hiero-ledger/hiero-local-node). Stop local-node once the tests are completed.

--- a/protobufs/Cargo.toml
+++ b/protobufs/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "hedera-proto"
 description = "Protobufs for the Hedera™ Hashgraph SDK"
-repository = "https://github.com/hashgraph/hedera-sdk-rust"
+repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
 version = "0.17.0"
 
 [features]

--- a/tck/Cargo.toml
+++ b/tck/Cargo.toml
@@ -16,10 +16,7 @@ async-trait = "0.1.88"
 hyper = "1.6.0"
 tower-http = { version = "0.6.6", features = ["full"] }
 hedera = { path = "../." }
-hedera-proto = { path = "../protobufs", version = "0.17.0", features = [
-  "time_0_3",
-  "fraction",
-] }
+hedera-proto = { path = "../protobufs", version = "0.17.0", features = ["time_0_3", "fraction"] }
 once_cell = "1.21.3"
 futures-util = "0.3.31"
 serde_json = {version = "1.0.140", features = ["raw_value"] }

--- a/tck/Cargo.toml
+++ b/tck/Cargo.toml
@@ -15,8 +15,8 @@ tracing = "0.1.41"
 async-trait = "0.1.88"
 hyper = "1.6.0"
 tower-http = { version = "0.6.6", features = ["full"] }
-hiero-sdk = { path = "../." }
-hiero-sdk-proto = { path = "../protobufs", version = "0.17.0", features = [
+hedera = { path = "../." }
+hedera-proto = { path = "../protobufs", version = "0.17.0", features = [
   "time_0_3",
   "fraction",
 ] }

--- a/tck/Cargo.toml
+++ b/tck/Cargo.toml
@@ -15,8 +15,8 @@ tracing = "0.1.41"
 async-trait = "0.1.88"
 hyper = "1.6.0"
 tower-http = { version = "0.6.6", features = ["full"] }
-hedera = { path = "../." }
-hedera-proto = { path = "../protobufs", version = "0.17.0", features = [
+hiero-sdk = { path = "../." }
+hiero-sdk-proto = { path = "../protobufs", version = "0.17.0", features = [
   "time_0_3",
   "fraction",
 ] }

--- a/tck/Cargo.toml
+++ b/tck/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "tck"
+name = "hiero-sdk-tck"
 version = "0.1.0"
 edition = "2021"
+repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Description

- Adds publishing workflow `zxf-publish-release.yaml`
  - Enables publishing via gh workflow
  - Enables dual publishing of the rust SDK

- Commented with TODOs where we need to modify this after we do initial publishes to the hiero namespaces

**Related Issue(s)**:

Implements #1008

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
  - [x] [Dual Publish Enabled](https://github.com/hiero-ledger/hiero-sdk-rust/actions/runs/16361765185)
  - [x] [Dual Publish Disabled](https://github.com/hiero-ledger/hiero-sdk-rust/actions/runs/16362175463)
