### PR TITLE
chore: Bump Protobufs and impl fees in ScheduleTransaction

### DIFF
--- a/src/fee_schedules.rs
+++ b/src/fee_schedules.rs
@@ -795,6 +795,9 @@ pub enum FeeDataType {
     /// The resource prices are scoped to a [`TopicCreateTransaction`](crate::TopicCreateTransaction)
     /// with a custom fee schedule.
     TopicCreateWithCustomFees,
+
+    /// The resource prices are scoped to a submit message operation with custom fees.
+    SubmitMessageWithCustomFees,
 }
 
 impl FromProtobuf<services::SubType> for FeeDataType {
@@ -810,6 +813,7 @@ impl FromProtobuf<services::SubType> for FeeDataType {
             }
             SubType::ScheduleCreateContractCall => Self::ScheduleCreateContractCall,
             SubType::TopicCreateWithCustomFees => Self::TopicCreateWithCustomFees,
+            SubType::SubmitMessageWithCustomFees => Self::SubmitMessageWithCustomFees,
         };
 
         Ok(value)
@@ -831,6 +835,7 @@ impl ToProtobuf for FeeDataType {
             }
             Self::ScheduleCreateContractCall => SubType::ScheduleCreateContractCall,
             Self::TopicCreateWithCustomFees => SubType::TopicCreateWithCustomFees,
+            Self::SubmitMessageWithCustomFees => SubType::SubmitMessageWithCustomFees,
         }
     }
 }

--- a/src/schedule/schedulable_transaction_body.rs
+++ b/src/schedule/schedulable_transaction_body.rs
@@ -102,6 +102,7 @@ impl SchedulableTransactionBody {
                 .max_transaction_fee
                 .unwrap_or_else(|| self.data.default_max_transaction_fee())
                 .to_tinybars() as u64,
+            max_custom_fees: vec![],
         }
     }
 }

--- a/src/schedule/schedule_create_transaction.rs
+++ b/src/schedule/schedule_create_transaction.rs
@@ -294,6 +294,7 @@ mod tests {
                         SchedulableTransactionBody {
                             transaction_fee: 200000000,
                             memo: "",
+                            max_custom_fees: [],
                             data: Some(
                                 CryptoTransfer(
                                     CryptoTransferTransactionBody {
@@ -428,6 +429,7 @@ mod tests {
                 data: Some(
                     scheduled_transaction().data().to_schedulable_transaction_data_protobuf(),
                 ),
+                max_custom_fees: vec![],
             }),
             memo: SCHEDULE_MEMO.to_owned(),
             admin_key: Some(admin_key().to_protobuf()),

--- a/src/schedule/schedule_create_transaction.rs
+++ b/src/schedule/schedule_create_transaction.rs
@@ -185,6 +185,7 @@ impl ToTransactionDataProtobuf for ScheduleCreateTransactionData {
                     .max_transaction_fee
                     .unwrap_or_else(|| scheduled.data.default_max_transaction_fee())
                     .to_tinybars() as u64,
+                max_custom_fees: vec![],
             }
         });
 

--- a/src/schedule/schedule_info.rs
+++ b/src/schedule/schedule_info.rs
@@ -274,6 +274,7 @@ mod tests {
                     SchedulableTransactionBody {
                         transaction_fee: 200000000,
                         memo: "",
+                        max_custom_fees: [],
                         data: Some(
                             CryptoDelete(
                                 CryptoDeleteTransactionBody {
@@ -459,6 +460,7 @@ mod tests {
                     SchedulableTransactionBody {
                         transaction_fee: 200000000,
                         memo: "",
+                        max_custom_fees: [],
                         data: Some(
                             CryptoDelete(
                                 CryptoDeleteTransactionBody {


### PR DESCRIPTION
**Description**:

Updates Rust SDK protobufs version to v0.65.0. Also introduces placeholder fields for fees in ScheduleTransaction. This PR will not entirely resolve https://github.com/hiero-ledger/hiero-sdk-rust/issues/1033 but provides us with solid grounds for creating tests. The Rust compiler required us adding the fields in this PR.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-rust/issues/1034

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
