### PR TITLE
ci: Add Package Version Summary to zxf-publish-release.yaml

### DIFF
--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -140,6 +140,16 @@ jobs:
           fi
           echo "hiero-publish-required=${HIERO_SDK_PUBLISH_REQUIRED}" >> "${GITHUB_OUTPUT}"
 
+      - name: Package Version Summary
+        run: |
+          echo "## Package Version Summary" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| Package | Version | Publish Required |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "|---------|---------|------------------|" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| hedera-proto | ${{ steps.cargo-versions.outputs.sdk-proto-version }} | ${{ needs.validate-release.outputs.hedera-proto-publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| hiero-sdk-proto | ${{ steps.cargo-versions.outputs.sdk-proto-version }} | ${{ needs.validate-release.outputs.hiero-proto-publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| hedera | ${{ steps.cargo-versions.outputs.sdk-version }} | ${{ needs.validate-release.outputs.hedera-publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| hiero-sdk | ${{ steps.cargo-versions.outputs.sdk-version }} | ${{ needs.validate-release.outputs.hiero-publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Extract SDK Tag Information
         id: sdk-tag
         env:


### PR DESCRIPTION
## Description

This pull request makes a small improvement to the release workflow by adding a summary table of package versions and their publish status to the GitHub Actions step summary.

- Workflow improvement:
  * [`.github/workflows/zxf-publish-release.yaml`](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eR143-R152): Added a "Package Version Summary" step that outputs a markdown table to the GitHub Actions step summary, showing each package, its version, and whether publishing is required.

### Related issue(s)

Closes #1067

### Testing
- [x] Tested [Link](https://github.com/hiero-ledger/hiero-sdk-rust/actions/runs/16782427784) :runner:
