### PR TITLE
chore: Set version to 0.38.0-beta.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "hedera"
 readme = "README.md"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
-version = "0.37.0"
+version = "0.38.0-beta.1"
 
 [lib]
 bench = false


### PR DESCRIPTION
**Description**:
Updates Cargo.toml version to 0.38.0-beta.1 for testing changes to rust publishing
