### PR TITLE
fix: handle domain names in addressbook

### DIFF
--- a/src/service_endpoint.rs
+++ b/src/service_endpoint.rs
@@ -39,6 +39,11 @@ fn validate_domain_name(domain_name: String) -> crate::Result<()> {
     }
 
     // Check for valid domain name format (simplified)
+    // Allow localhost and single-word domains for local development
+    if domain_name == "localhost" {
+        return Ok(());
+    }
+
     if !domain_name.contains('.') || domain_name.starts_with('.') || domain_name.ends_with('.') {
         return Err(Error::from_protobuf("Invalid domain name format"));
     }
@@ -98,5 +103,206 @@ impl ToProtobuf for ServiceEndpoint {
             port: self.port,
             domain_name: self.domain_name.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    #[test]
+    fn test_service_endpoint_with_ip_address() {
+        let ip = Ipv4Addr::new(192, 168, 1, 1);
+        let endpoint =
+            ServiceEndpoint { ip_address_v4: Some(ip), port: 50211, domain_name: String::new() };
+
+        let pb = endpoint.to_protobuf();
+        assert_eq!(pb.ip_address_v4, vec![192, 168, 1, 1]);
+        assert_eq!(pb.port, 50211);
+        assert_eq!(pb.domain_name, "");
+
+        let deserialized = ServiceEndpoint::from_protobuf(pb).unwrap();
+        assert_eq!(deserialized.ip_address_v4, Some(ip));
+        assert_eq!(deserialized.port, 50211);
+        assert_eq!(deserialized.domain_name, "");
+    }
+
+    #[test]
+    fn test_service_endpoint_with_domain_name() {
+        let endpoint = ServiceEndpoint {
+            ip_address_v4: None,
+            port: 50211,
+            domain_name: "example.com".to_string(),
+        };
+
+        let pb = endpoint.to_protobuf();
+        assert_eq!(pb.ip_address_v4, vec![] as Vec<u8>);
+        assert_eq!(pb.port, 50211);
+        assert_eq!(pb.domain_name, "example.com");
+
+        let deserialized = ServiceEndpoint::from_protobuf(pb).unwrap();
+        assert_eq!(deserialized.ip_address_v4, None);
+        assert_eq!(deserialized.port, 50211);
+        assert_eq!(deserialized.domain_name, "example.com");
+    }
+
+    #[test]
+    fn test_service_endpoint_with_empty_ip_address() {
+        let endpoint = ServiceEndpoint {
+            ip_address_v4: None,
+            port: 50211,
+            domain_name: "localhost".to_string(),
+        };
+
+        let pb = endpoint.to_protobuf();
+        assert_eq!(pb.ip_address_v4, vec![] as Vec<u8>);
+        assert_eq!(pb.port, 50211);
+        assert_eq!(pb.domain_name, "localhost");
+
+        let deserialized = ServiceEndpoint::from_protobuf(pb).unwrap();
+        assert_eq!(deserialized.ip_address_v4, None);
+        assert_eq!(deserialized.port, 50211);
+        assert_eq!(deserialized.domain_name, "localhost");
+    }
+
+    #[test]
+    fn test_service_endpoint_port_defaulting() {
+        // Test port 0 gets defaulted to 50211
+        let pb = services::ServiceEndpoint {
+            ip_address_v4: vec![192, 168, 1, 1],
+            port: 0,
+            domain_name: String::new(),
+        };
+
+        let endpoint = ServiceEndpoint::from_protobuf(pb).unwrap();
+        assert_eq!(endpoint.port, 50211);
+
+        // Test port 50111 gets defaulted to 50211
+        let pb = services::ServiceEndpoint {
+            ip_address_v4: vec![192, 168, 1, 1],
+            port: 50111,
+            domain_name: String::new(),
+        };
+
+        let endpoint = ServiceEndpoint::from_protobuf(pb).unwrap();
+        assert_eq!(endpoint.port, 50211);
+    }
+
+    #[test]
+    fn test_service_endpoint_domain_name_validation() {
+        // Valid domain name
+        let pb = services::ServiceEndpoint {
+            ip_address_v4: vec![],
+            port: 50211,
+            domain_name: "valid-domain.com".to_string(),
+        };
+
+        let result = ServiceEndpoint::from_protobuf(pb);
+        assert!(result.is_ok());
+
+        // Invalid domain name (too long)
+        let long_domain = "a".repeat(254);
+        let pb = services::ServiceEndpoint {
+            ip_address_v4: vec![],
+            port: 50211,
+            domain_name: long_domain,
+        };
+
+        let result = ServiceEndpoint::from_protobuf(pb);
+        assert!(result.is_err());
+
+        // Invalid domain name (invalid characters)
+        let pb = services::ServiceEndpoint {
+            ip_address_v4: vec![],
+            port: 50211,
+            domain_name: "invalid@domain.com".to_string(),
+        };
+
+        let result = ServiceEndpoint::from_protobuf(pb);
+        assert!(result.is_err());
+
+        // Invalid domain name (starts with dot)
+        let pb = services::ServiceEndpoint {
+            ip_address_v4: vec![],
+            port: 50211,
+            domain_name: ".domain.com".to_string(),
+        };
+
+        let result = ServiceEndpoint::from_protobuf(pb);
+        assert!(result.is_err());
+
+        // Invalid domain name (ends with dot)
+        let pb = services::ServiceEndpoint {
+            ip_address_v4: vec![],
+            port: 50211,
+            domain_name: "domain.com.".to_string(),
+        };
+
+        let result = ServiceEndpoint::from_protobuf(pb);
+        assert!(result.is_err());
+
+        // Invalid domain name (no dots)
+        let pb = services::ServiceEndpoint {
+            ip_address_v4: vec![],
+            port: 50211,
+            domain_name: "domain".to_string(),
+        };
+
+        let result = ServiceEndpoint::from_protobuf(pb);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_service_endpoint_round_trip() {
+        let original = ServiceEndpoint {
+            ip_address_v4: Some(Ipv4Addr::new(10, 0, 0, 1)),
+            port: 50211,
+            domain_name: "test.example.com".to_string(),
+        };
+
+        let pb = original.to_protobuf();
+        let deserialized = ServiceEndpoint::from_protobuf(pb).unwrap();
+
+        assert_eq!(deserialized.ip_address_v4, original.ip_address_v4);
+        assert_eq!(deserialized.port, original.port);
+        assert_eq!(deserialized.domain_name, original.domain_name);
+    }
+
+    #[test]
+    fn test_service_endpoint_with_localhost() {
+        let endpoint = ServiceEndpoint {
+            ip_address_v4: None,
+            port: 50211,
+            domain_name: "localhost".to_string(),
+        };
+
+        let pb = endpoint.to_protobuf();
+        assert_eq!(pb.ip_address_v4, vec![] as Vec<u8>);
+        assert_eq!(pb.port, 50211);
+        assert_eq!(pb.domain_name, "localhost");
+
+        let deserialized = ServiceEndpoint::from_protobuf(pb).unwrap();
+        assert_eq!(deserialized.ip_address_v4, None);
+        assert_eq!(deserialized.port, 50211);
+        assert_eq!(deserialized.domain_name, "localhost");
+    }
+
+    #[test]
+    fn test_service_endpoint_with_127_0_0_1() {
+        let ip = Ipv4Addr::new(127, 0, 0, 1);
+        let endpoint =
+            ServiceEndpoint { ip_address_v4: Some(ip), port: 50211, domain_name: String::new() };
+
+        let pb = endpoint.to_protobuf();
+        assert_eq!(pb.ip_address_v4, vec![127, 0, 0, 1]);
+        assert_eq!(pb.port, 50211);
+        assert_eq!(pb.domain_name, "");
+
+        let deserialized = ServiceEndpoint::from_protobuf(pb).unwrap();
+        assert_eq!(deserialized.ip_address_v4, Some(ip));
+        assert_eq!(deserialized.port, 50211);
+        assert_eq!(deserialized.domain_name, "");
     }
 }


### PR DESCRIPTION
**Description**:
This change correctly handles domain-names in address-book query and adds support for insecure local connections (using solo)
**Related issue(s)**:
https://github.com/hiero-ledger/hiero-sdk-rust/issues/905
https://github.com/hiero-ledger/hiero-sdk-rust/issues/1025

Fixes #
https://github.com/hiero-ledger/hiero-sdk-rust/issues/1025


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
