### PR TITLE
fix: ignored e2e tests

### DIFF
--- a/.github/workflows/flow-rust-ci.yaml
+++ b/.github/workflows/flow-rust-ci.yaml
@@ -119,8 +119,8 @@ jobs:
       - name: Create env file
         run: |
             touch .env
-            echo TEST_OPERATOR_KEY="302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137" >> .env
-            echo TEST_OPERATOR_ID="0.0.2" >> .env
+            echo TEST_OPERATOR_KEY="${{ steps.solo.outputs.privateKey }}" >> .env
+            echo TEST_OPERATOR_ID="${{ steps.solo.outputs.accountId }}" >> .env
             echo TEST_NETWORK_NAME="localhost" >> .env
             echo TEST_RUN_NONFREE="1" >> .env
             cat .env

--- a/tests/e2e/account/info.rs
+++ b/tests/e2e/account/info.rs
@@ -122,7 +122,6 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn get_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
     let Some(TestEnvironment { config, client }) = setup_nonfree() else {
         return Ok(());

--- a/tests/e2e/contract/info.rs
+++ b/tests/e2e/contract/info.rs
@@ -173,7 +173,6 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn query_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
     let Some(TestEnvironment { config, client }) = setup_nonfree() else {
         return Ok(());

--- a/tests/e2e/contract/mod.rs
+++ b/tests/e2e/contract/mod.rs
@@ -110,7 +110,7 @@ async fn create_contract(
         }
 
         let contract_id = tx
-            .gas(200_000)
+            .gas(300_000)
             .constructor_parameters(
                 ContractFunctionParameters::new().add_string("Hello from Hedera.").to_bytes(None),
             )

--- a/tests/e2e/file/contents.rs
+++ b/tests/e2e/file/contents.rs
@@ -190,7 +190,6 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn query_insufficient_tx_fee_fails() -> anyhow::Result<()> {
     let Some(TestEnvironment { config, client }) = setup_nonfree() else {
         return Ok(());

--- a/tests/e2e/network_version_info.rs
+++ b/tests/e2e/network_version_info.rs
@@ -85,7 +85,6 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn get_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
     let Some(TestEnvironment { config: _, client }) = setup_nonfree() else {
         return Ok(());

--- a/tests/e2e/schedule/info.rs
+++ b/tests/e2e/schedule/info.rs
@@ -223,7 +223,6 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn query_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
     let Some(TestEnvironment { config, client }) = setup_nonfree() else {
         return Ok(());

--- a/tests/e2e/token/info.rs
+++ b/tests/e2e/token/info.rs
@@ -271,7 +271,6 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn query_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
     let Some(TestEnvironment { config: _, client }) = setup_nonfree() else {
         return Ok(());

--- a/tests/e2e/topic/info.rs
+++ b/tests/e2e/topic/info.rs
@@ -106,7 +106,6 @@ async fn query_cost_small_max() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn query_cost_insufficient_tx_fee() -> anyhow::Result<()> {
     let Some(TestEnvironment { config: _, client }) = setup_nonfree() else {
         return Ok(());


### PR DESCRIPTION
**Description**:
This PR enables previously ignored e2e tests due to solo ci migration

Fixes #
https://github.com/hiero-ledger/hiero-sdk-rust/issues/1038
