### PR TITLE
ci: Update workflows for publishing and testing on PRs for consistency and correctness

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "PR Formatting"
+on:
+  pull_request_target:
+    types:
+      - assigned
+      - unassigned
+      - labeled
+      - unlabeled
+      - opened
+      - reopened
+      - edited
+      - converted_to_draft
+      - ready_for_review
+      - review_requested
+      - review_request_removed
+      - locked
+      - unlocked
+      - synchronize
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  statuses: write
+
+jobs:
+  title-check:
+    name: Title Check
+    runs-on: hiero-client-sdk-linux-medium
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Check PR Title
+        uses: step-security/conventional-pr-title-action@8a8989588c2547f23167c4c42f0fb2356479e81b # v3.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  assignee-check:
+    name: Assignee Check
+    runs-on: hiero-client-sdk-linux-medium
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Check Assignee
+        if: ${{ github.event.pull_request.assignees == null || github.event.pull_request.assignees[0] == null }}
+        run: |
+          echo "Assignee is not set. Failing the workflow."
+          exit 1

--- a/.github/workflows/flow-rust-ci.yaml
+++ b/.github/workflows/flow-rust-ci.yaml
@@ -12,11 +12,6 @@ permissions:
     contents: read
 
 env:
-  SOLO_CLUSTER_NAME: "solo-rust"
-  SOLO_NAMESPACE: "solo-rust"
-  SOLO_CLUSTER_SETUP_NAMESPACE: "solo-rust-cluster"
-  SOLO_DEPLOYMENT: "solo-rust-deployment"
-  CONSENSUS_NODE_VERSION: "v0.60.0-alpha.0"
   NODE_VERSION: "20.18.3"
 
 jobs:
@@ -114,31 +109,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      # Set up kind; needed for configuring the solo environment
-      - name: Setup Kind
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+      - name: Prepare Hiero Solo
+        id: solo
+        uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0
         with:
-          install_only: true
-          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
-          version: v0.26.0
-          kubectl_version: v1.31.4
-          verbosity: 3
-          wait: 120s
-
-      # Install solo and configure it for the safety checks
-      - name: Install Solo
-        run: npm install -g @hashgraph/solo@${{ vars.SOLO_VERSION }}
-
-      - name: Configure Solo
-        run: |
-          echo "::group::Kind Create Cluster"
-          kind create cluster -n "${SOLO_CLUSTER_NAME}"
-          echo "::endgroup::"
-
-          echo "::group::Solo Quick Start Single Deploy"
-          # Configures the entire network including the consensus node, mirror node, rpc, and explorer
-          solo quick-start single deploy
-          echo "::endgroup::"
+          installMirrorNode: true
+          hieroVersion: v0.60.0-alpha.0
 
       - name: Create env file
         run: |
@@ -153,12 +129,4 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
-          cargo test --workspace  
-
-      - name: Clean up solo deployment
-        run: |
-          solo quick-start single destroy
-          for cluster in $(kind get clusters); do
-            kind delete cluster -n $cluster
-          done
-          rm -rf ~/.solo
+          cargo test --workspace

--- a/.github/workflows/flow-rust-ci.yaml
+++ b/.github/workflows/flow-rust-ci.yaml
@@ -1,4 +1,4 @@
-name: Rust CI
+name: "Flow: Rust CI"
 on:
   pull_request:
   push:
@@ -59,11 +59,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Rust Cache
-        uses: step-security/rust-cache@94e3ae6a5bdb04807deb1cb2274adab839828881 # v2.8.0
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
-          workspaces: |
-            sdk/rust
+          toolchain: 1.88.0
 
       - name: Setup GCC and OpenSSL
         run: |
@@ -95,11 +94,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Rust Cache
-        uses: step-security/rust-cache@94e3ae6a5bdb04807deb1cb2274adab839828881 # v2.8.0
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
-          workspaces: |
-            .
+          toolchain: 1.88.0
 
       - name: Setup GCC and OpenSSL
         run: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -142,7 +142,7 @@ jobs:
           solo quick-start single deploy
           echo "::endgroup::"
 
-      - name: "Create env file"
+      - name: Create env file
         run: |
             touch .env
             echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -11,6 +11,13 @@ defaults:
 permissions:
     contents: read
 
+env:
+  SOLO_CLUSTER_NAME: "solo-rust"
+  SOLO_NAMESPACE: "solo-rust"
+  SOLO_CLUSTER_SETUP_NAMESPACE: "solo-rust-cluster"
+  SOLO_DEPLOYMENT: "solo-rust-deployment"
+  CONSENSUS_NODE_VERSION: "v0.60.0-alpha.0"
+
 jobs:
   format:
     runs-on: hiero-client-sdk-linux-medium
@@ -117,12 +124,36 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare Hiero Solo
-        id: solo
-        uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0
+      - name: Setup NodeJS
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          installMirrorNode: true
-          hieroVersion: v0.60.0-alpha.0
+          node-version: 20.18.3
+
+      # Set up kind; needed for configuring the solo environment
+      - name: Setup Kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          install_only: true
+          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+          version: v0.26.0
+          kubectl_version: v1.31.4
+          verbosity: 3
+          wait: 120s
+
+      # Install solo and configure it for the safety checks
+      - name: Install Solo
+        run: npm install -g @hashgraph/solo@${{ vars.SOLO_VERSION }}
+
+      - name: Configure Solo
+        run: |
+          echo "::group::Kind Create Cluster"
+          kind create cluster -n "${SOLO_CLUSTER_NAME}"
+          echo "::endgroup::"
+
+          echo "::group::Solo Quick Start Single Deploy"
+          # Configures the entire network including the consensus node, mirror node, rpc, and explorer
+          solo quick-start single deploy
+          echo "::endgroup::"
 
       - name: "Create env file"
         run: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -80,14 +80,6 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
           cargo check --examples --workspace
-
-      - name: Clean up solo deployment
-        run: |
-          solo quick-start single destroy
-          for cluster in $(kind get clusters); do
-            kind delete cluster -n $cluster
-          done
-          rm -rf ~/.solo
   
   test:
     needs: ['check']

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -17,6 +17,7 @@ env:
   SOLO_CLUSTER_SETUP_NAMESPACE: "solo-rust-cluster"
   SOLO_DEPLOYMENT: "solo-rust-deployment"
   CONSENSUS_NODE_VERSION: "v0.60.0-alpha.0"
+  NODE_VERSION: "20.18.3"
 
 jobs:
   format:
@@ -53,16 +54,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Setup NodeJS
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 18
-
-      - name: Setup GCC and OpenSSL
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev libssl-dev pkg-config openssl
-
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -74,10 +65,11 @@ jobs:
           workspaces: |
             sdk/rust
 
-      - name: Install pkg-config
+      - name: Setup GCC and OpenSSL
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config
+          sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev libssl-dev pkg-config openssl
+
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
@@ -88,6 +80,14 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
           cargo check --examples --workspace
+
+      - name: Clean up solo deployment
+        run: |
+          solo quick-start single destroy
+          for cluster in $(kind get clusters); do
+            kind delete cluster -n $cluster
+          done
+          rm -rf ~/.solo
   
   test:
     needs: ['check']
@@ -97,16 +97,6 @@ jobs:
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
-
-      - name: Setup NodeJS
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22
-
-      - name: Setup GCC and OpenSSL
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev libssl-dev pkg-config openssl
 
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -119,6 +109,11 @@ jobs:
           workspaces: |
             .
 
+      - name: Setup GCC and OpenSSL
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev libssl-dev pkg-config openssl
+
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
@@ -127,7 +122,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.18.3
+          node-version: ${{ env.NODE_VERSION }}
 
       # Set up kind; needed for configuring the solo environment
       - name: Setup Kind
@@ -169,3 +164,11 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
           cargo test --workspace  
+
+      - name: Clean up solo deployment
+        run: |
+          solo quick-start single destroy
+          for cluster in $(kind get clusters); do
+            kind delete cluster -n $cluster
+          done
+          rm -rf ~/.solo

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -7,11 +7,10 @@ on:
         type: string
         required: true
       dual-publish-enabled:
-        # default to true when dual-publishing period is active
         description: "Dual Publish Enabled"
         type: boolean
         required: false
-        default: false
+        default: true
       dry-run-enabled:
         description: "Dry Run Enabled"
         type: boolean
@@ -41,7 +40,7 @@ jobs:
     name: Validate Release
     runs-on: hiero-client-sdk-linux-medium
     env:
-      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || 'false' }}
+      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || 'true' }}
     outputs:
       # Project tag
       tag: ${{ steps.sdk-tag.outputs.name }}
@@ -325,8 +324,7 @@ jobs:
       - run-safety-checks
     runs-on: hiero-client-sdk-linux-medium
     env:
-      # Set the default to 'true' when the dual-publishing period is active
-      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || 'false' }}
+      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || 'true' }}
       DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled || 'false' }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -220,9 +220,39 @@ jobs:
             exit 1
           fi
 
+  set-solo-props:
+    name: Set Solo Outputs
+    runs-on: hiero-client-sdk-linux-medium
+    outputs:
+      solo-cluster-name: ${{ steps.solo-vars.outputs.cluster-name }}
+      solo-namespace: ${{ steps.solo-vars.outputs.namespace }}
+      solo-cluster-setup-namespace: ${{ steps.solo-vars.outputs.cluster-setup-namespace }}
+      solo-deployment: ${{ steps.solo-vars.outputs.deployment }}
+      solo-account-id: ${{ steps.solo-vars.outputs.account-id }}
+      solo-account-key: ${{ steps.solo-vars.outputs.account-key }}
+      solo-hcn-version: ${{ steps.solo-vars.outputs.consensus-node-version }}
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Set Solo Vars
+        id: solo-vars
+        run: |
+          echo "cluster-name=solo-rust" >> "${GITHUB_OUTPUT}"
+          echo "namespace=solo-rust" >> "${GITHUB_OUTPUT}"
+          echo "cluster-setup-namespace=solo-rust-cluster" >> "${GITHUB_OUTPUT}"
+          echo "deployment=solo-rust-deployment" >> "${GITHUB_OUTPUT}"
+          echo "account-id=0.0.2" >> "${GITHUB_OUTPUT}"
+          echo "account-key=302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> "${GITHUB_OUTPUT}"
+          echo "consensus-node-version=v0.60.0-alpha.0" >> "${GITHUB_OUTPUT}"
+
   run-safety-checks:
     name: Safety Checks
     runs-on: hiero-client-sdk-linux-medium
+    needs: set-solo-props
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -248,23 +278,42 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version: 20.18.0
 
-      # Uses the latest commit of the hiero-ledger/hiero-solo-action main branch (3bb6a23cc7915a38bde580c84a6c02c986dcac8f)
-      # this is the first version that supports the hbarAmount input.
-      - name: Prepare Hiero Solo
-        id: solo
-        uses: hiero-ledger/hiero-solo-action@3bb6a23cc7915a38bde580c84a6c02c986dcac8f # latest
+      # Set up kind; needed for configuring the solo environment
+      - name: Setup Kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          installMirrorNode: true
-          hieroVersion: v0.60.0-alpha.0
-          hbarAmount: 10000000000
+          install_only: true
+          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+          version: v0.26.0
+          kubectl_version: v1.31.4
+          verbosity: 3
+          wait: 120s
+
+      - name: Set up yq
+        uses: step-security/setup-yq@ad0cf3bb7054291a414b615c1160ce0af1193a26 # v1.0.1
+
+      # Install solo and configure it for the safety checks
+      - name: Install Solo
+        run: npm install -g @hashgraph/solo@${{ vars.SOLO_VERSION }}
+
+      - name: Configure Solo
+        run: |
+          kind create cluster -n "${{ needs.set-solo-props.outputs.solo-cluster-name }}"
+          solo quick-start single deploy
+          SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
+          solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
+          solo node start --deployment "${SOLO_DEPLOYMENT}"
+          solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref "kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}" --enable-ingress
+          solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}
+          solo relay deploy -i node1 --deployment "${SOLO_DEPLOYMENT}"
 
       - name: Create env file
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
-          echo TEST_OPERATOR_ID="0.0.2" >> .env
+          echo TEST_OPERATOR_KEY="${{ needs.set-solo-props.outputs.solo-account-key }}" >> .env
+          echo TEST_OPERATOR_ID="${{ needs.set-solo-props.outputs.solo-account-id }}" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
@@ -283,6 +332,7 @@ jobs:
     needs:
       - validate-release
       - run-safety-checks
+      - set-solo-props
     runs-on: hiero-client-sdk-linux-medium
     env:
       # Set the default to 'true' when the dual-publishing period is active
@@ -350,24 +400,43 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version: 20.18.0
 
-      # Uses the latest commit of the hiero-ledger/hiero-solo-action main branch (3bb6a23cc7915a38bde580c84a6c02c986dcac8f)
-      # this is the first version that supports the hbarAmount input.
-      - name: Prepare Hiero Solo
-        id: solo
-        uses: hiero-ledger/hiero-solo-action@3bb6a23cc7915a38bde580c84a6c02c986dcac8f # latest
+      # Set up kind; needed for configuring the solo environment
+      - name: Setup Kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          installMirrorNode: true
-          hieroVersion: v0.60.0-alpha.0
-          hbarAmount: 10000000000
+          install_only: true
+          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+          version: v0.26.0
+          kubectl_version: v1.31.4
+          verbosity: 3
+          wait: 120s
+
+      - name: Set up yq
+        uses: step-security/setup-yq@ad0cf3bb7054291a414b615c1160ce0af1193a26 # v1.0.1
+
+      # Install solo and configure it for the safety checks
+      - name: Install Solo
+        run: npm install -g @hashgraph/solo@${{ vars.SOLO_VERSION }}
+
+      - name: Configure Solo
+        run: |
+          kind create cluster -n "${{ needs.set-solo-props.outputs.solo-cluster-name }}"
+          solo quick-start single deploy
+          SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
+          solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
+          solo node start --deployment "${SOLO_DEPLOYMENT}"
+          solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref "kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}" --enable-ingress
+          solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}
+          solo relay deploy -i node1 --deployment "${SOLO_DEPLOYMENT}"
 
       - name: Create env file
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
-          echo TEST_OPERATOR_ID="0.0.2" >> .env
+          echo TEST_OPERATOR_KEY="${{ needs.set-solo-props.outputs.solo-account-key }}" >> .env
+          echo TEST_OPERATOR_ID="${{ needs.set-solo-props.outputs.solo-account-id }}" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -260,8 +260,8 @@ jobs:
       - name: Create env file
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
-          echo TEST_OPERATOR_ID="0.0.2" >> .env
+          echo TEST_OPERATOR_KEY="${{ steps.solo.outputs.ecdsaPrivateKey }}" >> .env
+          echo TEST_OPERATOR_ID="${{ steps.solo.outputs.accountId }}" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
@@ -270,7 +270,7 @@ jobs:
         env:
           #SOLO_DEPLOYMENT: "${{ steps.solo.outputs.deployment }}"
           SOLO_DEPLOYMENT: "solo-deployment"
-          TEST_OPERATOR_ID: "0.0.2"
+          TEST_OPERATOR_ID: "${{ steps.solo.outputs.accountId }}"
         run: |
           echo "::group::Run Safety Checks"
           cargo check
@@ -365,8 +365,8 @@ jobs:
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
-          echo TEST_OPERATOR_ID="0.0.2" >> .env
+          echo TEST_OPERATOR_KEY="${{ steps.solo.outputs.ecdsaPrivateKey }}" >> .env
+          echo TEST_OPERATOR_ID="${{ steps.solo.outputs.accountId }}" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
@@ -377,7 +377,7 @@ jobs:
         env:
           #SOLO_DEPLOYMENT: "${{ steps.solo.outputs.deployment }}"
           SOLO_DEPLOYMENT: "solo-deployment"
-          TEST_OPERATOR_ID: "0.0.2"
+          TEST_OPERATOR_ID: "${{ steps.solo.outputs.accountId }}"
         run: |
           echo "::group::Update protobufs/Cargo.toml with new name"       
           # Update the dependencies in the protobugs/Cargo.toml

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -349,48 +349,6 @@ jobs:
         with:
           node-version: 22
 
-      # Set up the node environment
-      # Version 20.18.0 is the recommended version for solo.
-      - name: Setup NodeJS Environment
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 20.18.0
-
-      # Set up kind; needed for configuring the solo environment
-      - name: Setup Kind
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
-        with:
-          install_only: true
-          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
-          version: v0.26.0
-          kubectl_version: v1.31.4
-          verbosity: 3
-          wait: 120s
-
-      # Install solo and configure to use the artifacts from
-      # the hiero-consensus-node build
-      - name: Install Solo
-        run: npm install -g @hashgraph/solo@0.37.1
-
-      - name: Configure and run solo
-        run: |
-          kind create cluster -n "${{ env.SOLO_CLUSTER_NAME }}"
-          solo init
-          solo cluster-ref connect --cluster-ref kind-${{ env.SOLO_CLUSTER_NAME }} --context kind-${{ env.SOLO_CLUSTER_NAME }}
-          solo deployment create -n "${{ env.SOLO_NAMESPACE }}" --deployment "${{ env.SOLO_DEPLOYMENT }}"
-          solo deployment add-cluster --deployment "${{ env.SOLO_DEPLOYMENT }}" --cluster-ref kind-${{ env.SOLO_CLUSTER_NAME }} --num-consensus-nodes 1
-          solo node keys --gossip-keys --tls-keys -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}"
-          solo cluster-ref setup -s "${{ env.SOLO_CLUSTER_SETUP_NAMESPACE }}"
-          solo network deploy -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}"
-          solo node setup -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}" --local-build-path ./hedera-node/data
-          solo node start -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}"
-          solo mirror-node deploy --deployment "${{ env.SOLO_DEPLOYMENT }}" --cluster-ref kind-${{ env.SOLO_CLUSTER_NAME }}
-
-          kubectl port-forward svc/haproxy-node1-svc -n "${{ env.SOLO_NAMESPACE }}" 50211:non-tls-grpc-client-port &
-          kubectl port-forward svc/mirror-monitor -n "${{ env.SOLO_NAMESPACE }}" 5600:http &
-          kubectl port-forward svc/mirror-rest -n "${{ env.SOLO_NAMESPACE }}" 5551:http &
-          kubectl port-forward svc/mirror-restjava -n "${{ env.SOLO_NAMESPACE }}" 8084:http &
-
       - name: Prepare Hiero Solo
         id: solo
         uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -309,7 +309,7 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Solo Node Setup and Start"
-          SOLO_DEPLOYMENT=`yq '.deployments.[].name' ~/.solo/local-config.yaml`
+          SOLO_DEPLOYMENT=$(yq eval -r '.deployments.[].name' ~/.solo/local-config.yaml)
           solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
           solo node start --deployment "${SOLO_DEPLOYMENT}"
           echo "::endgroup::"
@@ -450,7 +450,7 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Solo Node Setup and Start"
-          SOLO_DEPLOYMENT=`yq '.deployments.[].name' ~/.solo/local-config.yaml`
+          SOLO_DEPLOYMENT=$(yq eval -r '.deployments.[].name' ~/.solo/local-config.yaml)
           solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
           solo node start --deployment "${SOLO_DEPLOYMENT}"
           echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -264,6 +264,8 @@ jobs:
           echo TEST_OPERATOR_ID="0.0.2" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
+          #echo SOLO_DEPLOYMENT="${{ steps.solo.outputs.deployment }}" >> .env
+          echo SOLO_DEPLOYMENT="solo-deployment" >> .env
           cat .env
 
       - name: Run Safety Checks
@@ -272,6 +274,7 @@ jobs:
           cargo check
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
+          solo account update --account-id "${TEST_OPERATOR_ID}" --deployment "${SOLO_DEPLOYMENT}" --hbar-amount 1000000000
           cargo test --workspace
           echo "::endgroup::"
 
@@ -364,6 +367,8 @@ jobs:
           echo TEST_OPERATOR_ID="0.0.2" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
+          #echo SOLO_DEPLOYMENT="${{ steps.solo.outputs.deployment }}" >> .env
+          echo SOLO_DEPLOYMENT="solo-deployment" >> .env
           cat .env
 
       # Update the Cargo.toml files for the hiero-sdk-* packages
@@ -401,6 +406,7 @@ jobs:
           cargo check
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
+          solo account update --account-id "${TEST_OPERATOR_ID}" --deployment "${SOLO_DEPLOYMENT}" --hbar-amount 1000000000
           cargo test --workspace
           cargo generate-lockfile
           echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -28,6 +28,13 @@ defaults:
 permissions:
   contents: write
 
+env:
+  SOLO_CLUSTER_NAME: "solo-rust"
+  SOLO_NAMESPACE: "solo-rust"
+  SOLO_CLUSTER_SETUP_NAMESPACE: "solo-rust-cluster"
+  SOLO_DEPLOYMENT: "solo-rust-deployment"
+  CONSENSUS_NODE_VERSION: "v0.60.0-alpha.0"
+
 jobs:
   validate-release:
     name: Validate Release
@@ -220,39 +227,9 @@ jobs:
             exit 1
           fi
 
-  set-solo-props:
-    name: Set Solo Outputs
-    runs-on: hiero-client-sdk-linux-medium
-    outputs:
-      solo-cluster-name: ${{ steps.solo-vars.outputs.cluster-name }}
-      solo-namespace: ${{ steps.solo-vars.outputs.namespace }}
-      solo-cluster-setup-namespace: ${{ steps.solo-vars.outputs.cluster-setup-namespace }}
-      solo-deployment: ${{ steps.solo-vars.outputs.deployment }}
-      solo-account-id: ${{ steps.solo-vars.outputs.account-id }}
-      solo-account-key: ${{ steps.solo-vars.outputs.account-key }}
-      solo-hcn-version: ${{ steps.solo-vars.outputs.consensus-node-version }}
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: audit
-
-      - name: Set Solo Vars
-        id: solo-vars
-        run: |
-          echo "cluster-name=solo-rust" >> "${GITHUB_OUTPUT}"
-          echo "namespace=solo-rust" >> "${GITHUB_OUTPUT}"
-          echo "cluster-setup-namespace=solo-rust-cluster" >> "${GITHUB_OUTPUT}"
-          echo "deployment=solo-rust-deployment" >> "${GITHUB_OUTPUT}"
-          echo "account-id=0.0.2" >> "${GITHUB_OUTPUT}"
-          echo "account-key=302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> "${GITHUB_OUTPUT}"
-          echo "consensus-node-version=v0.60.0-alpha.0" >> "${GITHUB_OUTPUT}"
-
   run-safety-checks:
     name: Safety Checks
     runs-on: hiero-client-sdk-linux-medium
-    needs: set-solo-props
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -291,11 +268,6 @@ jobs:
           verbosity: 3
           wait: 120s
 
-      - name: Setup yq
-        uses: step-security/setup-yq@ad0cf3bb7054291a414b615c1160ce0af1193a26 # v1.0.1
-        with:
-          yq-version: v4.47.1
-
       # Install solo and configure it for the safety checks
       - name: Install Solo
         run: npm install -g @hashgraph/solo@${{ vars.SOLO_VERSION }}
@@ -303,25 +275,19 @@ jobs:
       - name: Configure Solo
         run: |
           echo "::group::Kind Create Cluster"
-          kind create cluster -n "${{ needs.set-solo-props.outputs.solo-cluster-name }}"
+          kind create cluster -n "${SOLO_CLUSTER_NAME}"
           echo "::endgroup::"
           
           echo "::group::Solo Quick Start Single Deploy"
           # Configures the entire network including the consensus node, mirror node, rpc, and explorer
           solo quick-start single deploy
           echo "::endgroup::"
-          
-          echo "::group::Solo Node Setup and Start"
-          SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
-          solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
-          solo node start --deployment "${SOLO_DEPLOYMENT}"
-          echo "::endgroup::"
 
       - name: Create env file
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="${{ needs.set-solo-props.outputs.solo-account-key }}" >> .env
-          echo TEST_OPERATOR_ID="${{ needs.set-solo-props.outputs.solo-account-id }}" >> .env
+          echo TEST_OPERATOR_KEY="0.0.2" >> .env
+          echo TEST_OPERATOR_ID="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
@@ -429,11 +395,6 @@ jobs:
           verbosity: 3
           wait: 120s
 
-      - name: Setup yq
-        uses: step-security/setup-yq@ad0cf3bb7054291a414b615c1160ce0af1193a26 # v1.0.1
-        with:
-          yq-version: v4.47.1
-
       # Install solo and configure it for the safety checks
       - name: Install Solo
         run: npm install -g @hashgraph/solo@${{ vars.SOLO_VERSION }}
@@ -441,26 +402,19 @@ jobs:
       - name: Configure Solo
         run: |
           echo "::group::Kind Create Cluster"
-          kind create cluster -n "${{ needs.set-solo-props.outputs.solo-cluster-name }}"
+          kind create cluster -n "${SOLO_CLUSTER_NAME}"
           echo "::endgroup::"
-          
+
           echo "::group::Solo Quick Start Single Deploy"
           # Configures the entire network including the consensus node, mirror node, rpc, and explorer
           solo quick-start single deploy
           echo "::endgroup::"
-          
-          echo "::group::Solo Node Setup and Start"
-          SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
-          solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
-          solo node start --deployment "${SOLO_DEPLOYMENT}"
-          echo "::endgroup::"
 
       - name: Create env file
-        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="${{ needs.set-solo-props.outputs.solo-account-key }}" >> .env
-          echo TEST_OPERATOR_ID="${{ needs.set-solo-props.outputs.solo-account-id }}" >> .env
+          echo TEST_OPERATOR_KEY="0.0.2" >> .env
+          echo TEST_OPERATOR_ID="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -250,7 +250,12 @@ jobs:
       - name: Install components
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
+          sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev libssl-dev pkg-config openssl
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -339,8 +344,13 @@ jobs:
       - name: Install components
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
+          sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev libssl-dev pkg-config openssl
           cargo install toml-cli
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Calculate Proto Subpackage Publish Arguments
         id: proto-publish-args

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -250,16 +250,21 @@ jobs:
         with:
           node-version: 22
 
-      - name: Start the local node
-        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
+      - name: Prepare Hiero Solo
+        id: solo
+        uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0
+        with:
+          installMirrorNode: true
+          hieroVersion: v0.60.0-alpha.0
 
-      - name: Create env file
+      - name: "Create env file"
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
-          echo TEST_OPERATOR_ID="0.0.1022" >> .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
+          echo TEST_OPERATOR_ID="0.0.2" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
+          cat .env
 
       - name: Run Safety Checks
         run: |
@@ -269,9 +274,6 @@ jobs:
           . $HOME/.cargo/env
           cargo test --workspace
           echo "::endgroup::"
-
-      - name: Stop the local node
-        run: npx @hashgraph/hedera-local stop
 
   publish:
     name: Publish SDK to crates.io
@@ -347,18 +349,22 @@ jobs:
         with:
           node-version: 22
 
-      - name: Start the local node
-        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
-        run: npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
+      - name: Prepare Hiero Solo
+        id: solo
+        uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0
+        with:
+          installMirrorNode: true
+          hieroVersion: v0.60.0-alpha.0
 
       - name: Create env file
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
-          echo TEST_OPERATOR_ID="0.0.1022" >> .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
+          echo TEST_OPERATOR_ID="0.0.2" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
+          cat .env
 
       # Update the Cargo.toml files for the hiero-sdk-* packages
       - name: Update Cargo.toml for hiero publishing
@@ -407,63 +413,6 @@ jobs:
           echo "cargo publish ${{ steps.proto-publish-args.outputs.args }}"
           cargo publish ${{ steps.proto-publish-args.outputs.args }}
         working-directory: protobufs
-
-      # TODO<BEGIN>: Remove this group of steps after the hiero-sdk-proto package is published
-      - name: Stop the local node (hiero-sdk-proto)
-        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
-        run: |
-          npx @hashgraph/hedera-local stop
-
-      - name: Reset the workspace
-        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' && !cancelled() && always() }}
-        run: |
-          echo "::group::Reset Workspace"
-          git reset --hard
-          git clean -fdx
-          echo "::endgroup::"
-
-      - name: Start the local node (hiero-sdk)
-        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
-        run: |
-          npx @hashgraph/hedera-local start -d --network local --network-tag=0.60.0-alpha.0
-
-      - name: Create env file (hiero-sdk)
-        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
-        run: |
-          touch .env
-          echo TEST_OPERATOR_KEY="302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4" >> .env
-          echo TEST_OPERATOR_ID="0.0.1022" >> .env
-          echo TEST_NETWORK_NAME="localhost" >> .env
-          echo TEST_RUN_NONFREE="1" >> .env
-
-      - name: Set up Cargo files for SDK Dual publish
-        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' && !cancelled() && always() }}
-        run: |
-          echo "::group::Update main Cargo.toml with new name and dependencies"
-          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-          
-          echo "::group::Update TCK Cargo.toml with new dependencies"
-          # Update the dependencies in the tck/Cargo.toml
-          sed -i "s/hedera =/hiero-sdk =/g" tck/Cargo.toml
-          echo "::endgroup::"
-          
-          echo "::group::Update files with new names"
-          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
-          find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
-          echo "::endgroup::"
-          
-          echo "::group::Verify Cargo.toml changes"
-          cargo check
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          . $HOME/.cargo/env
-          cargo test --workspace
-          cargo generate-lockfile
-          echo "::endgroup::"
-      # TODO<END>: Remove this group of steps after the hiero-sdk-proto package is published
-
-      - name: Stop the local node
-        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
-        run: npx @hashgraph/hedera-local stop
 
       - name: Publish SDK to crates.io (hiero-sdk)
         if: ${{ needs.validate-release.outputs.hiero-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -241,13 +241,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.tag || '' }}
-          submodules: recursive
+          submodules: 'recursive'
 
       - name: Rust Cache
         uses: step-security/rust-cache@94e3ae6a5bdb04807deb1cb2274adab839828881 # v2.8.0
         with:
           workspaces: |
-            sdk/rust
+            .
 
       - name: Install components
         run: |
@@ -299,11 +299,11 @@ jobs:
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
 
-      - name: Run Check
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          . $HOME/.cargo/env
-          cargo check --examples --workspace
+#      - name: Run Check
+#        run: |
+#          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+#          . $HOME/.cargo/env
+#          cargo check --examples --workspace
 
       - name: Run Tests
         run: |

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -252,31 +252,27 @@ jobs:
 
       - name: Prepare Hiero Solo
         id: solo
-        uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0
+        uses: hiero-ledger/hiero-solo-action@3bb6a23cc7915a38bde580c84a6c02c986dcac8f # latest
         with:
           installMirrorNode: true
           hieroVersion: v0.60.0-alpha.0
+          hbarAmount: 100000000
 
       - name: Create env file
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
-          echo TEST_OPERATOR_ID="0.0.2" >> .env
+          echo TEST_OPERATOR_KEY="${{ steps.solo.outputs.privateKey }}" >> .env
+          echo TEST_OPERATOR_ID="${{ steps.solo.outputs.accountId }}" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
 
       - name: Run Safety Checks
-        env:
-          #SOLO_DEPLOYMENT: "${{ steps.solo.outputs.deployment }}"
-          SOLO_DEPLOYMENT: "solo-deployment"
-          TEST_OPERATOR_ID: "${{ steps.solo.outputs.accountId }}"
         run: |
           echo "::group::Run Safety Checks"
           cargo check
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
-          solo account update --account-id "${TEST_OPERATOR_ID}" --deployment "${SOLO_DEPLOYMENT}" --hbar-amount 1000000000
           cargo test --workspace
           echo "::endgroup::"
 
@@ -356,17 +352,18 @@ jobs:
 
       - name: Prepare Hiero Solo
         id: solo
-        uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0
+        uses: hiero-ledger/hiero-solo-action@3bb6a23cc7915a38bde580c84a6c02c986dcac8f # latest
         with:
           installMirrorNode: true
           hieroVersion: v0.60.0-alpha.0
+          hbarAmount: 100000000
 
       - name: Create env file
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
-          echo TEST_OPERATOR_ID="0.0.2" >> .env
+          echo TEST_OPERATOR_KEY="${{ steps.solo.outputs.privateKey }}" >> .env
+          echo TEST_OPERATOR_ID="${{ steps.solo.outputs.accountId }}" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
@@ -374,10 +371,6 @@ jobs:
       # Update the Cargo.toml files for the hiero-sdk-* packages
       - name: Update Cargo.toml for hiero publishing
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
-        env:
-          #SOLO_DEPLOYMENT: "${{ steps.solo.outputs.deployment }}"
-          SOLO_DEPLOYMENT: "solo-deployment"
-          TEST_OPERATOR_ID: "${{ steps.solo.outputs.accountId }}"
         run: |
           echo "::group::Update protobufs/Cargo.toml with new name"       
           # Update the dependencies in the protobugs/Cargo.toml
@@ -407,7 +400,6 @@ jobs:
           cargo check
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
-          solo account update --account-id "${TEST_OPERATOR_ID}" --deployment "${SOLO_DEPLOYMENT}" --hbar-amount 1000000000
           cargo test --workspace
           cargo generate-lockfile
           echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -309,7 +309,7 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Solo Node Setup and Start"
-          SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
+          SOLO_DEPLOYMENT=$`yq '.deployments.[].name' ~/.solo/local-config.yaml`
           solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
           solo node start --deployment "${SOLO_DEPLOYMENT}"
           echo "::endgroup::"
@@ -450,7 +450,7 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Solo Node Setup and Start"
-          SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
+          SOLO_DEPLOYMENT=`yq '.deployments.[].name' ~/.solo/local-config.yaml`
           solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
           solo node start --deployment "${SOLO_DEPLOYMENT}"
           echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -307,6 +307,7 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Solo Quick Start Single Deploy"
+          # Configures the entire network including the consensus node, mirror node, rpc, and explorer
           solo quick-start single deploy
           echo "::endgroup::"
           
@@ -314,12 +315,6 @@ jobs:
           SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
           solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
           solo node start --deployment "${SOLO_DEPLOYMENT}"
-          echo "::endgroup::"
-          
-          echo "::group::Solo Deploy Mirror Node, Explorer, and Relay"
-          solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref "kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}" --enable-ingress
-          solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}
-          solo relay deploy -i node1 --deployment "${SOLO_DEPLOYMENT}"
           echo "::endgroup::"
 
       - name: Create env file
@@ -450,6 +445,7 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Solo Quick Start Single Deploy"
+          # Configures the entire network including the consensus node, mirror node, rpc, and explorer
           solo quick-start single deploy
           echo "::endgroup::"
           
@@ -457,12 +453,6 @@ jobs:
           SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
           solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
           solo node start --deployment "${SOLO_DEPLOYMENT}"
-          echo "::endgroup::"
-          
-          echo "::group::Solo Deploy Mirror Node, Explorer, and Relay"
-          solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref "kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}" --enable-ingress
-          solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}
-          solo relay deploy -i node1 --deployment "${SOLO_DEPLOYMENT}"
           echo "::endgroup::"
 
       - name: Create env file

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -299,11 +299,11 @@ jobs:
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
 
-#      - name: Run Check
-#        run: |
-#          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-#          . $HOME/.cargo/env
-#          cargo check --examples --workspace
+      - name: Run Check
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . $HOME/.cargo/env
+          cargo check --examples --workspace
 
       - name: Run Tests
         run: |
@@ -339,18 +339,18 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.tag || '' }}
-          submodules: recursive
+          submodules: 'recursive'
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
+      - name: Rust Cache
+        uses: step-security/rust-cache@94e3ae6a5bdb04807deb1cb2274adab839828881 # v2.8.0
         with:
-          toolchain: 1.88.0
+          workspaces: |
+            .
 
       - name: Install components
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev libssl-dev pkg-config openssl
-          cargo install toml-cli
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -464,6 +464,7 @@ jobs:
           echo "::group::Verify Cargo.toml changes"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
+          cargo check --examples --workspace
           cargo test --workspace 
           cargo generate-lockfile
           echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -347,6 +347,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gcc libc6-dev libc-dev libssl-dev pkg-config openssl
+          cargo install toml-cli
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -300,10 +300,9 @@ jobs:
       - name: Run Safety Checks
         run: |
           echo "::group::Run Safety Checks"
-          cargo check
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
-          cargo test --workspace
+          cargo test --workspace 
           echo "::endgroup::"
 
       - name: Clean up solo deployment
@@ -457,10 +456,9 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Verify Cargo.toml changes"
-          cargo check
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
-          cargo test --workspace
+          cargo test --workspace 
           cargo generate-lockfile
           echo "::endgroup::"
 

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -28,11 +28,6 @@ permissions:
   contents: write
 
 env:
-  SOLO_CLUSTER_NAME: "solo-rust"
-  SOLO_NAMESPACE: "solo-rust"
-  SOLO_CLUSTER_SETUP_NAMESPACE: "solo-rust-cluster"
-  SOLO_DEPLOYMENT: "solo-rust-deployment"
-  CONSENSUS_NODE_VERSION: "v0.60.0-alpha.0"
   NODE_VERSION: "20.18.3"
 
 jobs:
@@ -262,31 +257,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      # Set up kind; needed for configuring the solo environment
-      - name: Setup Kind
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+      - name: Prepare Hiero Solo
+        id: solo
+        uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0
         with:
-          install_only: true
-          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
-          version: v0.26.0
-          kubectl_version: v1.31.4
-          verbosity: 3
-          wait: 120s
-
-      # Install solo and configure it for the safety checks
-      - name: Install Solo
-        run: npm install -g @hashgraph/solo@${{ vars.SOLO_VERSION }}
-
-      - name: Configure Solo
-        run: |
-          echo "::group::Kind Create Cluster"
-          kind create cluster -n "${SOLO_CLUSTER_NAME}"
-          echo "::endgroup::"
-          
-          echo "::group::Solo Quick Start Single Deploy"
-          # Configures the entire network including the consensus node, mirror node, rpc, and explorer
-          solo quick-start single deploy
-          echo "::endgroup::"
+          installMirrorNode: true
+          hieroVersion: v0.60.0-alpha.0
 
       - name: Create env file
         run: |
@@ -307,15 +283,7 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
-          cargo test --workspace 
-
-      - name: Clean up solo deployment
-        run: |
-          solo quick-start single destroy
-          for cluster in $(kind get clusters); do
-            kind delete cluster -n $cluster
-          done
-          rm -rf ~/.solo
+          cargo test --workspace
 
   publish:
     name: Publish SDK to crates.io
@@ -394,31 +362,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      # Set up kind; needed for configuring the solo environment
-      - name: Setup Kind
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+      - name: Prepare Hiero Solo
+        id: solo
+        uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0
         with:
-          install_only: true
-          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
-          version: v0.26.0
-          kubectl_version: v1.31.4
-          verbosity: 3
-          wait: 120s
-
-      # Install solo and configure it for the safety checks
-      - name: Install Solo
-        run: npm install -g @hashgraph/solo@${{ vars.SOLO_VERSION }}
-
-      - name: Configure Solo
-        run: |
-          echo "::group::Kind Create Cluster"
-          kind create cluster -n "${SOLO_CLUSTER_NAME}"
-          echo "::endgroup::"
-
-          echo "::group::Solo Quick Start Single Deploy"
-          # Configures the entire network including the consensus node, mirror node, rpc, and explorer
-          solo quick-start single deploy
-          echo "::endgroup::"
+          installMirrorNode: true
+          hieroVersion: v0.60.0-alpha.0
 
       - name: Create env file
         run: |
@@ -464,14 +413,6 @@ jobs:
           cargo test --workspace 
           cargo generate-lockfile
           echo "::endgroup::"
-
-      - name: Clean up solo deployment
-        run: |
-          solo quick-start single destroy
-          for cluster in $(kind get clusters); do
-            kind delete cluster -n $cluster
-          done
-          rm -rf ~/.solo
 
       - name: Publish proto to crates.io (hiero-sdk-proto)
         if: ${{ needs.validate-release.outputs.hiero-proto-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -243,11 +243,10 @@ jobs:
           ref: ${{ inputs.tag || '' }}
           submodules: 'recursive'
 
-      - name: Rust Cache
-        uses: step-security/rust-cache@94e3ae6a5bdb04807deb1cb2274adab839828881 # v2.8.0
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
-          workspaces: |
-            .
+          toolchain: 1.88.0
 
       - name: Install components
         run: |
@@ -341,11 +340,10 @@ jobs:
           ref: ${{ inputs.tag || '' }}
           submodules: 'recursive'
 
-      - name: Rust Cache
-        uses: step-security/rust-cache@94e3ae6a5bdb04807deb1cb2274adab839828881 # v2.8.0
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
-          workspaces: |
-            .
+          toolchain: 1.88.0
 
       - name: Install components
         run: |

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -264,11 +264,13 @@ jobs:
           echo TEST_OPERATOR_ID="0.0.2" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
-          #echo SOLO_DEPLOYMENT="${{ steps.solo.outputs.deployment }}" >> .env
-          echo SOLO_DEPLOYMENT="solo-deployment" >> .env
           cat .env
 
       - name: Run Safety Checks
+        env:
+          #SOLO_DEPLOYMENT: "${{ steps.solo.outputs.deployment }}"
+          SOLO_DEPLOYMENT: "solo-deployment"
+          TEST_OPERATOR_ID: "0.0.2"
         run: |
           echo "::group::Run Safety Checks"
           cargo check
@@ -367,17 +369,16 @@ jobs:
           echo TEST_OPERATOR_ID="0.0.2" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
-          #echo SOLO_DEPLOYMENT="${{ steps.solo.outputs.deployment }}" >> .env
-          echo SOLO_DEPLOYMENT="solo-deployment" >> .env
           cat .env
 
       # Update the Cargo.toml files for the hiero-sdk-* packages
       - name: Update Cargo.toml for hiero publishing
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
-          OPERATOR_ID: ${{ secrets.TEST_OPERATOR_ID }}
-          OPERATOR_KEY: ${{ secrets.TEST_OPERATOR_KEY }}
-        run: |         
+          #SOLO_DEPLOYMENT: "${{ steps.solo.outputs.deployment }}"
+          SOLO_DEPLOYMENT: "solo-deployment"
+          TEST_OPERATOR_ID: "0.0.2"
+        run: |
           echo "::group::Update protobufs/Cargo.toml with new name"       
           # Update the dependencies in the protobugs/Cargo.toml
           toml set protobufs/Cargo.toml package.name "hiero-sdk-proto" > protobufs/Cargo.toml.tmp && mv protobufs/Cargo.toml.tmp protobufs/Cargo.toml

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -28,6 +28,11 @@ permissions:
   contents: write
 
 env:
+  SOLO_CLUSTER_NAME: "solo-rust"
+  SOLO_NAMESPACE: "solo-rust"
+  SOLO_CLUSTER_SETUP_NAMESPACE: "solo-rust-cluster"
+  SOLO_DEPLOYMENT: "solo-rust-deployment"
+  CONSENSUS_NODE_VERSION: "v0.60.0-alpha.0"
   NODE_VERSION: "20.18.3"
 
 jobs:
@@ -257,12 +262,31 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Prepare Hiero Solo
-        id: solo
-        uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0
+      # Set up kind; needed for configuring the solo environment
+      - name: Setup Kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          installMirrorNode: true
-          hieroVersion: v0.60.0-alpha.0
+          install_only: true
+          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+          version: v0.26.0
+          kubectl_version: v1.31.4
+          verbosity: 3
+          wait: 120s
+
+      # Install solo and configure it for the safety checks
+      - name: Install Solo
+        run: npm install -g @hashgraph/solo@${{ vars.SOLO_VERSION }}
+
+      - name: Configure Solo
+        run: |
+          echo "::group::Kind Create Cluster"
+          kind create cluster -n "${SOLO_CLUSTER_NAME}"
+          echo "::endgroup::"
+          
+          echo "::group::Solo Quick Start Single Deploy"
+          # Configures the entire network including the consensus node, mirror node, rpc, and explorer
+          solo quick-start single deploy
+          echo "::endgroup::"
 
       - name: Create env file
         run: |
@@ -283,7 +307,15 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
-          cargo test --workspace
+          cargo test --workspace 
+
+      - name: Clean up solo deployment
+        run: |
+          solo quick-start single destroy
+          for cluster in $(kind get clusters); do
+            kind delete cluster -n $cluster
+          done
+          rm -rf ~/.solo
 
   publish:
     name: Publish SDK to crates.io
@@ -362,12 +394,31 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Prepare Hiero Solo
-        id: solo
-        uses: hiero-ledger/hiero-solo-action@10ec96a107b8d2f5cd26b3e7ab47e65407b5c462 # v0.11.0
+      # Set up kind; needed for configuring the solo environment
+      - name: Setup Kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
-          installMirrorNode: true
-          hieroVersion: v0.60.0-alpha.0
+          install_only: true
+          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+          version: v0.26.0
+          kubectl_version: v1.31.4
+          verbosity: 3
+          wait: 120s
+
+      # Install solo and configure it for the safety checks
+      - name: Install Solo
+        run: npm install -g @hashgraph/solo@${{ vars.SOLO_VERSION }}
+
+      - name: Configure Solo
+        run: |
+          echo "::group::Kind Create Cluster"
+          kind create cluster -n "${SOLO_CLUSTER_NAME}"
+          echo "::endgroup::"
+
+          echo "::group::Solo Quick Start Single Deploy"
+          # Configures the entire network including the consensus node, mirror node, rpc, and explorer
+          solo quick-start single deploy
+          echo "::endgroup::"
 
       - name: Create env file
         run: |
@@ -396,7 +447,7 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Update TCK Cargo.toml with new dependencies"
-          # Update the dependencies in the tck/Cargo.toml
+          # Update the dependencies in the tck/Cargo.toml for both protobufs and sdk
           sed -i "s/hedera/hiero-sdk/g" tck/Cargo.toml
           echo "::endgroup::"
           
@@ -414,6 +465,14 @@ jobs:
           cargo generate-lockfile
           echo "::endgroup::"
 
+      - name: Clean up solo deployment
+        run: |
+          solo quick-start single destroy
+          for cluster in $(kind get clusters); do
+            kind delete cluster -n $cluster
+          done
+          rm -rf ~/.solo
+
       - name: Publish proto to crates.io (hiero-sdk-proto)
         if: ${{ needs.validate-release.outputs.hiero-proto-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
@@ -422,6 +481,69 @@ jobs:
           echo "cargo publish ${{ steps.proto-publish-args.outputs.args }}"
           cargo publish ${{ steps.proto-publish-args.outputs.args }}
         working-directory: protobufs
+
+      # Test the hiero-sdk package if proto hasn't been published yet.
+      - name: Reset the workspace
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
+        run: |
+          echo "::group::Reset Workspace"
+          git reset --hard
+          git clean -fdx
+          echo "::endgroup::"
+
+      - name: Configure Solo
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
+        run: |
+          echo "::group::Kind Create Cluster"
+          kind create cluster -n "${SOLO_CLUSTER_NAME}"
+          echo "::endgroup::"
+
+          echo "::group::Solo Quick Start Single Deploy"
+          # Configures the entire network including the consensus node, mirror node, rpc, and explorer
+          solo quick-start single deploy
+          echo "::endgroup::"
+
+      - name: Create env file
+        run: |
+          touch .env
+          echo TEST_OPERATOR_ID="0.0.2" >> .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
+          echo TEST_NETWORK_NAME="localhost" >> .env
+          echo TEST_RUN_NONFREE="1" >> .env
+          cat .env
+
+      - name: Set up Cargo files for SDK Dual publish
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
+        run: |
+          echo "::group::Update main Cargo.toml with new name and dependencies"
+          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          
+          echo "::group::Update TCK Cargo.toml with new dependencies"
+          # Update the dependencies in the tck/Cargo.toml
+          sed -i "s/hedera =/hiero-sdk =/g" tck/Cargo.toml
+          echo "::endgroup::"
+          
+          echo "::group::Update files with new names"
+          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
+          echo "::endgroup::"
+          
+          echo "::group::Verify Cargo.toml changes"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . $HOME/.cargo/env
+          cargo check --examples --workspace
+          cargo test --workspace 
+          cargo generate-lockfile
+          echo "::endgroup::"
+
+      - name: Clean up solo deployment
+        if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
+        run: |
+          solo quick-start single destroy
+          for cluster in $(kind get clusters); do
+            kind delete cluster -n $cluster
+          done
+          rm -rf ~/.solo
 
       - name: Publish SDK to crates.io (hiero-sdk)
         if: ${{ needs.validate-release.outputs.hiero-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -314,7 +314,6 @@ jobs:
     needs:
       - validate-release
       - run-safety-checks
-      - set-solo-props
     runs-on: hiero-client-sdk-linux-medium
     env:
       # Set the default to 'true' when the dual-publishing period is active

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -258,13 +258,13 @@ jobs:
         with:
           installMirrorNode: true
           hieroVersion: v0.60.0-alpha.0
-          hbarAmount: 100000000
+          hbarAmount: 10000000000
 
       - name: Create env file
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="${{ steps.solo.outputs.privateKey }}" >> .env
-          echo TEST_OPERATOR_ID="${{ steps.solo.outputs.accountId }}" >> .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
+          echo TEST_OPERATOR_ID="0.0.2" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
@@ -360,14 +360,14 @@ jobs:
         with:
           installMirrorNode: true
           hieroVersion: v0.60.0-alpha.0
-          hbarAmount: 100000000
+          hbarAmount: 10000000000
 
       - name: Create env file
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="${{ steps.solo.outputs.privateKey }}" >> .env
-          echo TEST_OPERATOR_ID="${{ steps.solo.outputs.accountId }}" >> .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
+          echo TEST_OPERATOR_ID="0.0.2" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -255,7 +255,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.18.0
+          node-version: 20.18.3
 
       # Set up kind; needed for configuring the solo environment
       - name: Setup Kind
@@ -381,7 +381,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.18.0
+          node-version: 20.18.3
 
       # Set up kind; needed for configuring the solo environment
       - name: Setup Kind

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -291,8 +291,10 @@ jobs:
           verbosity: 3
           wait: 120s
 
-      - name: Set up yq
+      - name: Setup yq
         uses: step-security/setup-yq@ad0cf3bb7054291a414b615c1160ce0af1193a26 # v1.0.1
+        with:
+          yq-version: v4.47.1
 
       # Install solo and configure it for the safety checks
       - name: Install Solo
@@ -309,7 +311,7 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Solo Node Setup and Start"
-          SOLO_DEPLOYMENT=$(yq eval -r '.deployments.[].name' ~/.solo/local-config.yaml)
+          SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
           solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
           solo node start --deployment "${SOLO_DEPLOYMENT}"
           echo "::endgroup::"
@@ -432,8 +434,10 @@ jobs:
           verbosity: 3
           wait: 120s
 
-      - name: Set up yq
+      - name: Setup yq
         uses: step-security/setup-yq@ad0cf3bb7054291a414b615c1160ce0af1193a26 # v1.0.1
+        with:
+          yq-version: v4.47.1
 
       # Install solo and configure it for the safety checks
       - name: Install Solo
@@ -450,7 +454,7 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Solo Node Setup and Start"
-          SOLO_DEPLOYMENT=$(yq eval -r '.deployments.[].name' ~/.solo/local-config.yaml)
+          SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
           solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
           solo node start --deployment "${SOLO_DEPLOYMENT}"
           echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -1,4 +1,4 @@
-name: "Publish Release"
+name: "ZXF: Publish Release"
 on:
   workflow_dispatch:
     inputs:
@@ -84,7 +84,7 @@ jobs:
           semver --version
           echo "::endgroup::"
             
-      - name: Set up Rust
+      - name: Setup Rust
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: 1.88.0
@@ -242,7 +242,7 @@ jobs:
           ref: ${{ inputs.tag || '' }}
           submodules: 'recursive'
 
-      - name: Set up Rust
+      - name: Setup Rust
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: 1.88.0
@@ -338,7 +338,7 @@ jobs:
           ref: ${{ inputs.tag || '' }}
           submodules: 'recursive'
 
-      - name: Set up Rust
+      - name: Setup Rust
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
         with:
           toolchain: 1.88.0

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -338,6 +338,14 @@ jobs:
           cargo test --workspace
           echo "::endgroup::"
 
+      - name: Clean up solo deployment
+        run: |
+          solo quick-start single destroy
+          for cluster in $(kind get clusters); do
+            kind delete cluster -n $cluster
+          done
+          rm -rf ~/.solo
+
   publish:
     name: Publish SDK to crates.io
     needs:
@@ -498,6 +506,14 @@ jobs:
           cargo test --workspace
           cargo generate-lockfile
           echo "::endgroup::"
+
+      - name: Clean up solo deployment
+        run: |
+          solo quick-start single destroy
+          for cluster in $(kind get clusters); do
+            kind delete cluster -n $cluster
+          done
+          rm -rf ~/.solo
 
       - name: Publish proto to crates.io (hiero-sdk-proto)
         if: ${{ needs.validate-release.outputs.hiero-proto-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -309,7 +309,7 @@ jobs:
           echo "::endgroup::"
           
           echo "::group::Solo Node Setup and Start"
-          SOLO_DEPLOYMENT=$`yq '.deployments.[].name' ~/.solo/local-config.yaml`
+          SOLO_DEPLOYMENT=`yq '.deployments.[].name' ~/.solo/local-config.yaml`
           solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
           solo node start --deployment "${SOLO_DEPLOYMENT}"
           echo "::endgroup::"

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -286,8 +286,8 @@ jobs:
       - name: Create env file
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="0.0.2" >> .env
-          echo TEST_OPERATOR_ID="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
+          echo TEST_OPERATOR_ID="0.0.2" >> .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
@@ -412,8 +412,8 @@ jobs:
       - name: Create env file
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="0.0.2" >> .env
-          echo TEST_OPERATOR_ID="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
+          echo TEST_OPERATOR_ID="0.0.2" >> .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -34,6 +34,7 @@ env:
   SOLO_CLUSTER_SETUP_NAMESPACE: "solo-rust-cluster"
   SOLO_DEPLOYMENT: "solo-rust-deployment"
   CONSENSUS_NODE_VERSION: "v0.60.0-alpha.0"
+  NODE_VERSION: "20.18.3"
 
 jobs:
   validate-release:
@@ -242,10 +243,11 @@ jobs:
           ref: ${{ inputs.tag || '' }}
           submodules: recursive
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # v1
+      - name: Rust Cache
+        uses: step-security/rust-cache@94e3ae6a5bdb04807deb1cb2274adab839828881 # v2.8.0
         with:
-          toolchain: 1.88.0
+          workspaces: |
+            sdk/rust
 
       - name: Install components
         run: |
@@ -260,7 +262,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.18.3
+          node-version: ${{ env.NODE_VERSION }}
 
       # Set up kind; needed for configuring the solo environment
       - name: Setup Kind
@@ -297,13 +299,17 @@ jobs:
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
 
-      - name: Run Safety Checks
+      - name: Run Check
         run: |
-          echo "::group::Run Safety Checks"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . $HOME/.cargo/env
+          cargo check --examples --workspace
+
+      - name: Run Tests
+        run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           . $HOME/.cargo/env
           cargo test --workspace 
-          echo "::endgroup::"
 
       - name: Clean up solo deployment
         run: |
@@ -390,7 +396,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.18.3
+          node-version: ${{ env.NODE_VERSION }}
 
       # Set up kind; needed for configuring the solo environment
       - name: Setup Kind

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -260,8 +260,8 @@ jobs:
       - name: Create env file
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="${{ steps.solo.outputs.ecdsaPrivateKey }}" >> .env
-          echo TEST_OPERATOR_ID="${{ steps.solo.outputs.accountId }}" >> .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
+          echo TEST_OPERATOR_ID="0.0.2" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
@@ -365,8 +365,8 @@ jobs:
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
         run: |
           touch .env
-          echo TEST_OPERATOR_KEY="${{ steps.solo.outputs.ecdsaPrivateKey }}" >> .env
-          echo TEST_OPERATOR_ID="${{ steps.solo.outputs.accountId }}" >> .env
+          echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
+          echo TEST_OPERATOR_ID="0.0.2" >> .env
           echo TEST_NETWORK_NAME="localhost" >> .env
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -6,14 +6,14 @@ on:
         description: "Existing Tag to Publish (eg: v3.7.0)"
         type: string
         required: true
-      dry-run-enabled:
-        description: "Dry Run Enabled"
-        type: boolean
-        required: false
-        default: false
       dual-publish-enabled:
         # default to true when dual-publishing period is active
         description: "Dual Publish Enabled"
+        type: boolean
+        required: false
+        default: false
+      dry-run-enabled:
+        description: "Dry Run Enabled"
         type: boolean
         required: false
         default: false

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -300,14 +300,25 @@ jobs:
 
       - name: Configure Solo
         run: |
+          echo "::group::Kind Create Cluster"
           kind create cluster -n "${{ needs.set-solo-props.outputs.solo-cluster-name }}"
+          echo "::endgroup::"
+          
+          echo "::group::Solo Quick Start Single Deploy"
           solo quick-start single deploy
+          echo "::endgroup::"
+          
+          echo "::group::Solo Node Setup and Start"
           SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
           solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
           solo node start --deployment "${SOLO_DEPLOYMENT}"
+          echo "::endgroup::"
+          
+          echo "::group::Solo Deploy Mirror Node, Explorer, and Relay"
           solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref "kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}" --enable-ingress
           solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}
           solo relay deploy -i node1 --deployment "${SOLO_DEPLOYMENT}"
+          echo "::endgroup::"
 
       - name: Create env file
         run: |
@@ -422,14 +433,25 @@ jobs:
 
       - name: Configure Solo
         run: |
+          echo "::group::Kind Create Cluster"
           kind create cluster -n "${{ needs.set-solo-props.outputs.solo-cluster-name }}"
+          echo "::endgroup::"
+          
+          echo "::group::Solo Quick Start Single Deploy"
           solo quick-start single deploy
+          echo "::endgroup::"
+          
+          echo "::group::Solo Node Setup and Start"
           SOLO_DEPLOYMENT=$(yq '.deployments.[].name' ~/.solo/local-config.yaml)
           solo node setup --deployment "${SOLO_DEPLOYMENT}" --release-tag "${{ needs.set-solo-props.outputs.solo-hcn-version }}"
           solo node start --deployment "${SOLO_DEPLOYMENT}"
+          echo "::endgroup::"
+          
+          echo "::group::Solo Deploy Mirror Node, Explorer, and Relay"
           solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref "kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}" --enable-ingress
           solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${{ needs.set-solo-props.outputs.solo-cluster-name }}
           solo relay deploy -i node1 --deployment "${SOLO_DEPLOYMENT}"
+          echo "::endgroup::"
 
       - name: Create env file
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -250,6 +250,8 @@ jobs:
         with:
           node-version: 22
 
+      # Uses the latest commit of the hiero-ledger/hiero-solo-action main branch (3bb6a23cc7915a38bde580c84a6c02c986dcac8f)
+      # this is the first version that supports the hbarAmount input.
       - name: Prepare Hiero Solo
         id: solo
         uses: hiero-ledger/hiero-solo-action@3bb6a23cc7915a38bde580c84a6c02c986dcac8f # latest
@@ -350,6 +352,8 @@ jobs:
         with:
           node-version: 22
 
+      # Uses the latest commit of the hiero-ledger/hiero-solo-action main branch (3bb6a23cc7915a38bde580c84a6c02c986dcac8f)
+      # this is the first version that supports the hbarAmount input.
       - name: Prepare Hiero Solo
         id: solo
         uses: hiero-ledger/hiero-solo-action@3bb6a23cc7915a38bde580c84a6c02c986dcac8f # latest

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -257,7 +257,7 @@ jobs:
           installMirrorNode: true
           hieroVersion: v0.60.0-alpha.0
 
-      - name: "Create env file"
+      - name: Create env file
         run: |
           touch .env
           echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
@@ -348,6 +348,48 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
+
+      # Set up the node environment
+      # Version 20.18.0 is the recommended version for solo.
+      - name: Setup NodeJS Environment
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20.18.0
+
+      # Set up kind; needed for configuring the solo environment
+      - name: Setup Kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          install_only: true
+          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+          version: v0.26.0
+          kubectl_version: v1.31.4
+          verbosity: 3
+          wait: 120s
+
+      # Install solo and configure to use the artifacts from
+      # the hiero-consensus-node build
+      - name: Install Solo
+        run: npm install -g @hashgraph/solo@0.37.1
+
+      - name: Configure and run solo
+        run: |
+          kind create cluster -n "${{ env.SOLO_CLUSTER_NAME }}"
+          solo init
+          solo cluster-ref connect --cluster-ref kind-${{ env.SOLO_CLUSTER_NAME }} --context kind-${{ env.SOLO_CLUSTER_NAME }}
+          solo deployment create -n "${{ env.SOLO_NAMESPACE }}" --deployment "${{ env.SOLO_DEPLOYMENT }}"
+          solo deployment add-cluster --deployment "${{ env.SOLO_DEPLOYMENT }}" --cluster-ref kind-${{ env.SOLO_CLUSTER_NAME }} --num-consensus-nodes 1
+          solo node keys --gossip-keys --tls-keys -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}"
+          solo cluster-ref setup -s "${{ env.SOLO_CLUSTER_SETUP_NAMESPACE }}"
+          solo network deploy -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}"
+          solo node setup -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}" --local-build-path ./hedera-node/data
+          solo node start -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}"
+          solo mirror-node deploy --deployment "${{ env.SOLO_DEPLOYMENT }}" --cluster-ref kind-${{ env.SOLO_CLUSTER_NAME }}
+
+          kubectl port-forward svc/haproxy-node1-svc -n "${{ env.SOLO_NAMESPACE }}" 50211:non-tls-grpc-client-port &
+          kubectl port-forward svc/mirror-monitor -n "${{ env.SOLO_NAMESPACE }}" 5600:http &
+          kubectl port-forward svc/mirror-rest -n "${{ env.SOLO_NAMESPACE }}" 5551:http &
+          kubectl port-forward svc/mirror-restjava -n "${{ env.SOLO_NAMESPACE }}" 8084:http &
 
       - name: Prepare Hiero Solo
         id: solo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hedera"
-version = "0.38.0-beta.8"
+version = "0.38.0-beta.9"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hedera"
-version = "0.38.0-beta.5"
+version = "0.38.0-beta.13"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hedera"
-version = "0.38.0-beta.13"
+version = "0.38.0-beta.14"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
@@ -34,7 +34,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
 ]
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -80,36 +80,37 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -126,9 +127,9 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_matches"
@@ -138,9 +139,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.12"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
 dependencies = [
  "brotli",
  "flate2",
@@ -171,7 +172,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -182,7 +183,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -193,15 +194,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.5"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -219,7 +220,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -250,24 +251,24 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "instant",
  "rand",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -284,15 +285,15 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitvec"
@@ -326,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -336,23 +337,22 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
- "syn_derive",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -361,13 +361,19 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytecheck"
@@ -392,16 +398,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cbc"
@@ -414,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "jobserver",
  "libc",
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -476,20 +476,20 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const-oid"
@@ -499,18 +499,18 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -561,14 +561,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -603,14 +603,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "dissimilar"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
 
 [[package]]
 name = "dotenvy"
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -684,40 +684,40 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -732,15 +732,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core",
  "subtle",
@@ -754,15 +754,15 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -812,9 +812,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -854,7 +854,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -900,20 +900,32 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "group"
@@ -938,7 +950,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.3.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -956,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -968,7 +980,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hedera"
-version = "0.37.0"
+version = "0.38.0-beta.8"
 dependencies = [
  "aes",
  "anyhow",
@@ -1042,12 +1054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1115,12 +1121,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -1128,27 +1134,21 @@ dependencies = [
 
 [[package]]
 name = "http-range-header"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a397c49fec283e3d6211adbe480be95aae5f304cfb923e9970e08956d5168a"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1192,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
  "hyper",
  "hyper-util",
@@ -1218,7 +1218,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -1236,19 +1236,19 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -1265,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1276,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "iri-string"
-version = "0.7.2"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5f6c2df22c009ac44f6f1499308e7a3ac7ba42cd2378475cc691510e1eef1b"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
 dependencies = [
  "memchr",
  "serde",
@@ -1292,26 +1292,61 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.3",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1361,7 +1396,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1454,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -1497,9 +1532,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -1525,7 +1560,7 @@ checksum = "d6c74ab4f1a0c0ab045260ee4727b23c00cc17e5eff5095262d08eef8c3c8d49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1541,30 +1576,29 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
- "hermit-abi",
  "libc",
- "wasi",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1655,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.3"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -1669,10 +1703,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "openssl"
-version = "0.10.72"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1691,14 +1731,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -1732,7 +1772,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1763,32 +1803,32 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.3.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1832,9 +1872,24 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1844,53 +1899,30 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.20"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -1924,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
  "itertools",
@@ -1938,7 +1970,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.101",
+ "syn 2.0.104",
  "tempfile",
 ]
 
@@ -1952,7 +1984,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1965,7 +1997,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2008,12 +2040,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -2048,14 +2086,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -2125,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.44"
+version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -2143,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.44"
+version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2186,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -2204,37 +2242,37 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa20"
@@ -2284,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -2305,14 +2343,14 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -2369,9 +2407,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -2388,30 +2426,27 @@ dependencies = [
 
 [[package]]
 name = "simdutf8"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2478,25 +2513,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -2513,12 +2536,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2526,32 +2549,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -2584,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2599,9 +2621,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2625,7 +2647,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2642,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2656,17 +2678,17 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.3.0",
+ "indexmap 2.10.0",
  "toml_datetime",
  "winnow",
 ]
@@ -2692,7 +2714,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.13.5",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -2712,7 +2734,7 @@ dependencies = [
  "prost-build",
  "prost-types 0.13.5",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2806,20 +2828,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2872,24 +2894,21 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unsize"
@@ -2908,18 +2927,20 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2944,9 +2965,76 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -2971,12 +3059,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2985,7 +3079,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2994,14 +3097,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3011,10 +3131,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3023,10 +3155,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3035,10 +3179,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3047,18 +3203,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.5.40"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -3072,23 +3249,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3099,27 +3275,27 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hedera"
-version = "0.38.0-beta.12"
+version = "0.38.0-beta.5"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hedera"
-version = "0.38.0-beta.9"
+version = "0.38.0-beta.10"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hedera"
-version = "0.38.0-beta.10"
+version = "0.38.0-beta.11"
 dependencies = [
  "aes",
  "anyhow",
@@ -2407,9 +2407,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -2664,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hedera"
-version = "0.38.0-beta.11"
+version = "0.38.0-beta.12"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "hedera"
 readme = "README.md"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
-version = "0.38.0-beta.11"
+version = "0.38.0-beta.12"
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "hedera"
 readme = "README.md"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
-version = "0.37.0"
+version = "0.38.0-beta.8"
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "hedera"
 readme = "README.md"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
-version = "0.38.0-beta.9"
+version = "0.38.0-beta.10"
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "hedera"
 readme = "README.md"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
-version = "0.38.0-beta.13"
+version = "0.38.0-beta.14"
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "hedera"
 readme = "README.md"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
-version = "0.38.0-beta.8"
+version = "0.38.0-beta.9"
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "hedera"
 readme = "README.md"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
-version = "0.38.0-beta.12"
+version = "0.38.0-beta.5"
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "hedera"
 readme = "README.md"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
-version = "0.38.0-beta.5"
+version = "0.38.0-beta.13"
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "hedera"
 readme = "README.md"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
-version = "0.38.0-beta.10"
+version = "0.38.0-beta.11"
 
 [lib]
 bench = false

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,11 +1,13 @@
-# Migration Guide: hedera → hiero
+# Migration Guide: hedera → hiero-sdk
 
 As part of the transition from the Hedera SDK to the new Hiero ecosystem, this Rust SDK will now be published under a new crate name:
 
--   ✅ **hiero** will be the new crate name.
+-   ✅ **hiero-sdk** will be the new crate name.
 -   ⚠️ **hedera** is still maintained temporarily for backward compatibility, but will be deprecated in the future.
+-   ✅ **hiero-sdk-proto** will be the new crate name for the protobufs crate.
+-   ⚠️ **hedera-proto** is still maintained temporarily for backward compatibility, but will be deprecated in the future.
 
-We encourage all users to migrate to **hiero** to receive future updates, features, and bug fixes.
+We encourage all users to migrate to **hiero-sdk** and **hiero-sdk-proto** to receive future updates, features, and bug fixes.
 
 ## 🛠 How to Migrate
 
@@ -17,14 +19,22 @@ Change your dependency from:
 name = "hedera"
 ```
 
+```toml
+name = "hedera-proto"
+```
+
 To:
 
 ```toml
-name = "hiero"
+name = "hiero-sdk"
+```
+
+```toml
+name = "hiero-sdk-proto"
 ```
 
 Make sure to run `cargo build` or `cargo update` to apply the change. Keep in mind that right after the dual publishing
-starts the namespace will still remain `hedera`. We will start publishing the `hiero` new SDK crates with the updated `.toml`
+starts the namespace will still remain `hedera`. We will start publishing the `hiero-sdk` new SDK crates with the updated `.toml`
 files.
 
 ### Import changes and other examples
@@ -40,12 +50,27 @@ use hedera::{
 Change it to:
 
 ```rust
-use hiero::{
+use hiero_sdk::{
     Client, AccountId, PrivateKey, TopicCreateTransaction, TopicMessageQuery, TopicMessageSubmitTransaction,
 };
 ```
 
-Most APIs and types will remain identical between `hedera` and `hiero`. Keep in mind that right after the dual publishing
+If you're using the hedera-proto crate:
+```rust
+use hedera_proto::services::{
+    self,
+};
+```
+
+Change it to:
+
+```rust
+use hiero_sdk_proto::services::{
+    self,
+};
+```
+
+Most APIs and types will remain identical between `hedera` and `hiero-sdk` and between `hedera-proto` and `hiero-sdk-proto`. Keep in mind that right after the dual publishing
 starts the namespace will still remain `hedera`. We will put up a notice when the namespace change will be mandatory.
 
 ### Update Transaction and Query Usage
@@ -67,7 +92,7 @@ let tx = TransferTransaction::new()
 Change to:
 
 ```rust
-use hiero::{Client, AccountId, TransferTransaction};
+use hiero_sdk::{Client, AccountId, TransferTransaction};
 
 let client = Client::for_testnet();
 let account_id = AccountId::from_string("0.0.1234");
@@ -91,7 +116,7 @@ let private_key = PrivateKey::generate();
 New:
 
 ```rust
-use hiero::PrivateKey;
+use hiero_sdk::PrivateKey;
 
 let private_key = PrivateKey::generate();
 ```
@@ -112,7 +137,7 @@ let topic = TopicCreateTransaction::new()
 New:
 
 ```rust
-use hiero::{TopicCreateTransaction, TopicMessageSubmitTransaction};
+use hiero_sdk::{TopicCreateTransaction, TopicMessageSubmitTransaction};
 
 let topic = TopicCreateTransaction::new()
     .memo("My Topic")
@@ -136,7 +161,7 @@ let balance = AccountBalanceQuery::new()
 New:
 
 ```rust
-use hiero::{AccountBalanceQuery, AccountId};
+use hiero_sdk::{AccountBalanceQuery, AccountId};
 
 let balance = AccountBalanceQuery::new()
     .account_id(AccountId::from_string("0.0.1234"))
@@ -161,27 +186,29 @@ Update to:
 ```rust
 match result {
     Ok(value) => { /* ... */ }
-    Err(hiero::Error::SomeError) => { /* ... */ }
+    Err(hiero_sdk::Error::SomeError) => { /* ... */ }
     Err(e) => { /* ... */ }
 }
 ```
 
 ## 📦 Crate Availability
 
-| Crate  | Status    | Description                                |
-| ------ | --------- | ------------------------------------------ |
-| hedera | ⌛ Legacy | Still works, but will be deprecated soon   |
-| hiero  | ✅ Active | New name, actively maintained and improved |
+| Crate           | Status   | Description                                 |
+|-----------------|----------|---------------------------------------------|
+| hedera          | ⌛ Legacy | Still works, but will be deprecated soon    |
+| hiero-sdk       | ✅ Active | New name, actively maintained and improved  |
+| hedera-proto    | ⌛ Legacy | Still works, but will be deprecated soon    |
+| hiero-sdk-proto | ✅ Active | New name for protobufs, actively maintained |
 
 We are currently starting dual-publishing new versions to both crates, but this will change in a future releases where `hedera` will be marked as deprecated.
 
 ## 📅 Deprecation Timeline
 
-We will continue to publish updates to both `hedera` and `hiero` for a short transition period. After that:
+We will continue to publish updates to both `hedera` and `hiero-sdk` as well as to `hedera-proto` and `hiero-sdk-proto` for a short transition period. After that:
 
 -   Final `hedera` version will be published
 -   Crate will be marked as deprecated on crates.io
--   All new development will occur under `hiero`
+-   All new development will occur under `hiero-sdk`
 
 ## 🗣 Support
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,20 +8,27 @@
 
 In the main directory, use the following steps to publish to [hedera](https://crates.io/crates/hedera): 
 
-1. Create a new git branch: `release/vX.Y.Z`.
+1. Create a new git branch: `prepare-release-vX.Y.Z`.
 2. Run all tests against [hiero-local-node](https://github.com/hiero-ledger/hiero-local-node). Stop local-node once the tests are completed.
 >- `cargo test`
 3. Change the version number in *Cargo.toml*.
 >- `version = major.minor.patch`
 >- Follows [semver 2.0](https://semver.org/spec/v2.0.0.html)
-4. Before publishing, run `--dry-run` to check for warnings or errors.
+4. Generate the `Cargo.lock` file.
+>- `cargo generate-lockfile`
+5. Before merging to main, run a `--dry-run` publish to check for warnings or errors.
 >- `cargo publish --dry-run`
-5. If all warnings and error are resolved, publish the newest version to *crates.io*.
->- `cargo publish`
-6. Once branch has been approved and merged to main, document added features pertaining to the newest release.
-7. Create the new tag in Github `vX.Y.Z`
+6. Merge the `prepare-release-vX.Y.Z` branch into `main`.
+>- *Pull Request* must be created and approved by a maintainer.
+7. Check out the latest version of the `main` branch.
+>- `git checkout main`
+8. Tag the `main` branch with the new version number.
+>- `git tag -s vX.Y.Z`
+9. Push the tag to the remote repository.
+>- `git push -u origin vX.Y.Z`
+10. The `Publish Release` workflow will trigger on the push of the tag (`vX.Y.Z`).
+>- This will publish the `hedera`, `hedera-proto`, `hiero-sdk`, and `hiero-sdk-proto` crates to *crates.io*. and create a release on GitHub.
 >- [Tags and Releases for Rust SDK](https://github.com/hiero-ledger/hiero-sdk-rust/releases)
 
 **Note** 
-- If there are new local changes to [`hedera-proto`](https://crates.io/crates/hedera-proto) crate, this must be published before `hedera` crate is published for each release. 
-Cargo will prevent publishing if this is the case.
+- The `Publish Release` workflow will only publish the crates if they have not been published before.

--- a/protobufs/Cargo.toml
+++ b/protobufs/Cargo.toml
@@ -5,6 +5,29 @@ name = "hedera-proto"
 description = "Protobufs for the Hedera™ Hashgraph SDK"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
 version = "0.17.0"
+exclude = [
+    "services/.github",
+    "services/config",
+    "services/docs",
+    "services/example-apps",
+    "services/gradle",
+    "services/hedera-node",
+    "services/hiero-dependency-versions",
+    "services/platform-sdk",
+    "services/.gitignore",
+    "services/.pre-commit-config.yaml",
+    "services/.remarkrc",
+    "services/.snyk",
+    "services/build.gradle",
+    "services/codecov.yml",
+    "services/gradle.properties",
+    "services/gradlew",
+    "services/gradlew.bat",
+    "services/LICENSE",
+    "services/README.md",
+    "services/settings.gradle.kts",
+    "services/version.txt"
+]
 
 [features]
 

--- a/protobufs/Cargo.toml
+++ b/protobufs/Cargo.toml
@@ -6,10 +6,6 @@ description = "Protobufs for the Hedera™ Hashgraph SDK"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
 version = "0.17.0"
 
-exclude = [
-    "services/*"
-]
-
 [features]
 
 [dependencies]

--- a/protobufs/Cargo.toml
+++ b/protobufs/Cargo.toml
@@ -6,6 +6,10 @@ description = "Protobufs for the Hedera™ Hashgraph SDK"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
 version = "0.17.0"
 
+exclude = [
+    "services/*"
+]
+
 [features]
 
 [dependencies]


### PR DESCRIPTION
## Description

- Updates the `RELEASE.md` file with the new process for publishing releases to [crates.io](https://crates.io).
- Updates the Cargo.toml file in `protobufs` to exclude the services directory.
- Removes some todo's
- Updates the default value of dual publish to `true`

### Related Issue(s)

Closes #1050 

### Testing
- [x] Publish to `hedera` and `hedera-proto` dry-run - [Pass](https://github.com/hiero-ledger/hiero-sdk-rust/actions/runs/16652967945)
- [x] Publish to [hedera](https://crates.io/crates/hedera) (version [0.38.0-beta.5](https://crates.io/crates/hedera/0.38.0-beta.5)) - [Pass](https://github.com/hiero-ledger/hiero-sdk-rust/actions/runs/16653255892)
- [x] Publish to `hiero-sdk` and `hiero-sdk-proto` dry-run - [Pass](https://github.com/hiero-ledger/hiero-sdk-rust/actions/runs/16653506870)
- [x] Publish to [hiero-sdk-proto](https://crates.io/crates/hiero-sdk-proto) (version [0.17.0](https://crates.io/crates/hiero-sdk-proto)) [Pass](https://github.com/hiero-ledger/hiero-sdk-rust/actions/runs/16653992472/job/47134670424#step:15:1)
- [x] Publish to [hiero-sdk](https://crates.io/crates/hiero-sdk) (version [0.38.0-beta.5](https://crates.io/crates/hiero-sdk)) [Pass](https://github.com/hiero-ledger/hiero-sdk-rust/actions/runs/16653992472/job/47134670424#step:22:1)
- [x] Publish dry run (dual publish) - v0.38.0-beta.9 - [fail](https://github.com/hiero-ledger/hiero-sdk-rust/actions/runs/16691266795) :x:

