### PR TITLE
chore(ci): Fix DUAL_PUBLISH_ENABLED trigger

### DIFF
--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -40,7 +40,7 @@ jobs:
     name: Validate Release
     runs-on: hiero-client-sdk-linux-medium
     env:
-      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || 'true' }}
+      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled == 'true' || github.event_name == 'push' }}
     outputs:
       # Project tag
       tag: ${{ steps.sdk-tag.outputs.name }}
@@ -324,7 +324,7 @@ jobs:
       - run-safety-checks
     runs-on: hiero-client-sdk-linux-medium
     env:
-      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || 'true' }}
+      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled == 'true' || github.event_name == 'push' }}
       DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled || 'false' }}
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Description

Updates the `DUAL_PUBLISH_ENABLED` flag so it doesn't always evaluate to true.

### Related Issue(s)

Fixes #1059

