### PR TITLE
fix: refer signed sources

### DIFF
--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -588,7 +588,9 @@ impl<D: TransactionExecute> Transaction<D> {
     /// # Panics
     /// - If `!self.is_frozen()`.
     pub fn to_bytes(&self) -> crate::Result<Vec<u8>> {
-        let transaction_list = self.make_transaction_list().unwrap();
+        let transaction_list = self
+            .signed_sources()
+            .map_or_else(|| self.make_transaction_list(), |it| Ok(it.transactions().to_vec()))?;
         Ok(hedera_proto::sdk::TransactionList { transaction_list }.encode_to_vec())
     }
 

--- a/src/transaction/tests.rs
+++ b/src/transaction/tests.rs
@@ -10,9 +10,9 @@ use crate::{
     Client,
     Hbar,
     PrivateKey,
-    TransferTransaction,
     TopicMessageSubmitTransaction,
     TransactionId,
+    TransferTransaction,
 };
 
 #[test]


### PR DESCRIPTION
**Description**:
This fixes an issue where the to_bytes method serializes a transaction without the signatures.

Fixes #
https://github.com/hiero-ledger/hiero-sdk-rust/issues/1070

