### PR TITLE
feat: Introduce delete GRPC Web proxies

### DIFF
--- a/src/address_book/node_update_transaction.rs
+++ b/src/address_book/node_update_transaction.rs
@@ -554,11 +554,11 @@ mod tests {
     fn delete_grpc_proxy_endpoint() {
         let grpc_proxy_endpoint = make_ip_address_list().into_iter().next().unwrap();
         let mut tx = NodeUpdateTransaction::new();
-        
+
         // First set the grpc proxy endpoint
         tx.grpc_proxy_endpoint(grpc_proxy_endpoint.clone());
         assert_eq!(tx.get_grpc_proxy_endpoint(), Some(&grpc_proxy_endpoint));
-        
+
         // Then delete it
         tx.delete_grpc_proxy_endpoint();
         assert_eq!(tx.get_grpc_proxy_endpoint(), None);

--- a/src/address_book/node_update_transaction.rs
+++ b/src/address_book/node_update_transaction.rs
@@ -225,6 +225,14 @@ impl NodeUpdateTransaction {
         self.data_mut().grpc_proxy_endpoint = Some(grpc_proxy_endpoint);
         self
     }
+
+    /// Deletes the gRPC proxy endpoint and sets it to null.
+    ///
+    /// This clears the gRPC proxy endpoint field, effectively removing it from the node update.
+    pub fn delete_grpc_proxy_endpoint(&mut self) -> &mut Self {
+        self.data_mut().grpc_proxy_endpoint = None;
+        self
+    }
 }
 
 impl TransactionData for NodeUpdateTransactionData {}
@@ -540,6 +548,26 @@ mod tests {
         tx.grpc_proxy_endpoint(grpc_proxy_endpoint.clone());
 
         assert_eq!(tx.get_grpc_proxy_endpoint(), Some(&grpc_proxy_endpoint));
+    }
+
+    #[test]
+    fn delete_grpc_proxy_endpoint() {
+        let grpc_proxy_endpoint = make_ip_address_list().into_iter().next().unwrap();
+        let mut tx = NodeUpdateTransaction::new();
+        
+        // First set the grpc proxy endpoint
+        tx.grpc_proxy_endpoint(grpc_proxy_endpoint.clone());
+        assert_eq!(tx.get_grpc_proxy_endpoint(), Some(&grpc_proxy_endpoint));
+        
+        // Then delete it
+        tx.delete_grpc_proxy_endpoint();
+        assert_eq!(tx.get_grpc_proxy_endpoint(), None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn delete_grpc_proxy_endpoint_frozen_panic() {
+        make_transaction().delete_grpc_proxy_endpoint();
     }
 
     #[test]


### PR DESCRIPTION
**Description**:

Introduces new method DeleteGrpcWebProxyEndpoint for NodeUpdateTransaction that sets the proxy to null and removes it from the address book state.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-rust/issues/1053

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
