### PR TITLE
fix: Example rework and enable batch e2e

### DIFF
--- a/tests/e2e/batch_transaction.rs
+++ b/tests/e2e/batch_transaction.rs
@@ -25,7 +25,6 @@ use crate::common::{
 use crate::resources::BIG_CONTENTS;
 
 #[tokio::test]
-#[ignore] // Due to NotSupported error from network
 async fn can_execute_batch_transaction() -> anyhow::Result<()> {
     let Some(TestEnvironment { config: _, client }) = setup_nonfree() else {
         return Ok(());
@@ -58,7 +57,6 @@ async fn can_execute_batch_transaction() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-#[ignore] // Due to NotSupported error from network
 async fn can_execute_large_batch_transaction() -> anyhow::Result<()> {
     let Some(TestEnvironment { config: _, client }) = setup_nonfree() else {
         return Ok(());
@@ -162,7 +160,7 @@ async fn cannot_execute_batch_transaction_with_blacklisted_transaction() -> anyh
 }
 
 #[tokio::test]
-#[ignore]
+#[ignore] // Ignored for now as we run the tests with 0.0.2 which does not incur fees
 async fn cannot_execute_batch_transaction_with_invalid_inner_batch_key() -> anyhow::Result<()> {
     let Some(TestEnvironment { config: _, client }) = setup_nonfree() else {
         return Ok(());
@@ -231,7 +229,6 @@ async fn cannot_execute_batch_transaction_without_batchifying_inner() -> anyhow:
 }
 
 #[tokio::test]
-#[ignore] // Due to NotSupported error from network
 async fn can_execute_batch_transaction_with_chunked_inner() -> anyhow::Result<()> {
     let Some(TestEnvironment { config: _, client }) = setup_nonfree() else {
         return Ok(());


### PR DESCRIPTION
**Description**:

Example was misleading the usage of `BatchTransactions` and the e2e tests where ignored as the feature got disabled in the past.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-rust/issues/1161

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
