### PR TITLE
feat: Switch codebase to be hiero-ledger centric instead of hedera

### DIFF
--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -98,15 +98,6 @@ jobs:
           echo "sdk-version=${SDK_PACKAGE_VERSION}" >> "${GITHUB_OUTPUT}"
           echo "sdk-proto-version=${SDK_PROTO_VERSION}" >> "${GITHUB_OUTPUT}"
 
-      - name: Hedera Proto Subpackage Publish Required
-        id: hedera-proto-required
-        run: |
-          HEDERA_PROTO_PUBLISH_REQUIRED="false"
-          if ! curl -sSLf "https://crates.io/api/v1/crates/hedera-proto/${{ steps.cargo-versions.outputs.sdk-proto-version }}" >/dev/null 2>&1; then
-            HEDERA_PROTO_PUBLISH_REQUIRED="true"
-          fi
-          echo "hedera-proto-publish-required=${HEDERA_PROTO_PUBLISH_REQUIRED}" >> "${GITHUB_OUTPUT}"
-
       - name: Hiero SDK Proto Subpackage Publish Required
         id: hiero-sdk-proto-required
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
@@ -117,14 +108,14 @@ jobs:
           fi
           echo "hiero-proto-publish-required=${HIERO_SDK_PROTO_PUBLISH_REQUIRED}" >> "${GITHUB_OUTPUT}"
 
-      - name: Hedera SDK Publish Required
-        id: hedera-sdk-required
+      - name: Hedera Proto Subpackage Publish Required
+        id: hedera-proto-required
         run: |
-          HEDERA_SDK_PUBLISH_REQUIRED="false"
-          if ! curl -sSLf "https://crates.io/api/v1/crates/hedera/${{ steps.cargo-versions.outputs.sdk-version }}" >/dev/null 2>&1; then
-            HEDERA_SDK_PUBLISH_REQUIRED="true"
+          HEDERA_PROTO_PUBLISH_REQUIRED="false"
+          if ! curl -sSLf "https://crates.io/api/v1/crates/hedera-proto/${{ steps.cargo-versions.outputs.sdk-proto-version }}" >/dev/null 2>&1; then
+            HEDERA_PROTO_PUBLISH_REQUIRED="true"
           fi
-          echo "hedera-publish-required=${HEDERA_SDK_PUBLISH_REQUIRED}" >> "${GITHUB_OUTPUT}"
+          echo "hedera-proto-publish-required=${HEDERA_PROTO_PUBLISH_REQUIRED}" >> "${GITHUB_OUTPUT}"
 
       - name: Hiero SDK Publish Required
         id: hiero-sdk-required
@@ -136,15 +127,24 @@ jobs:
           fi
           echo "hiero-publish-required=${HIERO_SDK_PUBLISH_REQUIRED}" >> "${GITHUB_OUTPUT}"
 
+      - name: Hedera SDK Publish Required
+        id: hedera-sdk-required
+        run: |
+          HEDERA_SDK_PUBLISH_REQUIRED="false"
+          if ! curl -sSLf "https://crates.io/api/v1/crates/hedera/${{ steps.cargo-versions.outputs.sdk-version }}" >/dev/null 2>&1; then
+            HEDERA_SDK_PUBLISH_REQUIRED="true"
+          fi
+          echo "hedera-publish-required=${HEDERA_SDK_PUBLISH_REQUIRED}" >> "${GITHUB_OUTPUT}"
+
       - name: Package Version Summary
         run: |
           echo "## Package Version Summary" >> "${GITHUB_STEP_SUMMARY}"
           echo "| Package | Version | Publish Required |" >> "${GITHUB_STEP_SUMMARY}"
           echo "|---------|---------|------------------|" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| hedera-proto | ${{ steps.cargo-versions.outputs.sdk-proto-version }} | ${{ steps.hedera-proto-required.outputs.hedera-proto-publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
           echo "| hiero-sdk-proto | ${{ steps.cargo-versions.outputs.sdk-proto-version }} | ${{ steps.hiero-sdk-proto-required.outputs.hiero-proto-publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
-          echo "| hedera | ${{ steps.cargo-versions.outputs.sdk-version }} | ${{ steps.hedera-sdk-required.outputs.hedera-publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| hedera-proto | ${{ steps.cargo-versions.outputs.sdk-proto-version }} | ${{ steps.hedera-proto-required.outputs.hedera-proto-publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
           echo "| hiero-sdk | ${{ steps.cargo-versions.outputs.sdk-version }} | ${{ steps.hiero-sdk-required.outputs.hiero-publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
+          echo "| hedera | ${{ steps.cargo-versions.outputs.sdk-version }} | ${{ steps.hedera-sdk-required.outputs.hedera-publish-required }} |" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Extract SDK Tag Information
         id: sdk-tag
@@ -354,19 +354,21 @@ jobs:
           
           echo "args=${PUBLISH_ARGS}" >> "${GITHUB_OUTPUT}"
 
-      # Publish the hedera-proto package
-      - name: Publish Proto Subpackage to crates.io (hedera-proto)
-        if: ${{ needs.validate-release.outputs.hedera-proto-publish-required == 'true'}}
+      # Publish the hiero-sdk-proto package
+      - name: Publish proto to crates.io (hiero-sdk-proto)
+        if: ${{ needs.validate-release.outputs.hiero-proto-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
-        run: cargo publish ${{ steps.proto-publish-args.outputs.args }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
+        run: |
+          echo "cargo publish ${{ steps.proto-publish-args.outputs.args }}"
+          cargo publish ${{ steps.proto-publish-args.outputs.args }}
         working-directory: protobufs
 
-      # Publish the main SDK package (hedera)
-      - name: Publish SDK to crates.io (hedera)
-        if: ${{ needs.validate-release.outputs.hedera-publish-required == 'true' }}
+      # Publish the main SDK package (hiero-sdk)
+      - name: Publish SDK to crates.io (hiero-sdk)
+        if: ${{ needs.validate-release.outputs.hiero-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
         run: cargo publish ${{ steps.sdk-publish-args.outputs.args }}
 
       - name: Setup NodeJS
@@ -390,32 +392,32 @@ jobs:
           echo TEST_RUN_NONFREE="1" >> .env
           cat .env
 
-      # Update the Cargo.toml files for the hiero-sdk-* packages
+      # Update the Cargo.toml files for the hedera-* packages
       - name: Update Cargo.toml for hiero publishing
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' }}
         run: |
           echo "::group::Update protobufs/Cargo.toml with new name"       
           # Update the dependencies in the protobugs/Cargo.toml
-          toml set protobufs/Cargo.toml package.name "hiero-sdk-proto" > protobufs/Cargo.toml.tmp && mv protobufs/Cargo.toml.tmp protobufs/Cargo.toml
+          toml set protobufs/Cargo.toml package.name "hedera-proto" > protobufs/Cargo.toml.tmp && mv protobufs/Cargo.toml.tmp protobufs/Cargo.toml
           echo "::endgroup::"
           
           echo "::group::Update main Cargo.toml with new name and dependencies"
-          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          toml set Cargo.toml package.name "hedera" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
           # Update the dependencies in the main Cargo.toml
-          sed -i "s/hedera-proto/hiero-sdk-proto/g" Cargo.toml
+          sed -i "s/hiero-sdk-proto/hedera-proto/g" Cargo.toml
 
           echo "::endgroup::"
           
           echo "::group::Update TCK Cargo.toml with new dependencies"
           # Update the dependencies in the tck/Cargo.toml for both protobufs and sdk
-          sed -i "s/hedera/hiero-sdk/g" tck/Cargo.toml
+          sed -i "s/hiero-sdk/hedera/g" tck/Cargo.toml
           echo "::endgroup::"
           
           echo "::group::Update files with new names"
-          find . -type f -name "*.rs" -exec sed -i "s/\bhedera_proto\b/hiero_sdk_proto/g" {} +
-          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
-          find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\bhiero_sdk_proto\b/hedera_proto/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\buse hiero_sdk\b/use hedera/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\bhiero_sdk::\b/hedera::/g" {} +
           echo "::endgroup::"
           
           echo "::group::Verify Cargo.toml changes"
@@ -426,16 +428,15 @@ jobs:
           cargo generate-lockfile
           echo "::endgroup::"
 
-      - name: Publish proto to crates.io (hiero-sdk-proto)
-        if: ${{ needs.validate-release.outputs.hiero-proto-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
+      # Publish the hedera-proto package
+      - name: Publish Proto Subpackage to crates.io (hedera-proto)
+        if: ${{ needs.validate-release.outputs.hedera-proto-publish-required == 'true'}}
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
-        run: | 
-          echo "cargo publish ${{ steps.proto-publish-args.outputs.args }}"
-          cargo publish ${{ steps.proto-publish-args.outputs.args }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
+        run: cargo publish ${{ steps.proto-publish-args.outputs.args }}
         working-directory: protobufs
 
-      # Test the hiero-sdk package if proto hasn't been published yet.
+      # Test the hedera package if proto hasn't been published yet.
       - name: Reset the workspace
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
         run: |
@@ -457,16 +458,16 @@ jobs:
         if: ${{ env.DUAL_PUBLISH_ENABLED == 'true' && env.DRY_RUN_ENABLED == 'true' }}
         run: |
           echo "::group::Update main Cargo.toml with new name and dependencies"
-          toml set Cargo.toml package.name "hiero-sdk" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          toml set Cargo.toml package.name "hedera" > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
           
           echo "::group::Update TCK Cargo.toml with new dependencies"
           # Update the dependencies in the tck/Cargo.toml
-          sed -i "s/hedera =/hiero-sdk =/g" tck/Cargo.toml
+          sed -i "s/hiero-sdk =/hedera =/g" tck/Cargo.toml
           echo "::endgroup::"
           
           echo "::group::Update files with new names"
-          find . -type f -name "*.rs" -exec sed -i "s/\buse hedera\b/use hiero_sdk/g" {} +
-          find . -type f -name "*.rs" -exec sed -i "s/\bhedera::\b/hiero_sdk::/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\buse hiero_sdk\b/use hedera/g" {} +
+          find . -type f -name "*.rs" -exec sed -i "s/\bhiero_sdk::\b/hedera::/g" {} +
           echo "::endgroup::"
           
           echo "::group::Verify Cargo.toml changes"
@@ -477,10 +478,11 @@ jobs:
           cargo generate-lockfile
           echo "::endgroup::"
 
-      - name: Publish SDK to crates.io (hiero-sdk)
-        if: ${{ needs.validate-release.outputs.hiero-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
+      # Publish the main SDK package (hedera)
+      - name: Publish SDK to crates.io (hedera)
+        if: ${{ needs.validate-release.outputs.hedera-publish-required == 'true' }}
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HL_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_HG_TOKEN }}
         run: cargo publish ${{ steps.sdk-publish-args.outputs.args }}
 
       - name: Reset the workspace

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 target
 **/Cargo.toml.bak
 **/Cargo.lock.bak
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,9 +760,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "a2152dbcb980c05735e2a651d96011320a949eb31a0c8b38b72645ce97dec676"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1200,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1452,9 +1452,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "linked-hash-map"
@@ -1488,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchers"
@@ -1569,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hedera"
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
+name = "hiero-sdk"
 version = "0.42.1"
 dependencies = [
  "aes",
@@ -993,9 +1005,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "hedera-proto",
  "hex",
  "hex-literal",
+ "hiero-sdk-proto",
  "hmac",
  "hyper",
  "hyper-openssl",
@@ -1033,7 +1045,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "hedera-proto"
+name = "hiero-sdk-proto"
 version = "0.20.0"
 dependencies = [
  "anyhow",
@@ -1048,28 +1060,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-literal"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
-
-[[package]]
 name = "hiero-sdk-tck"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "futures-util",
- "hedera",
- "hedera-proto",
  "hex",
  "hex-literal",
+ "hiero-sdk",
+ "hiero-sdk-proto",
  "hyper",
  "jsonrpsee",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hiero-sdk"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "hiero-sdk"
 readme = "README.md"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
-version = "0.42.1"
+version = "0.43.0"
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "protobufs", "tck"]
 description = "The SDK for interacting with Hedera Hashgraph."
 edition = "2021"
 license = "Apache-2.0"
-name = "hedera"
+name = "hiero-sdk"
 readme = "README.md"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
 version = "0.42.1"
@@ -27,7 +27,7 @@ fraction = { version = "0.15.1", default-features = false }
 futures-core = "0.3.31"
 # Transitive dependency of tonic 0.12
 h2 = "0.4.12"
-hedera-proto = { path = "./protobufs", version = "0.20.0", features = ["time_0_3", "fraction"] }
+hiero-sdk-proto = { path = "./protobufs", version = "0.20.0", features = ["time_0_3", "fraction"] }
 hex = "0.4.3"
 hmac = "0.12.1"
 # Dependency of tonic 0.12

--- a/examples/account_alias.rs
+++ b/examples/account_alias.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery, AccountId, AccountInfoQuery, Client, Hbar, PrivateKey, TransferTransaction
 };
 

--- a/examples/account_allowance.rs
+++ b/examples/account_allowance.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountAllowanceApproveTransaction, AccountBalanceQuery, AccountCreateTransaction, AccountDeleteTransaction, AccountId, Client, Hbar, PrivateKey, TransactionId, TransferTransaction
 };
 
@@ -24,7 +24,7 @@ struct Account {
     name: &'static str,
 }
 
-async fn create_account(client: &Client, name: &'static str) -> hedera::Result<Account> {
+async fn create_account(client: &Client, name: &'static str) -> hiero_sdk::Result<Account> {
     let key = PrivateKey::generate_ed25519();
 
     let reciept = AccountCreateTransaction::new()
@@ -67,7 +67,7 @@ async fn create_accounts(client: &Client) -> anyhow::Result<[Account; 3]> {
 
 // this needs to be a function because rust doesn't have try blocks.
 /// Transfer from `alice` (0) to `charlie` (2) via `bob`'s allowance (1).
-async fn transfer(client: &Client, accounts: &[Account; 3], value: Hbar) -> hedera::Result<()> {
+async fn transfer(client: &Client, accounts: &[Account; 3], value: Hbar) -> hiero_sdk::Result<()> {
     let [alice, bob, charlie] = accounts;
     // `approved_{hbar,token}_transfer()` means that the transfer has been approved by an allowance
     // The allowance spender must be pay the fee for the transaction.
@@ -237,7 +237,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn print_balances(client: &Client, accounts: &[Account; 3]) -> hedera::Result<()> {
+async fn print_balances(client: &Client, accounts: &[Account; 3]) -> hiero_sdk::Result<()> {
     for account in accounts {
         let balance = AccountBalanceQuery::new()
             .account_id(account.id)

--- a/examples/batch_transaction.rs
+++ b/examples/batch_transaction.rs
@@ -134,7 +134,11 @@ async fn create_account(
     })
 }
 
-async fn print_balance(client: &Client, name: &str, account_id: AccountId) -> hiero_sdk::Result<()> {
+async fn print_balance(
+    client: &Client,
+    name: &str,
+    account_id: AccountId,
+) -> hiero_sdk::Result<()> {
     let balance = AccountBalanceQuery::new()
         .account_id(account_id)
         .execute(client)

--- a/examples/batch_transaction.rs
+++ b/examples/batch_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery, AccountCreateTransaction, AccountId, BatchTransaction, Client, Hbar, PrivateKey, TransferTransaction
 };
 
@@ -117,9 +117,9 @@ async fn main() -> anyhow::Result<()> {
 
 async fn create_account(
     client: &Client,
-    public_key: hedera::PublicKey,
+    public_key: hiero_sdk::PublicKey,
     initial_balance: Hbar,
-) -> hedera::Result<AccountId> {
+) -> hiero_sdk::Result<AccountId> {
     let response = AccountCreateTransaction::new()
         .set_key_without_alias(public_key)
         .initial_balance(initial_balance)
@@ -128,13 +128,13 @@ async fn create_account(
 
     let receipt = response.get_receipt(client).await?;
     receipt.account_id.ok_or_else(|| {
-        hedera::Error::TimedOut(Box::new(hedera::Error::GrpcStatus(
+        hiero_sdk::Error::TimedOut(Box::new(hiero_sdk::Error::GrpcStatus(
             tonic::Status::not_found("account_id not found in receipt"),
         )))
     })
 }
 
-async fn print_balance(client: &Client, name: &str, account_id: AccountId) -> hedera::Result<()> {
+async fn print_balance(client: &Client, name: &str, account_id: AccountId) -> hiero_sdk::Result<()> {
     let balance = AccountBalanceQuery::new()
         .account_id(account_id)
         .execute(client)

--- a/examples/consensus_pub_sub.rs
+++ b/examples/consensus_pub_sub.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 // `use futures::TryStreamExt`, this is better practice though.
 use futures_util::TryStreamExt;
-use hedera::{
+use hiero_sdk::{
     AccountId, Client, PrivateKey, TopicId, TopicMessageQuery, TopicMessageSubmitTransaction
 };
 use parking_lot::RwLock;

--- a/examples/consensus_pub_sub_chunked.rs
+++ b/examples/consensus_pub_sub_chunked.rs
@@ -6,7 +6,7 @@ mod resources;
 
 use clap::Parser;
 use futures_util::StreamExt;
-use hedera::{
+use hiero_sdk::{
     AccountId, Client, PrivateKey, TopicCreateTransaction, TopicMessageQuery, TopicMessageSubmitTransaction, Transaction
 };
 use tokio::task::JoinHandle;
@@ -51,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::time::sleep(Duration::from_secs(10)).await;
 
-    let _handle: JoinHandle<hedera::Result<()>> = tokio::spawn({
+    let _handle: JoinHandle<hiero_sdk::Result<()>> = tokio::spawn({
         let client = client.clone();
         async move {
             println!(

--- a/examples/consensus_pub_sub_with_submit_key.rs
+++ b/examples/consensus_pub_sub_with_submit_key.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use clap::Parser;
 use futures_util::StreamExt;
-use hedera::{
+use hiero_sdk::{
     AccountId, Client, PrivateKey, TopicCreateTransaction, TopicMessageQuery, TopicMessageSubmitTransaction
 };
 
@@ -47,7 +47,7 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::time::sleep(Duration::from_secs(10)).await;
 
-    let _handle: tokio::task::JoinHandle<hedera::Result<()>> = tokio::spawn({
+    let _handle: tokio::task::JoinHandle<hiero_sdk::Result<()>> = tokio::spawn({
         let client = client.clone();
         async move {
             println!("sending 5 messages");

--- a/examples/contract/mod.rs
+++ b/examples/contract/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera::{
+use hiero_sdk::{
     AccountId, Client, ContractCreateFlow, ContractExecuteTransaction, ContractFunctionParameters,
     ContractFunctionResult, ContractId, Hbar, PrivateKey, TransactionId,
 };
@@ -24,7 +24,7 @@ impl ContractHelper {
         Self { contract_id, steps }
     }
 
-    pub async fn execute(&self, client: &Client) -> hedera::Result<()> {
+    pub async fn execute(&self, client: &Client) -> hiero_sdk::Result<()> {
         for (index, step) in self.steps.iter().enumerate() {
             println!("Attempting to execute step {index}");
 
@@ -88,7 +88,7 @@ pub async fn create_contract(
     client: &Client,
     bytecode: &str,
     constructor_parameters: ContractFunctionParameters,
-) -> hedera::Result<ContractId> {
+) -> hiero_sdk::Result<ContractId> {
     let contract_id = ContractCreateFlow::new()
         .bytecode_hex(bytecode)?
         .max_chunks(30)

--- a/examples/create_account.rs
+++ b/examples/create_account.rs
@@ -2,7 +2,7 @@
 
 use assert_matches::assert_matches;
 use clap::Parser;
-use hedera::{AccountCreateTransaction, AccountId, Client, PrivateKey};
+use hiero_sdk::{AccountCreateTransaction, AccountId, Client, PrivateKey};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/create_account_threshold_key.rs
+++ b/examples/create_account_threshold_key.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery, AccountCreateTransaction, AccountId, Client, Hbar, Key, KeyList, PrivateKey, TransferTransaction
 };
 

--- a/examples/create_file.rs
+++ b/examples/create_file.rs
@@ -2,7 +2,7 @@
 
 use assert_matches::assert_matches;
 use clap::Parser;
-use hedera::{AccountId, Client, FileCreateTransaction, PrivateKey};
+use hiero_sdk::{AccountId, Client, FileCreateTransaction, PrivateKey};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/create_simple_contract.rs
+++ b/examples/create_simple_contract.rs
@@ -3,7 +3,7 @@
 mod resources;
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountId, Client, ContractCallQuery, ContractCreateTransaction, ContractDeleteTransaction, ContractFunctionParameters, FileCreateTransaction, PrivateKey
 };
 

--- a/examples/create_stateful_contract.rs
+++ b/examples/create_stateful_contract.rs
@@ -3,7 +3,7 @@
 mod resources;
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountId, Client, ContractCallQuery, ContractCreateTransaction, ContractExecuteTransaction, ContractFunctionParameters, FileCreateTransaction, PrivateKey
 };
 

--- a/examples/create_topic.rs
+++ b/examples/create_topic.rs
@@ -2,7 +2,7 @@
 
 use assert_matches::assert_matches;
 use clap::Parser;
-use hedera::{AccountId, Client, PrivateKey, TopicCreateTransaction};
+use hiero_sdk::{AccountId, Client, PrivateKey, TopicCreateTransaction};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/delete_file.rs
+++ b/examples/delete_file.rs
@@ -3,7 +3,7 @@
 use std::iter;
 
 use clap::Parser;
-use hedera::{AccountId, Client, FileCreateTransaction, FileDeleteTransaction, PrivateKey};
+use hiero_sdk::{AccountId, Client, FileCreateTransaction, FileDeleteTransaction, PrivateKey};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/file_append_chunked.rs
+++ b/examples/file_append_chunked.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountId, FileAppendTransaction, FileContentsQuery, FileCreateTransaction, Hbar, PrivateKey
 };
 
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
-    let client = hedera::Client::for_name(&args.hedera_network)?;
+    let client = hiero_sdk::Client::for_name(&args.hedera_network)?;
 
     client.set_operator(args.operator_account_id, args.operator_key.clone());
 

--- a/examples/generate_key.rs
+++ b/examples/generate_key.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera::PrivateKey;
+use hiero_sdk::PrivateKey;
 
 fn main() {
     // Generate a Ed25519 key

--- a/examples/get_account_balance.rs
+++ b/examples/get_account_balance.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera::{AccountBalanceQuery, AccountId, Client, NodeAddressBookQuery};
+use hiero_sdk::{AccountBalanceQuery, AccountId, Client, NodeAddressBookQuery};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/get_account_info.rs
+++ b/examples/get_account_info.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{AccountId, AccountInfoQuery, Client, PrivateKey};
+use hiero_sdk::{AccountId, AccountInfoQuery, Client, PrivateKey};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/get_address_book.rs
+++ b/examples/get_address_book.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{AccountId, Client, FileId, NodeAddressBookQuery, PrivateKey};
+use hiero_sdk::{AccountId, Client, FileId, NodeAddressBookQuery, PrivateKey};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/get_exchange_rates.rs
+++ b/examples/get_exchange_rates.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{AccountId, Client, ExchangeRates, FileContentsQuery, FileId, PrivateKey};
+use hiero_sdk::{AccountId, Client, ExchangeRates, FileContentsQuery, FileId, PrivateKey};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/get_file_contents.rs
+++ b/examples/get_file_contents.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{AccountId, Client, FileContentsQuery, FileId, PrivateKey};
+use hiero_sdk::{AccountId, Client, FileContentsQuery, FileId, PrivateKey};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/initialize_client_with_mirror_network.rs
+++ b/examples/initialize_client_with_mirror_network.rs
@@ -2,7 +2,7 @@
 
 use assert_matches::assert_matches;
 use clap::Parser;
-use hedera::{AccountCreateTransaction, AccountId, Client, Hbar, PrivateKey};
+use hiero_sdk::{AccountCreateTransaction, AccountId, Client, Hbar, PrivateKey};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/long_term_scheduled_transaction.rs
+++ b/examples/long_term_scheduled_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction, AccountId, AccountInfoQuery, AccountUpdateTransaction, Client, Hbar, Key, KeyList, PrivateKey, ScheduleInfoQuery, ScheduleSignTransaction, TransferTransaction
 };
 use time::{Duration, OffsetDateTime};

--- a/examples/modify_token_keys.rs
+++ b/examples/modify_token_keys.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountId, Client, KeyList, PrivateKey, PublicKey, TokenCreateTransaction, TokenInfoQuery, TokenKeyValidation, TokenUpdateTransaction
 };
 use time::{Duration, OffsetDateTime};
@@ -46,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
     let token_id = TokenCreateTransaction::new()
         .name("Example NFT")
         .symbol("ENFT")
-        .token_type(hedera::TokenType::NonFungibleUnique)
+        .token_type(hiero_sdk::TokenType::NonFungibleUnique)
         .treasury_account_id(client.get_operator_account_id().unwrap())
         .admin_key(admin_key.public_key())
         .wipe_key(wipe_key.public_key())

--- a/examples/multi_app_transfer.rs
+++ b/examples/multi_app_transfer.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery, AccountCreateTransaction, AccountId, Client, Hbar, PrivateKey, Transaction, TransferTransaction
 };
 
@@ -120,7 +120,7 @@ async fn main() -> anyhow::Result<()> {
 fn exchange_signs_transaction(
     exchange_key: PrivateKey,
     transaction_data: &[u8],
-) -> hedera::Result<Vec<u8>> {
+) -> hiero_sdk::Result<Vec<u8>> {
     Transaction::from_bytes(transaction_data)?
         .sign(exchange_key)
         .to_bytes()

--- a/examples/multi_sig_offline.rs
+++ b/examples/multi_sig_offline.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction, AccountId, Client, Hbar, KeyList, PrivateKey, Transaction, TransferTransaction
 };
 

--- a/examples/nft_update_metadata.rs
+++ b/examples/nft_update_metadata.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction, AccountId, Client, Hbar, NftId, PrivateKey, TokenCreateTransaction, TokenInfoQuery, TokenMintTransaction, TokenNftInfoQuery, TokenType, TokenUpdateNftsTransaction, TransferTransaction
 };
 use time::{Duration, OffsetDateTime};

--- a/examples/prng.rs
+++ b/examples/prng.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{AccountId, Client, PrivateKey, PrngTransaction};
+use hiero_sdk::{AccountId, Client, PrivateKey, PrngTransaction};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/schedule.rs
+++ b/examples/schedule.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction, AccountId, Client, Hbar, KeyList, PrivateKey, ScheduleInfoQuery, ScheduleSignTransaction, TransferTransaction
 };
 use time::OffsetDateTime;

--- a/examples/schedule_identical_transaction.rs
+++ b/examples/schedule_identical_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction, AccountDeleteTransaction, AccountId, Client, Hbar, Key, KeyList, PrivateKey, ScheduleCreateTransaction, ScheduleId, ScheduleInfoQuery, ScheduleSignTransaction, Status, TransactionReceiptQuery, TransferTransaction
 };
 

--- a/examples/schedule_multi_sig_transaction.rs
+++ b/examples/schedule_multi_sig_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction, AccountId, Client, Hbar, KeyList, PrivateKey, ScheduleInfoQuery, ScheduleSignTransaction, TransactionId, TransferTransaction
 };
 

--- a/examples/scheduled_transaction_multi_sig_threshold.rs
+++ b/examples/scheduled_transaction_multi_sig_threshold.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery, AccountCreateTransaction, AccountId, Client, Hbar, Key, KeyList, PrivateKey, ScheduleInfoQuery, ScheduleSignTransaction, TransactionRecordQuery, TransferTransaction
 };
 

--- a/examples/scheduled_transfer.rs
+++ b/examples/scheduled_transfer.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery, AccountCreateTransaction, AccountDeleteTransaction, AccountId, Client, Hbar, PrivateKey, ScheduleCreateTransaction, ScheduleInfoQuery, ScheduleSignTransaction, TransferTransaction
 };
 

--- a/examples/sign_transaction.rs
+++ b/examples/sign_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction, AccountId, Client, Hbar, KeyList, PrivateKey, TransferTransaction
 };
 

--- a/examples/staking.rs
+++ b/examples/staking.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{AccountCreateTransaction, AccountId, AccountInfoQuery, Client, Hbar, PrivateKey};
+use hiero_sdk::{AccountCreateTransaction, AccountId, AccountInfoQuery, Client, Hbar, PrivateKey};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/staking_with_update.rs
+++ b/examples/staking_with_update.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction, AccountId, AccountInfoQuery, AccountUpdateTransaction, Client, Hbar, PrivateKey
 };
 

--- a/examples/token_airdrop.rs
+++ b/examples/token_airdrop.rs
@@ -3,7 +3,7 @@
 use std::iter::repeat;
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery, AccountCreateTransaction, AccountId, Client, Hbar, PrivateKey, TokenAirdropTransaction, TokenCancelAirdropTransaction, TokenClaimAirdropTransaction, TokenCreateTransaction, TokenMintTransaction, TokenRejectTransaction
 };
 use time::{Duration, OffsetDateTime};
@@ -88,7 +88,7 @@ async fn main() -> anyhow::Result<()> {
         .initial_supply(100)
         .max_supply(100)
         .treasury_account_id(treasury_account_id)
-        .token_supply_type(hedera::TokenSupplyType::Finite)
+        .token_supply_type(hiero_sdk::TokenSupplyType::Finite)
         .admin_key(operator_key.clone().public_key())
         .freeze_key(operator_key.clone().public_key())
         .supply_key(operator_key.clone().public_key())
@@ -108,8 +108,8 @@ async fn main() -> anyhow::Result<()> {
         .symbol("F")
         .max_supply(10)
         .treasury_account_id(treasury_account_id)
-        .token_supply_type(hedera::TokenSupplyType::Finite)
-        .token_type(hedera::TokenType::NonFungibleUnique)
+        .token_supply_type(hiero_sdk::TokenSupplyType::Finite)
+        .token_type(hiero_sdk::TokenType::NonFungibleUnique)
         .admin_key(operator_key.clone().public_key())
         .freeze_key(operator_key.clone().public_key())
         .supply_key(operator_key.clone().public_key())

--- a/examples/token_update_metadata_with_admin_key.rs
+++ b/examples/token_update_metadata_with_admin_key.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountId, Client, PrivateKey, TokenCreateTransaction, TokenInfoQuery, TokenType, TokenUpdateTransaction
 };
 use time::{Duration, OffsetDateTime};

--- a/examples/token_update_metadata_with_metadata_key.rs
+++ b/examples/token_update_metadata_with_metadata_key.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountId, Client, PrivateKey, TokenCreateTransaction, TokenInfoQuery, TokenType, TokenUpdateTransaction
 };
 use time::{Duration, OffsetDateTime};

--- a/examples/topic_with_admin_key.rs
+++ b/examples/topic_with_admin_key.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountId, Client, Key, KeyList, PrivateKey, TopicCreateTransaction, TopicId, TopicInfoQuery, TopicUpdateTransaction
 };
 

--- a/examples/transfer_crypto.rs
+++ b/examples/transfer_crypto.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{AccountId, Client, Hbar, PrivateKey, TransferTransaction};
+use hiero_sdk::{AccountId, Client, Hbar, PrivateKey, TransferTransaction};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/transfer_crypto_cost.rs
+++ b/examples/transfer_crypto_cost.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{AccountId, Client, Hbar, PrivateKey, TransferTransaction};
+use hiero_sdk::{AccountId, Client, Hbar, PrivateKey, TransferTransaction};
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/transfer_tokens.rs
+++ b/examples/transfer_tokens.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction, AccountDeleteTransaction, AccountId, Client, Hbar, PrivateKey, TokenAssociateTransaction, TokenCreateTransaction, TokenDeleteTransaction, TokenGrantKycTransaction, TokenWipeTransaction, TransferTransaction
 };
 use time::{Duration, OffsetDateTime};

--- a/examples/update_account_public_key.rs
+++ b/examples/update_account_public_key.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction, AccountId, AccountInfoQuery, AccountUpdateTransaction, Hbar, PrivateKey
 };
 
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
-    let client = hedera::Client::for_name(&args.hedera_network)?;
+    let client = hiero_sdk::Client::for_name(&args.hedera_network)?;
 
     client.set_operator(args.operator_account_id, args.operator_key.clone());
 

--- a/examples/validate_checksum.rs
+++ b/examples/validate_checksum.rs
@@ -3,7 +3,7 @@
 use std::io::Write;
 
 use clap::Parser;
-use hedera::{AccountBalanceQuery, AccountId, Client};
+use hiero_sdk::{AccountBalanceQuery, AccountId, Client};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -43,7 +43,7 @@ async fn manual_checksum_validation(client: &Client) -> anyhow::Result<Option<Ac
             Ok(()) => {}
             Err(e) => {
                 println!("{e}");
-                if let hedera::Error::BadEntityId {
+                if let hiero_sdk::Error::BadEntityId {
                     shard,
                     realm,
                     num,
@@ -111,7 +111,7 @@ fn parse_account_id() -> anyhow::Result<Option<AccountId>> {
 
         let account_id: AccountId = match line.parse() {
             Ok(account_id) => account_id,
-            Err(err @ hedera::Error::BasicParse(_)) => {
+            Err(err @ hiero_sdk::Error::BasicParse(_)) => {
                 println!("{err:?}");
                 continue;
             }

--- a/protobufs/Cargo.toml
+++ b/protobufs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 license = "Apache-2.0"
-name = "hedera-proto"
+name = "hiero-sdk-proto"
 description = "Protobufs for the Hedera™ Hashgraph SDK"
 repository = "https://github.com/hiero-ledger/hiero-sdk-rust"
 version = "0.20.0"

--- a/src/account/account_allowance_approve_transaction.rs
+++ b/src/account/account_allowance_approve_transaction.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 

--- a/src/account/account_allowance_delete_transaction.rs
+++ b/src/account/account_allowance_delete_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/account/account_balance.rs
+++ b/src/account/account_balance.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use prost::Message;
 
 use crate::protobuf::ToProtobuf;

--- a/src/account/account_balance_query.rs
+++ b/src/account/account_balance_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
 use services::crypto_get_account_balance_query::BalanceSource;
 use tonic::transport::Channel;
 

--- a/src/account/account_create_transaction.rs
+++ b/src/account/account_create_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
 use time::Duration;
 use tonic::transport::Channel;
 
@@ -398,7 +398,7 @@ impl ToProtobuf for AccountCreateTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use hex_literal::hex;
     use time::Duration;
 

--- a/src/account/account_create_transaction.rs
+++ b/src/account/account_create_transaction.rs
@@ -398,8 +398,8 @@ impl ToProtobuf for AccountCreateTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hiero_sdk_proto::services;
     use hex_literal::hex;
+    use hiero_sdk_proto::services;
     use time::Duration;
 
     use crate::account::AccountCreateTransactionData;

--- a/src/account/account_delete_transaction.rs
+++ b/src/account/account_delete_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -134,7 +134,7 @@ impl ToProtobuf for AccountDeleteTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::account::AccountDeleteTransactionData;
     use crate::protobuf::{

--- a/src/account/account_id.rs
+++ b/src/account/account_id.rs
@@ -8,7 +8,7 @@ use std::fmt::{
 };
 use std::str::FromStr;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::entity_id::{
     Checksum,

--- a/src/account/account_info.rs
+++ b/src/account/account_info.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use prost::Message;
 use time::{
     Duration,

--- a/src/account/account_info_query.rs
+++ b/src/account/account_info_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
 use crate::account::AccountInfo;

--- a/src/account/account_records_query.rs
+++ b/src/account/account_records_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/account/account_update_transaction.rs
+++ b/src/account/account_update_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
 use time::{
     Duration,
     OffsetDateTime,
@@ -389,7 +389,7 @@ impl ToProtobuf for AccountUpdateTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use time::{
         Duration,
         OffsetDateTime,

--- a/src/account/proxy_staker.rs
+++ b/src/account/proxy_staker.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::{
     AccountId,

--- a/src/address_book/node_create_transaction.rs
+++ b/src/address_book/node_create_transaction.rs
@@ -2,8 +2,8 @@
 
 use std::net::Ipv4Addr;
 
-use hedera_proto::services;
-use hedera_proto::services::address_book_service_client::AddressBookServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::address_book_service_client::AddressBookServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -323,7 +323,7 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use expect_test::expect_file;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use super::NodeCreateTransaction;
     use crate::address_book::NodeCreateTransactionData;

--- a/src/address_book/node_delete_transaction.rs
+++ b/src/address_book/node_delete_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::address_book_service_client::AddressBookServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::address_book_service_client::AddressBookServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -121,7 +121,7 @@ impl ToProtobuf for NodeDeleteTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect_file;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use super::NodeDeleteTransaction;
     use crate::address_book::NodeDeleteTransactionData;

--- a/src/address_book/node_update_transaction.rs
+++ b/src/address_book/node_update_transaction.rs
@@ -2,8 +2,8 @@
 
 use std::net::Ipv4Addr;
 
-use hedera_proto::services;
-use hedera_proto::services::address_book_service_client::AddressBookServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::address_book_service_client::AddressBookServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -361,7 +361,7 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use expect_test::expect_file;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use super::NodeUpdateTransaction;
     use crate::address_book::NodeUpdateTransactionData;

--- a/src/batch_transaction.rs
+++ b/src/batch_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::util_service_client::UtilServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::util_service_client::UtilServiceClient;
 use prost::Message;
 use tonic::transport::Channel;
 
@@ -44,9 +44,9 @@ use crate::{
 /// # Example usage
 ///
 /// ```rust,no_run
-/// use hedera::{BatchTransaction, TransferTransaction, PrivateKey, Client, Hbar, AccountId};
+/// use hiero_sdk::{BatchTransaction, TransferTransaction, PrivateKey, Client, Hbar, AccountId};
 ///
-/// # async fn example() -> hedera::Result<()> {
+/// # async fn example() -> hiero_sdk::Result<()> {
 /// let client = Client::for_testnet();
 /// let batch_key = PrivateKey::generate_ed25519();
 /// let operator_key = PrivateKey::generate_ed25519();
@@ -560,7 +560,7 @@ mod tests {
 
         // Should return AtomicBatch variant
         match protobuf_data {
-            hedera_proto::services::transaction_body::Data::AtomicBatch(atomic_batch) => {
+            hiero_sdk_proto::services::transaction_body::Data::AtomicBatch(atomic_batch) => {
                 assert_eq!(atomic_batch.transactions.len(), 1);
                 assert!(!atomic_batch.transactions[0].is_empty());
             }
@@ -585,7 +585,7 @@ mod tests {
 
         // Extract AtomicBatchTransactionBody
         let atomic_batch = match protobuf_data {
-            hedera_proto::services::transaction_body::Data::AtomicBatch(atomic_batch) => {
+            hiero_sdk_proto::services::transaction_body::Data::AtomicBatch(atomic_batch) => {
                 atomic_batch
             }
             _ => panic!("Expected AtomicBatch variant"),
@@ -613,7 +613,7 @@ mod tests {
         let protobuf_data = empty_batch.data().to_transaction_data_protobuf(&chunk_info);
 
         match protobuf_data {
-            hedera_proto::services::transaction_body::Data::AtomicBatch(atomic_batch) => {
+            hiero_sdk_proto::services::transaction_body::Data::AtomicBatch(atomic_batch) => {
                 assert!(atomic_batch.transactions.is_empty());
             }
             _ => panic!("Expected AtomicBatch variant"),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -232,7 +232,7 @@ impl Client {
     /// ```
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use hedera::Client;
+    /// use hiero_sdk::Client;
     ///
     /// let client = Client::for_testnet();
     ///

--- a/src/contract/contract_bytecode_query.rs
+++ b/src/contract/contract_bytecode_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/contract/contract_call_query.rs
+++ b/src/contract/contract_call_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -162,7 +162,7 @@ impl ValidateChecksums for ContractCallQueryData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::query::ToQueryProtobuf;
     use crate::{

--- a/src/contract/contract_create_transaction.rs
+++ b/src/contract/contract_create_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use time::Duration;
 use tonic::transport::Channel;
 
@@ -380,7 +380,7 @@ impl ToProtobuf for ContractCreateTransactionData {
 mod tests {
 
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use time::Duration;
 
     use crate::contract::ContractCreateTransactionData;

--- a/src/contract/contract_delete_transaction.rs
+++ b/src/contract/contract_delete_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -174,7 +174,7 @@ impl ToProtobuf for ContractDeleteTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::contract::ContractDeleteTransactionData;
     use crate::protobuf::{

--- a/src/contract/contract_execute_transaction.rs
+++ b/src/contract/contract_execute_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -193,7 +193,7 @@ impl ToProtobuf for ContractExecuteTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::contract::ContractExecuteTransactionData;
     use crate::protobuf::{

--- a/src/contract/contract_function_result.rs
+++ b/src/contract/contract_function_result.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::str;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use num_bigint::{
     BigInt,
     BigUint,
@@ -298,7 +298,7 @@ impl ToProtobuf for ContractFunctionResult {
 
 #[cfg(test)]
 mod tests {
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use hex_literal::hex;
     use num_bigint::{
         BigInt,

--- a/src/contract/contract_function_result.rs
+++ b/src/contract/contract_function_result.rs
@@ -298,8 +298,8 @@ impl ToProtobuf for ContractFunctionResult {
 
 #[cfg(test)]
 mod tests {
-    use hiero_sdk_proto::services;
     use hex_literal::hex;
+    use hiero_sdk_proto::services;
     use num_bigint::{
         BigInt,
         BigUint,

--- a/src/contract/contract_id.rs
+++ b/src/contract/contract_id.rs
@@ -8,7 +8,7 @@ use std::fmt::{
 };
 use std::str::FromStr;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::entity_id::{
     Checksum,

--- a/src/contract/contract_info.rs
+++ b/src/contract/contract_info.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use time::{
     Duration,
     OffsetDateTime,
@@ -157,7 +157,7 @@ impl ToProtobuf for ContractInfo {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use prost::Message;
 
     use crate::protobuf::{

--- a/src/contract/contract_info_query.rs
+++ b/src/contract/contract_info_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/contract/contract_log_info.rs
+++ b/src/contract/contract_log_info.rs
@@ -1,4 +1,4 @@
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::{
     FromProtobuf,
@@ -70,7 +70,7 @@ impl ToProtobuf for ContractLogInfo {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use prost::Message;
 
     use crate::protobuf::{

--- a/src/contract/contract_nonce_info.rs
+++ b/src/contract/contract_nonce_info.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::{
     FromProtobuf,
@@ -61,7 +61,7 @@ impl ToProtobuf for ContractNonceInfo {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/contract/contract_update_transaction.rs
+++ b/src/contract/contract_update_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use time::{
     Duration,
     OffsetDateTime,
@@ -315,7 +315,7 @@ impl From<ContractUpdateTransactionData> for AnyTransactionData {
 mod tests {
 
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use time::{
         Duration,
         OffsetDateTime,

--- a/src/contract/delegate_contract_id.rs
+++ b/src/contract/delegate_contract_id.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::entity_id::{
     Checksum,

--- a/src/custom_fee_limit.rs
+++ b/src/custom_fee_limit.rs
@@ -1,4 +1,4 @@
-use hedera_proto::services::{
+use hiero_sdk_proto::services::{
     self,
 };
 

--- a/src/custom_fixed_fee.rs
+++ b/src/custom_fixed_fee.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::{
     AccountId,

--- a/src/ethereum/ethereum_transaction.rs
+++ b/src/ethereum/ethereum_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/exchange_rates.rs
+++ b/src/exchange_rates.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use time::OffsetDateTime;
 
 use crate::protobuf::FromProtobuf;

--- a/src/fee_schedules.rs
+++ b/src/fee_schedules.rs
@@ -1,4 +1,4 @@
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use time::OffsetDateTime;
 
 use crate::protobuf::{

--- a/src/file/file_append_transaction.rs
+++ b/src/file/file_append_transaction.rs
@@ -3,8 +3,8 @@
 use std::cmp;
 use std::num::NonZeroUsize;
 
-use hedera_proto::services;
-use hedera_proto::services::file_service_client::FileServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::file_service_client::FileServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/file/file_contents_query.rs
+++ b/src/file/file_contents_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::file_service_client::FileServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::file_service_client::FileServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/file/file_contents_response.rs
+++ b/src/file/file_contents_response.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::{
     FileId,

--- a/src/file/file_create_transaction.rs
+++ b/src/file/file_create_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::file_service_client::FileServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::file_service_client::FileServiceClient;
 use time::{
     Duration,
     OffsetDateTime,
@@ -242,7 +242,7 @@ impl ToProtobuf for FileCreateTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use hex_literal::hex;
     use time::OffsetDateTime;
 

--- a/src/file/file_create_transaction.rs
+++ b/src/file/file_create_transaction.rs
@@ -242,8 +242,8 @@ impl ToProtobuf for FileCreateTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hiero_sdk_proto::services;
     use hex_literal::hex;
+    use hiero_sdk_proto::services;
     use time::OffsetDateTime;
 
     use crate::file::FileCreateTransactionData;

--- a/src/file/file_delete_transaction.rs
+++ b/src/file/file_delete_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::file_service_client::FileServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::file_service_client::FileServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -113,7 +113,7 @@ impl ToProtobuf for FileDeleteTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::file::FileDeleteTransactionData;
     use crate::protobuf::{

--- a/src/file/file_id.rs
+++ b/src/file/file_id.rs
@@ -8,7 +8,7 @@ use std::fmt::{
 };
 use std::str::FromStr;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::entity_id::{
     Checksum,

--- a/src/file/file_info.rs
+++ b/src/file/file_info.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use time::{
     Duration,
     OffsetDateTime,
@@ -124,7 +124,7 @@ impl ToProtobuf for FileInfo {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use prost::Message;
 
     use crate::protobuf::{

--- a/src/file/file_info_query.rs
+++ b/src/file/file_info_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::file_service_client::FileServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::file_service_client::FileServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/file/file_update_transaction.rs
+++ b/src/file/file_update_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::file_service_client::FileServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::file_service_client::FileServiceClient;
 use time::{
     Duration,
     OffsetDateTime,
@@ -241,7 +241,7 @@ impl ToProtobuf for FileUpdateTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use time::OffsetDateTime;
 
     use crate::file::FileUpdateTransactionData;

--- a/src/hbar.rs
+++ b/src/hbar.rs
@@ -51,7 +51,7 @@ impl HbarUnit {
     ///
     /// # Examples
     /// ```
-    /// use hedera::HbarUnit;
+    /// use hiero_sdk::HbarUnit;
     /// assert_eq!(HbarUnit::Microbar.tinybars(), 100);
     /// ```
     #[must_use]
@@ -63,7 +63,7 @@ impl HbarUnit {
     ///
     /// # Examples
     /// ```
-    /// use hedera::HbarUnit;
+    /// use hiero_sdk::HbarUnit;
     /// assert_eq!(HbarUnit::Millibar.symbol(), "mℏ");
     /// ```
     #[must_use]
@@ -123,7 +123,7 @@ impl Hbar {
     ///
     /// # Examples
     /// ```
-    /// # use hedera::Hbar;
+    /// # use hiero_sdk::Hbar;
     /// let hbar = Hbar::new(52);
     /// assert_eq!(hbar.to_string(), "52 ℏ");
     #[must_use]
@@ -135,7 +135,7 @@ impl Hbar {
     ///
     /// # Examples
     /// ```
-    /// # use hedera::Hbar;
+    /// # use hiero_sdk::Hbar;
     /// let hbar = Hbar::from_tinybars(250);
     /// assert_eq!(hbar.to_string(), "250 tℏ");
     /// ```
@@ -162,8 +162,8 @@ impl Hbar {
     /// # Examples
     ///
     /// ```
-    /// use hedera::Hbar;
-    /// use hedera::HbarUnit;
+    /// use hiero_sdk::Hbar;
+    /// use hiero_sdk::HbarUnit;
     /// let value = Hbar::from_unit(20, HbarUnit::Millibar);
     /// assert_eq!(value.to_string(), "0.02 ℏ");
     /// ```
@@ -196,7 +196,7 @@ impl Hbar {
     /// # Examples
     /// ```
     /// use rust_decimal::Decimal;
-    /// use hedera::Hbar;
+    /// use hiero_sdk::Hbar;
     /// # use std::str::FromStr;
     /// let value: Hbar = "20 mℏ".parse().unwrap();
     ///

--- a/src/key/key.rs
+++ b/src/key/key.rs
@@ -112,8 +112,8 @@ impl FromProtobuf<services::Key> for Key {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use hiero_sdk_proto::services;
     use hex_literal::hex;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::FromProtobuf;
     use crate::{

--- a/src/key/key.rs
+++ b/src/key/key.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::contract::DelegateContractId;
 use crate::{
@@ -112,7 +112,7 @@ impl FromProtobuf<services::Key> for Key {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use hex_literal::hex;
 
     use crate::protobuf::FromProtobuf;

--- a/src/key/key_list.rs
+++ b/src/key/key_list.rs
@@ -1,4 +1,4 @@
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::{
     FromProtobuf,
@@ -117,7 +117,7 @@ impl FromProtobuf<services::ThresholdKey> for KeyList {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/key/private_key/mod.rs
+++ b/src/key/private_key/mod.rs
@@ -335,7 +335,7 @@ impl PrivateKey {
     ///
     /// ```
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use hedera::PrivateKey;
+    /// use hiero_sdk::PrivateKey;
     /// use hex_literal::hex;
     ///
     /// // ⚠️ WARNING ⚠️
@@ -511,7 +511,7 @@ impl PrivateKey {
     /// # Examples
     ///
     /// ```
-    /// use hedera::PrivateKey;
+    /// use hiero_sdk::PrivateKey;
     ///
     /// let key: PrivateKey = "3030020100300706052b8104000a042204208776c6b831a1b61ac10dac0304a2843de4716f54b1919bb91a2685d0fe3f3048".parse().unwrap();
     ///
@@ -538,13 +538,13 @@ impl PrivateKey {
     ///
     /// # Examples
     /// ```
-    /// use hedera::PrivateKey;
+    /// use hiero_sdk::PrivateKey;
     /// let sk = PrivateKey::generate_ed25519();
     ///
     /// assert!(sk.is_ed25519());
     /// ```
     /// ```
-    /// use hedera::PrivateKey;
+    /// use hiero_sdk::PrivateKey;
     /// let sk = PrivateKey::generate_ecdsa();
     ///
     /// assert!(!sk.is_ed25519());
@@ -558,13 +558,13 @@ impl PrivateKey {
     ///
     /// # Examples
     /// ```
-    /// use hedera::PrivateKey;
+    /// use hiero_sdk::PrivateKey;
     /// let sk = PrivateKey::generate_ecdsa();
     ///
     /// assert!(sk.is_ecdsa());
     /// ```
     /// ```
-    /// use hedera::PrivateKey;
+    /// use hiero_sdk::PrivateKey;
     /// let sk = PrivateKey::generate_ed25519();
     ///
     /// assert!(!sk.is_ecdsa());

--- a/src/key/public_key/mod.rs
+++ b/src/key/public_key/mod.rs
@@ -13,7 +13,7 @@ use std::hash::{
 use std::str::FromStr;
 
 use ed25519_dalek::Verifier as _;
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use hmac::digest::generic_array::sequence::Split;
 use hmac::digest::generic_array::GenericArray;
 use k256::ecdsa;
@@ -294,7 +294,7 @@ impl PublicKey {
     /// # Examples
     ///
     /// ```
-    /// use hedera::PublicKey;
+    /// use hiero_sdk::PublicKey;
     ///
     /// let key: PublicKey = "302d300706052b8104000a03220002703a9370b0443be6ae7c507b0aec81a55e94e4a863b9655360bd65358caa6588".parse().unwrap();
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ pub use hbar::{
     HbarUnit,
     Tinybar,
 };
-pub use hedera_proto::services::ResponseCodeEnum as Status;
+pub use hiero_sdk_proto::services::ResponseCodeEnum as Status;
 pub use key::{
     Key,
     KeyList,

--- a/src/network_version_info.rs
+++ b/src/network_version_info.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::{
     FromProtobuf,

--- a/src/network_version_info_query.rs
+++ b/src/network_version_info_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::network_service_client::NetworkServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::network_service_client::NetworkServiceClient;
 use tonic::transport::Channel;
 
 use crate::entity_id::ValidateChecksums;

--- a/src/node_address.rs
+++ b/src/node_address.rs
@@ -2,7 +2,7 @@
 
 use std::net::SocketAddrV4;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::ToProtobuf;
 use crate::{

--- a/src/node_address_book.rs
+++ b/src/node_address_book.rs
@@ -1,4 +1,4 @@
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::{
     FromProtobuf,

--- a/src/node_address_book_query.rs
+++ b/src/node_address_book_query.rs
@@ -9,7 +9,7 @@ use futures_util::{
     TryFutureExt,
     TryStreamExt,
 };
-use hedera_proto::{
+use hiero_sdk_proto::{
     mirror,
     services,
 };

--- a/src/pending_airdrop_id.rs
+++ b/src/pending_airdrop_id.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::ledger_id::RefLedgerId;
 use crate::{

--- a/src/pending_airdrop_record.rs
+++ b/src/pending_airdrop_record.rs
@@ -2,7 +2,7 @@
 
 use core::fmt;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::pending_airdrop_id::PendingAirdropId;
 use crate::protobuf::{
@@ -76,7 +76,7 @@ impl ToProtobuf for PendingAirdropRecord {
             pending_airdrop_id: Some(self.pending_airdrop_id.to_protobuf()),
             pending_airdrop_value: self
                 .pending_airdrop_value
-                .map(|v| hedera_proto::services::PendingAirdropValue { amount: v }),
+                .map(|v| hiero_sdk_proto::services::PendingAirdropValue { amount: v }),
         }
     }
 }

--- a/src/ping_query.rs
+++ b/src/ping_query.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
 
 use crate::entity_id::ValidateChecksums;
 use crate::execute::{
@@ -122,7 +122,7 @@ impl Execute for PingQuery {
 
     fn make_error_pre_check(
         &self,
-        status: hedera_proto::services::ResponseCodeEnum,
+        status: hiero_sdk_proto::services::ResponseCodeEnum,
         _transaction_id: Option<&crate::TransactionId>,
         _response: Self::GrpcResponse,
     ) -> crate::Error {

--- a/src/prng_transaction.rs
+++ b/src/prng_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::util_service_client::UtilServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::util_service_client::UtilServiceClient;
 
 use crate::entity_id::ValidateChecksums;
 use crate::protobuf::{

--- a/src/protobuf/convert.rs
+++ b/src/protobuf/convert.rs
@@ -2,7 +2,7 @@
 
 use crate::Error;
 
-/// Convert to a `hedera_protobufs` type.
+/// Convert to a `hiero_sdk_protobufs` type.
 pub trait ToProtobuf: Send + Sync {
     /// The protobuf output.
     type Protobuf;
@@ -45,7 +45,7 @@ impl<T: ToProtobuf> ToProtobuf for Vec<T> {
     }
 }
 
-/// Convert from a `hedera_protobufs` type.
+/// Convert from a `hiero_sdk_protobufs` type.
 pub trait FromProtobuf<Protobuf>
 where
     Self: Sized,

--- a/src/protobuf/time.rs
+++ b/src/protobuf/time.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use time::{
     Duration,
     OffsetDateTime,

--- a/src/query/any.rs
+++ b/src/query/any.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use tonic::transport::Channel;
 
 use super::ToQueryProtobuf;

--- a/src/query/cost.rs
+++ b/src/query/cost.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use tonic::transport::Channel;
 
 use crate::entity_id::ValidateChecksums;

--- a/src/query/execute.rs
+++ b/src/query/execute.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Debug;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use tonic::transport::Channel;
 
 use crate::entity_id::ValidateChecksums;

--- a/src/query/payment_transaction.rs
+++ b/src/query/payment_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
 use crate::transaction::{

--- a/src/query/protobuf.rs
+++ b/src/query/protobuf.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 pub trait ToQueryProtobuf: Send + Sync {
     fn to_query_protobuf(&self, header: services::QueryHeader) -> services::Query;

--- a/src/schedule/schedulable_transaction_body.rs
+++ b/src/schedule/schedulable_transaction_body.rs
@@ -1,4 +1,4 @@
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::FromProtobuf;
 use crate::transaction::{

--- a/src/schedule/schedule_create_transaction.rs
+++ b/src/schedule/schedule_create_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::schedule_service_client::ScheduleServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::schedule_service_client::ScheduleServiceClient;
 use time::OffsetDateTime;
 use tonic::transport::Channel;
 
@@ -226,7 +226,7 @@ impl FromProtobuf<services::ScheduleCreateTransactionBody> for ScheduleCreateTra
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use time::OffsetDateTime;
 
     use super::ScheduleCreateTransactionData;

--- a/src/schedule/schedule_delete_transaction.rs
+++ b/src/schedule/schedule_delete_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::schedule_service_client::ScheduleServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::schedule_service_client::ScheduleServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -108,7 +108,7 @@ impl ToProtobuf for ScheduleDeleteTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use super::ScheduleDeleteTransactionData;
     use crate::protobuf::{

--- a/src/schedule/schedule_id.rs
+++ b/src/schedule/schedule_id.rs
@@ -8,7 +8,7 @@ use std::fmt::{
 };
 use std::str::FromStr;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::entity_id::{
     Checksum,

--- a/src/schedule/schedule_info.rs
+++ b/src/schedule/schedule_info.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use time::OffsetDateTime;
 
 use super::schedulable_transaction_body::SchedulableTransactionBody;

--- a/src/schedule/schedule_info_query.rs
+++ b/src/schedule/schedule_info_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::schedule_service_client::ScheduleServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::schedule_service_client::ScheduleServiceClient;
 use tonic::transport::Channel;
 
 use crate::query::{

--- a/src/schedule/schedule_sign_transaction.rs
+++ b/src/schedule/schedule_sign_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::schedule_service_client::ScheduleServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::schedule_service_client::ScheduleServiceClient;
 use tonic::transport::Channel;
 
 use crate::protobuf::{
@@ -93,7 +93,7 @@ impl FromProtobuf<services::ScheduleSignTransactionBody> for ScheduleSignTransac
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/semantic_version/mod.rs
+++ b/src/semantic_version/mod.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::{
     FromProtobuf,

--- a/src/service_endpoint.rs
+++ b/src/service_endpoint.rs
@@ -5,7 +5,7 @@ use std::net::{
     SocketAddrV4,
 };
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::ToProtobuf;
 use crate::{

--- a/src/staked_id.rs
+++ b/src/staked_id.rs
@@ -50,7 +50,7 @@ impl From<u64> for StakedId {
 }
 
 mod proto {
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use super::StakedId;
     use crate::FromProtobuf;

--- a/src/staking_info.rs
+++ b/src/staking_info.rs
@@ -1,4 +1,4 @@
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use time::OffsetDateTime;
 
 use crate::protobuf::ToProtobuf;

--- a/src/system/freeze_transaction.rs
+++ b/src/system/freeze_transaction.rs
@@ -160,8 +160,8 @@ impl ToProtobuf for FreezeTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hiero_sdk_proto::services;
     use hex_literal::hex;
+    use hiero_sdk_proto::services;
     use time::OffsetDateTime;
 
     use crate::protobuf::{

--- a/src/system/freeze_transaction.rs
+++ b/src/system/freeze_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::freeze_service_client::FreezeServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::freeze_service_client::FreezeServiceClient;
 use time::OffsetDateTime;
 use tonic::transport::Channel;
 
@@ -160,7 +160,7 @@ impl ToProtobuf for FreezeTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use hex_literal::hex;
     use time::OffsetDateTime;
 

--- a/src/system/system_delete_transaction.rs
+++ b/src/system/system_delete_transaction.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::file_service_client::FileServiceClient;
-use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::file_service_client::FileServiceClient;
+use hiero_sdk_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use time::OffsetDateTime;
 use tonic::transport::Channel;
 
@@ -183,7 +183,7 @@ impl ToProtobuf for SystemDeleteTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/system/system_undelete_transaction.rs
+++ b/src/system/system_undelete_transaction.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::file_service_client::FileServiceClient;
-use hedera_proto::services::smart_contract_service_client::SmartContractServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::file_service_client::FileServiceClient;
+use hiero_sdk_proto::services::smart_contract_service_client::SmartContractServiceClient;
 use tonic::transport::Channel;
 
 use crate::protobuf::{
@@ -155,7 +155,7 @@ impl ToProtobuf for SystemUndeleteTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/assessed_custom_fee.rs
+++ b/src/token/assessed_custom_fee.rs
@@ -1,4 +1,4 @@
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::{
     FromProtobuf,
@@ -72,7 +72,7 @@ impl ToProtobuf for AssessedCustomFee {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/custom_fees/mod.rs
+++ b/src/token/custom_fees/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fraction::Fraction;
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::{
     AccountId,

--- a/src/token/custom_fees/tests.rs
+++ b/src/token/custom_fees/tests.rs
@@ -1,5 +1,5 @@
 use fraction::Fraction;
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::token::custom_fees::{
     AnyCustomFee,

--- a/src/token/nft_id.rs
+++ b/src/token/nft_id.rs
@@ -8,7 +8,7 @@ use std::fmt::{
 };
 use std::str::FromStr;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::entity_id::ValidateChecksums;
 use crate::ledger_id::RefLedgerId;
@@ -116,7 +116,7 @@ impl ValidateChecksums for NftId {
 mod tests {
     use std::str::FromStr;
 
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::ledger_id::RefLedgerId;
     use crate::token::nft_id::NftId;

--- a/src/token/token_airdrop_transaction.rs
+++ b/src/token/token_airdrop_transaction.rs
@@ -2,8 +2,8 @@
 
 use std::collections::HashMap;
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use super::{
@@ -406,7 +406,7 @@ mod tests {
     use std::str::FromStr;
 
     use expect_test::expect_file;
-    use hedera_proto::services::{
+    use hiero_sdk_proto::services::{
         self,
         AccountAmount,
         NftTransfer,

--- a/src/token/token_associate_transaction.rs
+++ b/src/token/token_associate_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -144,7 +144,7 @@ impl ToProtobuf for TokenAssociateTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect_file;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/token_association.rs
+++ b/src/token/token_association.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::ToProtobuf;
 use crate::{

--- a/src/token/token_burn_transaction.rs
+++ b/src/token/token_burn_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::protobuf::{
@@ -167,7 +167,7 @@ impl ToProtobuf for TokenBurnTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect_file;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use super::TokenBurnTransactionData;
     use crate::protobuf::{

--- a/src/token/token_cancel_airdrop_transaction.rs
+++ b/src/token/token_cancel_airdrop_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -136,7 +136,7 @@ impl FromProtobuf<services::TokenCancelAirdropTransactionBody>
 #[cfg(test)]
 mod tests {
     use expect_test::expect_file;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::pending_airdrop_id::PendingAirdropId;
     use crate::protobuf::{

--- a/src/token/token_claim_airdrop_transaction.rs
+++ b/src/token/token_claim_airdrop_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -150,7 +150,7 @@ impl FromProtobuf<services::TokenClaimAirdropTransactionBody> for TokenClaimAird
 #[cfg(test)]
 mod tests {
     use expect_test::expect_file;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::pending_airdrop_id::PendingAirdropId;
     use crate::protobuf::{

--- a/src/token/token_create_transaction.rs
+++ b/src/token/token_create_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use time::{
     Duration,
     OffsetDateTime,
@@ -610,7 +610,7 @@ mod tests {
     use std::str::FromStr;
 
     use expect_test::expect_file;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use time::OffsetDateTime;
 
     use crate::protobuf::{

--- a/src/token/token_delete_transaction.rs
+++ b/src/token/token_delete_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -117,7 +117,7 @@ impl ToProtobuf for TokenDeleteTransactionData {
 mod tests {
 
     use expect_test::expect_file;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/token_dissociate_transaction.rs
+++ b/src/token/token_dissociate_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -150,7 +150,7 @@ impl ToProtobuf for TokenDissociateTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/token_fee_schedule_update_transaction.rs
+++ b/src/token/token_fee_schedule_update_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::protobuf::{
@@ -145,7 +145,7 @@ impl ToProtobuf for TokenFeeScheduleUpdateTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/token_freeze_transaction.rs
+++ b/src/token/token_freeze_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -142,7 +142,7 @@ impl ToProtobuf for TokenFreezeTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/token_grant_kyc_transaction.rs
+++ b/src/token/token_grant_kyc_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -143,7 +143,7 @@ impl ToProtobuf for TokenGrantKycTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/token_id.rs
+++ b/src/token/token_id.rs
@@ -8,7 +8,7 @@ use std::fmt::{
 };
 use std::str::FromStr;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::entity_id::{
     Checksum,

--- a/src/token/token_info.rs
+++ b/src/token/token_info.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::{
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::{
     TokenFreezeStatus,
     TokenKycStatus,
     TokenPauseStatus,

--- a/src/token/token_info_query.rs
+++ b/src/token/token_info_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/token/token_key_validation_type.rs
+++ b/src/token/token_key_validation_type.rs
@@ -7,7 +7,7 @@ use std::fmt::{
     Formatter,
 };
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::{
     FromProtobuf,

--- a/src/token/token_mint_transaction.rs
+++ b/src/token/token_mint_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -168,7 +168,7 @@ impl ToProtobuf for TokenMintTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services::TokenMintTransactionBody;
+    use hiero_sdk_proto::services::TokenMintTransactionBody;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/token_nft_info.rs
+++ b/src/token/token_nft_info.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use prost::Message;
 use time::OffsetDateTime;
 

--- a/src/token/token_nft_info_query.rs
+++ b/src/token/token_nft_info_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/token/token_nft_transfer.rs
+++ b/src/token/token_nft_transfer.rs
@@ -1,4 +1,4 @@
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::FromProtobuf;
 use crate::{

--- a/src/token/token_pause_transaction.rs
+++ b/src/token/token_pause_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -116,7 +116,7 @@ impl ToProtobuf for TokenPauseTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services::TokenPauseTransactionBody;
+    use hiero_sdk_proto::services::TokenPauseTransactionBody;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/token_reject_transaction.rs
+++ b/src/token/token_reject_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use super::NftId;
@@ -198,7 +198,7 @@ impl ToProtobuf for TokenRejectTransactionData {
 mod tests {
 
     use expect_test::expect_file;
-    use hedera_proto::services::{
+    use hiero_sdk_proto::services::{
         token_reference,
         TokenReference,
         TokenRejectTransactionBody,

--- a/src/token/token_revoke_kyc_transaction.rs
+++ b/src/token/token_revoke_kyc_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -143,7 +143,7 @@ impl ToProtobuf for TokenRevokeKycTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use super::TokenRevokeKycTransactionData;
     use crate::protobuf::{

--- a/src/token/token_supply_type.rs
+++ b/src/token/token_supply_type.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::{
     FromProtobuf,
@@ -42,7 +42,7 @@ impl ToProtobuf for TokenSupplyType {
 
 #[cfg(test)]
 mod tests {
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::token::token_supply_type::TokenSupplyType;
     use crate::{

--- a/src/token/token_type.rs
+++ b/src/token/token_type.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::{
     FromProtobuf,
@@ -51,7 +51,7 @@ impl ToProtobuf for TokenType {
 
 #[cfg(test)]
 mod tests {
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::token::token_type::TokenType;
     use crate::{

--- a/src/token/token_unfreeze_transaction.rs
+++ b/src/token/token_unfreeze_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -141,7 +141,7 @@ impl ToProtobuf for TokenUnfreezeTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/token_unpause_transaction.rs
+++ b/src/token/token_unpause_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -115,7 +115,7 @@ impl ToProtobuf for TokenUnpauseTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/token/token_update_nfts_transaction.rs
+++ b/src/token/token_update_nfts_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -153,7 +153,7 @@ impl ToProtobuf for TokenUpdateNftsTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect_file;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use super::TokenUpdateNftsTransactionData;
     use crate::protobuf::{

--- a/src/token/token_update_transaction.rs
+++ b/src/token/token_update_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use time::{
     Duration,
     OffsetDateTime,
@@ -475,7 +475,7 @@ mod tests {
     use std::str::FromStr;
 
     use expect_test::expect_file;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use time::{
         Duration,
         OffsetDateTime,

--- a/src/token/token_wipe_transaction.rs
+++ b/src/token/token_wipe_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::token_service_client::TokenServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::token_service_client::TokenServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
@@ -193,7 +193,7 @@ impl ToProtobuf for TokenWipeTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
 
     use crate::protobuf::{
         FromProtobuf,

--- a/src/topic/topic_create_transaction.rs
+++ b/src/topic/topic_create_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::consensus_service_client::ConsensusServiceClient;
 use time::Duration;
 use tonic::transport::Channel;
 
@@ -318,7 +318,7 @@ impl ToProtobuf for TopicCreateTransactionData {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use time::Duration;
 
     use super::TopicCreateTransactionData;

--- a/src/topic/topic_delete_transaction.rs
+++ b/src/topic/topic_delete_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::consensus_service_client::ConsensusServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/topic/topic_id.rs
+++ b/src/topic/topic_id.rs
@@ -8,7 +8,7 @@ use std::fmt::{
 };
 use std::str::FromStr;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::entity_id::{
     Checksum,

--- a/src/topic/topic_info.rs
+++ b/src/topic/topic_info.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use time::{
     Duration,
     OffsetDateTime,
@@ -159,7 +159,7 @@ impl ToProtobuf for TopicInfo {
 #[cfg(test)]
 mod tests {
     use expect_test::expect;
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use prost::Message;
 
     use crate::protobuf::{

--- a/src/topic/topic_info_query.rs
+++ b/src/topic/topic_info_query.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::consensus_service_client::ConsensusServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/topic/topic_message_query.rs
+++ b/src/topic/topic_message_query.rs
@@ -10,9 +10,9 @@ use futures_core::future::BoxFuture;
 use futures_core::stream::BoxStream;
 use futures_core::Stream;
 use futures_util::TryStreamExt;
-use hedera_proto::mirror;
-use hedera_proto::mirror::consensus_service_client::ConsensusServiceClient;
-use hedera_proto::mirror::ConsensusTopicQuery;
+use hiero_sdk_proto::mirror;
+use hiero_sdk_proto::mirror::consensus_service_client::ConsensusServiceClient;
+use hiero_sdk_proto::mirror::ConsensusTopicQuery;
 use time::{
     Duration,
     OffsetDateTime,

--- a/src/topic/topic_message_submit_transaction.rs
+++ b/src/topic/topic_message_submit_transaction.rs
@@ -3,8 +3,8 @@
 use std::cmp;
 use std::num::NonZeroUsize;
 
-use hedera_proto::services;
-use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::consensus_service_client::ConsensusServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/topic/topic_update_transaction.rs
+++ b/src/topic/topic_update_transaction.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::consensus_service_client::ConsensusServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::consensus_service_client::ConsensusServiceClient;
 use time::{
     Duration,
     OffsetDateTime,

--- a/src/transaction/any.rs
+++ b/src/transaction/any.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use tonic::transport::Channel;
 
 use super::chunked::ChunkInfo;

--- a/src/transaction/chunked.rs
+++ b/src/transaction/chunked.rs
@@ -1,7 +1,7 @@
 use std::cmp;
 use std::num::NonZeroUsize;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use tonic::transport::Channel;
 
 use super::{

--- a/src/transaction/cost.rs
+++ b/src/transaction/cost.rs
@@ -1,4 +1,4 @@
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use tonic::transport::Channel;
 
 use super::{

--- a/src/transaction/execute.rs
+++ b/src/transaction/execute.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use prost::Message;
 use tonic::transport::Channel;
 

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -9,7 +9,7 @@ use std::fmt::{
 };
 use std::num::NonZeroUsize;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use prost::Message;
 use time::Duration;
 use triomphe::Arc;
@@ -591,7 +591,7 @@ impl<D: TransactionExecute> Transaction<D> {
         let transaction_list = self
             .signed_sources()
             .map_or_else(|| self.make_transaction_list(), |it| Ok(it.transactions().to_vec()))?;
-        Ok(hedera_proto::sdk::TransactionList { transaction_list }.encode_to_vec())
+        Ok(hiero_sdk_proto::sdk::TransactionList { transaction_list }.encode_to_vec())
     }
 
     pub(crate) fn add_signature_signer(&mut self, signer: &AnySigner) -> Vec<u8> {
@@ -1068,8 +1068,8 @@ where
 impl AnyTransaction {
     /// # Examples
     /// ```
-    /// # fn main() -> hedera::Result<()> {
-    /// use hedera::AnyTransaction;
+    /// # fn main() -> hiero_sdk::Result<()> {
+    /// use hiero_sdk::AnyTransaction;
     /// let bytes = hex::decode(concat!(
     ///     "0a522a500a4c0a120a0c0885c8879e0610a8bdd9840312021865120218061880",
     ///     "94ebdc0322020877320c686920686173686772617068721a0a180a0a0a021802",
@@ -1087,8 +1087,8 @@ impl AnyTransaction {
     /// - [`Error::FromProtobuf`] if a valid transaction cannot be parsed from the bytes.
     #[allow(deprecated)]
     pub fn from_bytes(bytes: &[u8]) -> crate::Result<Self> {
-        let list: hedera_proto::sdk::TransactionList =
-            hedera_proto::sdk::TransactionList::decode(bytes).map_err(Error::from_protobuf)?;
+        let list: hiero_sdk_proto::sdk::TransactionList =
+            hiero_sdk_proto::sdk::TransactionList::decode(bytes).map_err(Error::from_protobuf)?;
 
         let list = if list.transaction_list.is_empty() {
             Vec::from([services::Transaction::decode(bytes).map_err(Error::from_protobuf)?])
@@ -1325,7 +1325,7 @@ where
 
 #[cfg(test)]
 pub(crate) mod test_helpers {
-    use hedera_proto::services;
+    use hiero_sdk_proto::services;
     use prost::Message;
     use time::{
         Duration,

--- a/src/transaction/protobuf.rs
+++ b/src/transaction/protobuf.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use super::chunked::ChunkInfo;
 

--- a/src/transaction/source.rs
+++ b/src/transaction/source.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::ops::Range;
 
-use hedera_proto::services::{
+use hiero_sdk_proto::services::{
     self,
     SignedTransaction,
 };

--- a/src/transaction_id.rs
+++ b/src/transaction_id.rs
@@ -8,7 +8,7 @@ use std::fmt::{
 };
 use std::str::FromStr;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use rand::{
     thread_rng,
     Rng,

--- a/src/transaction_receipt.rs
+++ b/src/transaction_receipt.rs
@@ -2,7 +2,7 @@
 
 use std::ops::Not;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 #[cfg(test)]
 pub(super) use tests::make_receipt;
 

--- a/src/transaction_receipt_query.rs
+++ b/src/transaction_receipt_query.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
-use hedera_proto::services::response::Response;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services::response::Response;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/transaction_record.rs
+++ b/src/transaction_record.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 use time::OffsetDateTime;
 
 use crate::protobuf::ToProtobuf;

--- a/src/transaction_record_query.rs
+++ b/src/transaction_record_query.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
-use hedera_proto::services::response::Response;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services::response::Response;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1,4 +1,4 @@
-use hedera_proto::services;
+use hiero_sdk_proto::services;
 
 use crate::protobuf::{
     FromProtobuf,

--- a/src/transfer_transaction.rs
+++ b/src/transfer_transaction.rs
@@ -3,8 +3,8 @@
 use std::collections::HashMap;
 use std::ops::Not;
 
-use hedera_proto::services;
-use hedera_proto::services::crypto_service_client::CryptoServiceClient;
+use hiero_sdk_proto::services;
+use hiero_sdk_proto::services::crypto_service_client::CryptoServiceClient;
 use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;

--- a/tck/Cargo.toml
+++ b/tck/Cargo.toml
@@ -15,8 +15,8 @@ tracing = "0.1.41"
 async-trait = "0.1.89"
 hyper = "1.6.0"
 tower-http = { version = "0.6.6", features = ["full"] }
-hedera = { path = "../." }
-hedera-proto = { path = "../protobufs", version = "0.20.0", features = ["time_0_3", "fraction"] }
+hiero-sdk = { path = "../." }
+hiero-sdk-proto = { path = "../protobufs", version = "0.20.0", features = ["time_0_3", "fraction"] }
 once_cell = "1.21.3"
 futures-util = "0.3.31"
 serde_json = {version = "1.0.145", features = ["raw_value"] }

--- a/tck/src/errors.rs
+++ b/tck/src/errors.rs
@@ -1,4 +1,4 @@
-use hedera::Error;
+use hiero_sdk::Error;
 use jsonrpsee::types::error::INTERNAL_ERROR_CODE;
 use jsonrpsee::types::{
     ErrorObject,

--- a/tck/src/helpers.rs
+++ b/tck/src/helpers.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use hedera::{
+use hiero_sdk::{
     AccountId,
     Hbar,
     Key,

--- a/tck/src/helpers.rs
+++ b/tck/src/helpers.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
+use hex::ToHex;
 use hiero_sdk::{
     AccountId,
     Hbar,
@@ -11,7 +12,6 @@ use hiero_sdk::{
     Transaction,
     TransactionId,
 };
-use hex::ToHex;
 use jsonrpsee::types::error::INVALID_PARAMS_CODE;
 use jsonrpsee::types::{
     ErrorObject,

--- a/tck/src/methods.rs
+++ b/tck/src/methods.rs
@@ -5,7 +5,7 @@ use std::sync::{
     Mutex,
 };
 
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction,
     AccountId,
     AccountUpdateTransaction,

--- a/tests/e2e/account/allowance_approve.rs
+++ b/tests/e2e/account/allowance_approve.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     AccountAllowanceApproveTransaction,
     Hbar,
     TokenAssociateTransaction,
@@ -156,8 +156,8 @@ async fn missing_nft_allowance_approval_fails() -> anyhow::Result<()> {
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: hedera::Status::SpenderDoesNotHaveAllowance,
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: hiero_sdk::Status::SpenderDoesNotHaveAllowance,
             ..
         })
     );

--- a/tests/e2e/account/allowance_delete.rs
+++ b/tests/e2e/account/allowance_delete.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     AccountAllowanceApproveTransaction,
     AccountAllowanceDeleteTransaction,
     Hbar,
@@ -84,8 +84,8 @@ async fn transfer_after_allowance_remove_fails() -> anyhow::Result<()> {
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: hedera::Status::SpenderDoesNotHaveAllowance,
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: hiero_sdk::Status::SpenderDoesNotHaveAllowance,
             ..
         })
     );

--- a/tests/e2e/account/balance.rs
+++ b/tests/e2e/account/balance.rs
@@ -5,7 +5,7 @@
 // - cannotConnectToPreviewnetWhenNetworkNameIsNullAndCertificateVerificationIsEnabled
 
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery,
     AccountId,
     Hbar,
@@ -139,7 +139,7 @@ async fn invalid_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryNoPaymentPreCheckStatus { status: Status::InvalidAccountId })
+        Err(hiero_sdk::Error::QueryNoPaymentPreCheckStatus { status: Status::InvalidAccountId })
     );
 
     Ok(())

--- a/tests/e2e/account/create.rs
+++ b/tests/e2e/account/create.rs
@@ -86,7 +86,10 @@ async fn missing_key_error() {
 
     assert_matches::assert_matches!(
         res,
-        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: hiero_sdk::Status::KeyRequired, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
+            status: hiero_sdk::Status::KeyRequired,
+            ..
+        })
     );
 }
 

--- a/tests/e2e/account/create.rs
+++ b/tests/e2e/account/create.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction,
     AccountInfoQuery,
     Hbar,
@@ -86,7 +86,7 @@ async fn missing_key_error() {
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: hedera::Status::KeyRequired, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: hiero_sdk::Status::KeyRequired, .. })
     );
 }
 
@@ -254,7 +254,7 @@ async fn alias_from_admin_key_with_receiver_sig_required_and_no_signature_errors
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: hedera::Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: hiero_sdk::Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -317,7 +317,7 @@ async fn alias_missing_signature_fails() -> anyhow::Result<()> {
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: hedera::Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: hiero_sdk::Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -384,7 +384,7 @@ async fn alias_with_receiver_sig_required_missing_signature_fails() -> anyhow::R
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: hedera::Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: hiero_sdk::Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -407,8 +407,8 @@ async fn cannot_create_account_with_invalid_negative_max_auto_token_assocation(
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: hedera::Status::InvalidMaxAutoAssociations,
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
+            status: hiero_sdk::Status::InvalidMaxAutoAssociations,
             ..
         })
     );

--- a/tests/e2e/account/delete.rs
+++ b/tests/e2e/account/delete.rs
@@ -63,7 +63,10 @@ async fn missing_account_id_fails() {
 
     assert_matches!(
         res,
-        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::AccountIdDoesNotExist, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
+            status: Status::AccountIdDoesNotExist,
+            ..
+        })
     );
 }
 

--- a/tests/e2e/account/delete.rs
+++ b/tests/e2e/account/delete.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction,
     AccountDeleteTransaction,
     AccountInfoQuery,
@@ -44,7 +44,7 @@ async fn create_then_delete() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryNoPaymentPreCheckStatus { status: Status::AccountDeleted })
+        Err(hiero_sdk::Error::QueryNoPaymentPreCheckStatus { status: Status::AccountDeleted })
     );
 
     Ok(())
@@ -63,7 +63,7 @@ async fn missing_account_id_fails() {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::AccountIdDoesNotExist, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::AccountIdDoesNotExist, .. })
     );
 }
 
@@ -100,7 +100,7 @@ async fn missing_deletee_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())

--- a/tests/e2e/account/info.rs
+++ b/tests/e2e/account/info.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     account_info_flow,
     AccountInfoQuery,
     Hbar,
@@ -108,7 +108,7 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 
     let (max_query_payment, query_cost) = assert_matches!(
         res,
-        Err(hedera::Error::MaxQueryPaymentExceeded {
+        Err(hiero_sdk::Error::MaxQueryPaymentExceeded {
             max_query_payment,
             query_cost
         }) => (max_query_payment, query_cost)
@@ -143,7 +143,7 @@ async fn get_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
+        Err(hiero_sdk::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     Ok(())
@@ -165,14 +165,14 @@ async fn flow_verify_transaction() -> anyhow::Result<()> {
 
     let new_public_key = new_key.public_key();
 
-    let mut signed_tx = hedera::AccountCreateTransaction::new();
+    let mut signed_tx = hiero_sdk::AccountCreateTransaction::new();
     signed_tx
         .set_key_without_alias(new_public_key)
         .initial_balance(Hbar::from_tinybars(1000))
         .freeze_with(&client)?
         .sign_with_operator(&client)?;
 
-    let mut unsigned_tx = hedera::AccountCreateTransaction::new();
+    let mut unsigned_tx = hiero_sdk::AccountCreateTransaction::new();
     unsigned_tx
         .set_key_without_alias(new_public_key)
         .initial_balance(Hbar::from_tinybars(1000))
@@ -187,7 +187,7 @@ async fn flow_verify_transaction() -> anyhow::Result<()> {
     assert_matches!(
         account_info_flow::verify_transaction_signature(&client, op.account_id, &mut unsigned_tx)
             .await,
-        Err(hedera::Error::SignatureVerify(_))
+        Err(hiero_sdk::Error::SignatureVerify(_))
     );
 
     Ok(())

--- a/tests/e2e/account/mod.rs
+++ b/tests/e2e/account/mod.rs
@@ -6,7 +6,7 @@ mod delete;
 mod info;
 mod update;
 
-use hedera::{
+use hiero_sdk::{
     AccountId,
     Hbar,
     PrivateKey,
@@ -19,10 +19,10 @@ pub struct Account {
 }
 
 impl Account {
-    pub async fn create(initial_balance: Hbar, client: &hedera::Client) -> hedera::Result<Self> {
+    pub async fn create(initial_balance: Hbar, client: &hiero_sdk::Client) -> hiero_sdk::Result<Self> {
         let key = PrivateKey::generate_ed25519();
 
-        let receipt = hedera::AccountCreateTransaction::new()
+        let receipt = hiero_sdk::AccountCreateTransaction::new()
             .set_key_without_alias(key.public_key())
             .initial_balance(initial_balance)
             .execute(client)
@@ -35,8 +35,8 @@ impl Account {
         Ok(Self { key, id: account_id })
     }
 
-    pub async fn delete(self, client: &hedera::Client) -> hedera::Result<()> {
-        hedera::AccountDeleteTransaction::new()
+    pub async fn delete(self, client: &hiero_sdk::Client) -> hiero_sdk::Result<()> {
+        hiero_sdk::AccountDeleteTransaction::new()
             .account_id(self.id)
             .transfer_account_id(client.get_operator_account_id().unwrap())
             .freeze_with(client)?
@@ -52,9 +52,9 @@ impl Account {
     pub async fn create_with_max_associations(
         max_automatic_token_associations: i32,
         account_key: &PrivateKey,
-        client: &hedera::Client,
-    ) -> hedera::Result<Self> {
-        let receipt = hedera::AccountCreateTransaction::new()
+        client: &hiero_sdk::Client,
+    ) -> hiero_sdk::Result<Self> {
+        let receipt = hiero_sdk::AccountCreateTransaction::new()
             .set_key_without_alias(account_key.public_key())
             .initial_balance(Hbar::new(10))
             .max_automatic_token_associations(max_automatic_token_associations)

--- a/tests/e2e/account/mod.rs
+++ b/tests/e2e/account/mod.rs
@@ -19,7 +19,10 @@ pub struct Account {
 }
 
 impl Account {
-    pub async fn create(initial_balance: Hbar, client: &hiero_sdk::Client) -> hiero_sdk::Result<Self> {
+    pub async fn create(
+        initial_balance: Hbar,
+        client: &hiero_sdk::Client,
+    ) -> hiero_sdk::Result<Self> {
         let key = PrivateKey::generate_ed25519();
 
         let receipt = hiero_sdk::AccountCreateTransaction::new()

--- a/tests/e2e/account/update.rs
+++ b/tests/e2e/account/update.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction,
     AccountInfoQuery,
     AccountUpdateTransaction,
@@ -78,8 +78,8 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: hedera::Status::AccountIdDoesNotExist,
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
+            status: hiero_sdk::Status::AccountIdDoesNotExist,
             ..
         })
     );
@@ -142,8 +142,8 @@ async fn cannot_update_max_token_association_to_lower_value_fails() -> anyhow::R
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
-            status: hedera::Status::ExistingAutomaticAssociationsExceedGivenLimit,
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: hiero_sdk::Status::ExistingAutomaticAssociationsExceedGivenLimit,
             ..
         })
     );

--- a/tests/e2e/address_book/node_create.rs
+++ b/tests/e2e/address_book/node_create.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use hedera::{
+use hiero_sdk::{
     AccountId,
     Client,
     NodeCreateTransaction,

--- a/tests/e2e/batch_transaction.rs
+++ b/tests/e2e/batch_transaction.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction,
     AccountId,
     AccountInfoQuery,

--- a/tests/e2e/client.rs
+++ b/tests/e2e/client.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use hedera::Client;
+use hiero_sdk::Client;
 
 #[tokio::test]
 async fn initialize_with_mirror_network() -> anyhow::Result<()> {

--- a/tests/e2e/common/mod.rs
+++ b/tests/e2e/common/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 
 use anyhow::Context;
-use hedera::{
+use hiero_sdk::{
     AccountId,
     Client,
     PrivateKey,

--- a/tests/e2e/contract/bytecode.rs
+++ b/tests/e2e/contract/bytecode.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     ContractBytecodeQuery,
     ContractCreateTransaction,
     ContractDeleteTransaction,
@@ -187,7 +187,7 @@ async fn get_cost_small_max_query() -> anyhow::Result<()> {
 
     assert_matches!(
         bytecode,
-        Err(hedera::Error::MaxQueryPaymentExceeded {
+        Err(hiero_sdk::Error::MaxQueryPaymentExceeded {
             max_query_payment: _max_payment_amount,
             query_cost: _cost
         })

--- a/tests/e2e/contract/create.rs
+++ b/tests/e2e/contract/create.rs
@@ -176,7 +176,10 @@ async fn bytecode_file_id_unset_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidFileId, .. }));
+    assert_matches!(
+        res,
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidFileId, .. })
+    );
 
     Ok(())
 }

--- a/tests/e2e/contract/create.rs
+++ b/tests/e2e/contract/create.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     ContractCreateTransaction,
     ContractDeleteTransaction,
     ContractFunctionParameters,
@@ -123,7 +123,7 @@ async fn unset_gas_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InsufficientGas, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InsufficientGas, .. })
     );
 
     Ok(())
@@ -153,7 +153,7 @@ async fn constructor_parameters_unset_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::ContractRevertExecuted, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::ContractRevertExecuted, .. })
     );
 
     Ok(())
@@ -176,7 +176,7 @@ async fn bytecode_file_id_unset_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::InvalidFileId, .. }));
+    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidFileId, .. }));
 
     Ok(())
 }

--- a/tests/e2e/contract/create_flow.rs
+++ b/tests/e2e/contract/create_flow.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     ContractCreateFlow,
     ContractDeleteTransaction,
     ContractFunctionParameters,
@@ -81,7 +81,7 @@ async fn admin_key_missing_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())

--- a/tests/e2e/contract/delete.rs
+++ b/tests/e2e/contract/delete.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     ContractDeleteTransaction,
     ContractInfoQuery,
     Status,
@@ -64,7 +64,7 @@ async fn missing_admin_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::ModifyingImmutableContract, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::ModifyingImmutableContract, .. })
     );
 
     Ok(())
@@ -80,7 +80,7 @@ async fn missing_contract_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidContractId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidContractId, .. })
     );
 
     Ok(())

--- a/tests/e2e/contract/execute.rs
+++ b/tests/e2e/contract/execute.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     ContractDeleteTransaction,
     ContractExecuteTransaction,
     ContractFunctionParameters,
@@ -67,7 +67,7 @@ async fn missing_contract_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidContractId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidContractId, .. })
     );
 
     Ok(())
@@ -98,7 +98,7 @@ async fn missing_function_parameters_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::ContractRevertExecuted, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::ContractRevertExecuted, .. })
     );
 
     ContractDeleteTransaction::new()
@@ -138,7 +138,7 @@ async fn missing_gas_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InsufficientGas, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InsufficientGas, .. })
     );
 
     ContractDeleteTransaction::new()

--- a/tests/e2e/contract/info.rs
+++ b/tests/e2e/contract/info.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     ContractDeleteTransaction,
     ContractInfoQuery,
     Hbar,
@@ -86,7 +86,7 @@ async fn missing_contract_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryNoPaymentPreCheckStatus { status: Status::InvalidContractId })
+        Err(hiero_sdk::Error::QueryNoPaymentPreCheckStatus { status: Status::InvalidContractId })
     );
 
     Ok(())
@@ -151,7 +151,7 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 
     let (max_query_payment, query_cost) = assert_matches!(
         res,
-        Err(hedera::Error::MaxQueryPaymentExceeded {
+        Err(hiero_sdk::Error::MaxQueryPaymentExceeded {
             max_query_payment,
             query_cost
         }) => (max_query_payment, query_cost)
@@ -197,7 +197,7 @@ async fn query_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
+        Err(hiero_sdk::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     ContractDeleteTransaction::new()

--- a/tests/e2e/contract/mod.rs
+++ b/tests/e2e/contract/mod.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     ContractCreateTransaction,
     ContractFunctionParameters,
     ContractId,
@@ -59,9 +59,9 @@ const SMART_CONTRACT_BYTECODE: &str = concat!(
 ///
 /// This is intended as an optimization (cost wise & network resource wise).
 async fn bytecode_file_id(
-    client: &hedera::Client,
-    op_key: hedera::PublicKey,
-) -> hedera::Result<FileId> {
+    client: &hiero_sdk::Client,
+    op_key: hiero_sdk::PublicKey,
+) -> hiero_sdk::Result<FileId> {
     use time::{
         Duration,
         OffsetDateTime,
@@ -69,10 +69,10 @@ async fn bytecode_file_id(
     static BYTECODE_FILE: tokio::sync::OnceCell<FileId> = tokio::sync::OnceCell::const_new();
 
     async fn make_file(
-        client: &hedera::Client,
-        op_key: hedera::PublicKey,
-    ) -> hedera::Result<FileId> {
-        let file_id = hedera::FileCreateTransaction::new()
+        client: &hiero_sdk::Client,
+        op_key: hiero_sdk::PublicKey,
+    ) -> hiero_sdk::Result<FileId> {
+        let file_id = hiero_sdk::FileCreateTransaction::new()
             .keys([op_key])
             .contents(SMART_CONTRACT_BYTECODE)
             .expiration_time(OffsetDateTime::now_utc() + Duration::days(30))
@@ -92,15 +92,15 @@ async fn bytecode_file_id(
 }
 
 async fn create_contract(
-    client: &hedera::Client,
+    client: &hiero_sdk::Client,
     op_key: PublicKey,
     admin_key: impl Into<Option<ContractAdminKey>>,
-) -> hedera::Result<ContractId> {
+) -> hiero_sdk::Result<ContractId> {
     async fn inner(
-        client: &hedera::Client,
+        client: &hiero_sdk::Client,
         op_key: PublicKey,
         admin_key: Option<ContractAdminKey>,
-    ) -> hedera::Result<ContractId> {
+    ) -> hiero_sdk::Result<ContractId> {
         let file_id = bytecode_file_id(client, op_key).await?;
 
         let mut tx = ContractCreateTransaction::new();

--- a/tests/e2e/contract/nonce_info.rs
+++ b/tests/e2e/contract/nonce_info.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     ContractCreateTransaction,
     ContractDeleteTransaction,
     FileCreateTransaction,

--- a/tests/e2e/contract/update.rs
+++ b/tests/e2e/contract/update.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     ContractDeleteTransaction,
     ContractInfoQuery,
     ContractUpdateTransaction,
@@ -68,7 +68,7 @@ async fn missing_contract_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidContractId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidContractId, .. })
     );
 
     Ok(())
@@ -97,7 +97,7 @@ async fn immutable_contract_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::ModifyingImmutableContract, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::ModifyingImmutableContract, .. })
     );
 
     Ok(())

--- a/tests/e2e/ethereum_transaction.rs
+++ b/tests/e2e/ethereum_transaction.rs
@@ -2,7 +2,7 @@ use bytes::{
     BufMut,
     BytesMut,
 };
-use hedera::{
+use hiero_sdk::{
     AccountInfoQuery,
     ContractCreateTransaction,
     ContractDeleteTransaction,

--- a/tests/e2e/fee_schedules.rs
+++ b/tests/e2e/fee_schedules.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     FeeSchedules,
     FileContentsQuery,
     FileId,

--- a/tests/e2e/file/append.rs
+++ b/tests/e2e/file/append.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     FileAppendTransaction,
     FileContentsQuery,
     FileCreateTransaction,

--- a/tests/e2e/file/contents.rs
+++ b/tests/e2e/file/contents.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     FileContentsQuery,
     FileCreateTransaction,
     FileDeleteTransaction,
@@ -91,7 +91,7 @@ async fn missing_file_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryNoPaymentPreCheckStatus { status: Status::InvalidFileId })
+        Err(hiero_sdk::Error::QueryNoPaymentPreCheckStatus { status: Status::InvalidFileId })
     );
 
     Ok(())
@@ -169,7 +169,7 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 
     let (max_query_payment, query_cost) = assert_matches!(
         res,
-        Err(hedera::Error::MaxQueryPaymentExceeded {
+        Err(hiero_sdk::Error::MaxQueryPaymentExceeded {
             max_query_payment,
             query_cost
         }) => (max_query_payment, query_cost)
@@ -220,7 +220,7 @@ async fn query_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
+        Err(hiero_sdk::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     FileDeleteTransaction::new()

--- a/tests/e2e/file/create.rs
+++ b/tests/e2e/file/create.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     FileCreateTransaction,
     FileDeleteTransaction,
     FileInfoQuery,

--- a/tests/e2e/file/delete.rs
+++ b/tests/e2e/file/delete.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     FileCreateTransaction,
     FileDeleteTransaction,
     FileInfoQuery,
@@ -68,7 +68,7 @@ async fn immutable_file_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::Unauthorized, .. }));
+    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::Unauthorized, .. }));
 
     Ok(())
 }

--- a/tests/e2e/file/file_id.rs
+++ b/tests/e2e/file/file_id.rs
@@ -1,4 +1,4 @@
-use hedera::FileId;
+use hiero_sdk::FileId;
 
 #[tokio::test]
 async fn should_get_address_book_file_id_for_shard_realm() -> anyhow::Result<()> {

--- a/tests/e2e/file/info.rs
+++ b/tests/e2e/file/info.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     FileCreateTransaction,
     FileDeleteTransaction,
     FileInfoQuery,
@@ -149,7 +149,7 @@ async fn query_cost_small_max() -> anyhow::Result<()> {
 
     let (max_query_payment, query_cost) = assert_matches!(
         res,
-        Err(hedera::Error::MaxQueryPaymentExceeded {
+        Err(hiero_sdk::Error::MaxQueryPaymentExceeded {
             max_query_payment,
             query_cost
         }) => (max_query_payment, query_cost)
@@ -200,7 +200,7 @@ async fn query_cost_insufficient_tx_fee() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
+        Err(hiero_sdk::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     FileDeleteTransaction::new()

--- a/tests/e2e/file/update.rs
+++ b/tests/e2e/file/update.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     FileCreateTransaction,
     FileDeleteTransaction,
     FileInfoQuery,
@@ -86,7 +86,7 @@ async fn immutable_file_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::Unauthorized, .. }));
+    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::Unauthorized, .. }));
 
     Ok(())
 }
@@ -101,7 +101,7 @@ async fn missing_file_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidFileId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidFileId, .. })
     );
 
     Ok(())

--- a/tests/e2e/network_version_info.rs
+++ b/tests/e2e/network_version_info.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     NetworkVersionInfoQuery,
     Status,
@@ -71,7 +71,7 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 
     let (max_query_payment, query_cost) = assert_matches!(
         res,
-        Err(hedera::Error::MaxQueryPaymentExceeded {
+        Err(hiero_sdk::Error::MaxQueryPaymentExceeded {
             max_query_payment,
             query_cost
         }) => (max_query_payment, query_cost)
@@ -99,7 +99,7 @@ async fn get_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
+        Err(hiero_sdk::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     Ok(())

--- a/tests/e2e/node/update.rs
+++ b/tests/e2e/node/update.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction,
     AccountDeleteTransaction,
     AccountId,
@@ -134,7 +134,7 @@ async fn fails_with_invalid_signature_when_updating_without_admin_key() -> anyho
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -173,7 +173,7 @@ async fn fails_when_changing_to_non_existent_account_id() -> anyhow::Result<()> 
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -208,7 +208,7 @@ async fn fails_when_changing_node_account_id_without_account_key() -> anyhow::Re
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -255,7 +255,7 @@ async fn fails_when_changing_to_deleted_account_id() -> anyhow::Result<()> {
 
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::AccountDeleted, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::AccountDeleted, .. })
     );
 
     Ok(())
@@ -292,7 +292,7 @@ async fn fails_when_new_node_account_has_zero_balance() -> anyhow::Result<()> {
     // Should fail with status code 526 (NODE_ACCOUNT_HAS_ZERO_BALANCE)
     assert_matches::assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::NodeAccountHasZeroBalance, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::NodeAccountHasZeroBalance, .. })
     );
 
     Ok(())

--- a/tests/e2e/node_address_book.rs
+++ b/tests/e2e/node_address_book.rs
@@ -1,4 +1,4 @@
-use hedera::NodeAddressBookQuery;
+use hiero_sdk::NodeAddressBookQuery;
 
 use crate::common::TestEnvironment;
 

--- a/tests/e2e/prng.rs
+++ b/tests/e2e/prng.rs
@@ -1,4 +1,4 @@
-use hedera::PrngTransaction;
+use hiero_sdk::PrngTransaction;
 
 use crate::common::{
     setup_nonfree,

--- a/tests/e2e/schedule/create.rs
+++ b/tests/e2e/schedule/create.rs
@@ -224,7 +224,10 @@ async fn double_schedule_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::IdenticalScheduleAlreadyCreated, .. })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::IdenticalScheduleAlreadyCreated,
+            ..
+        })
     );
 
     account.delete(&client).await?;

--- a/tests/e2e/schedule/create.rs
+++ b/tests/e2e/schedule/create.rs
@@ -6,7 +6,7 @@ use std::hash::{
 use std::thread::sleep;
 
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery,
     AccountCreateTransaction,
     AccountDeleteTransaction,
@@ -224,7 +224,7 @@ async fn double_schedule_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::IdenticalScheduleAlreadyCreated, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::IdenticalScheduleAlreadyCreated, .. })
     );
 
     account.delete(&client).await?;
@@ -386,7 +386,7 @@ async fn schedule_ahead_one_year_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
+        Err(hiero_sdk::Error::ReceiptStatus {
             status: Status::ScheduleExpirationTimeTooFarInFuture,
             ..
         })
@@ -424,7 +424,7 @@ async fn schedule_in_the_past_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
+        Err(hiero_sdk::Error::ReceiptStatus {
             status: Status::ScheduleExpirationTimeMustBeHigherThanConsensusTime,
             ..
         })

--- a/tests/e2e/schedule/delete.rs
+++ b/tests/e2e/schedule/delete.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     ScheduleDeleteTransaction,
     Status,
@@ -78,7 +78,7 @@ async fn missing_admin_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::ScheduleIsImmutable, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::ScheduleIsImmutable, .. })
     );
 
     Ok(())
@@ -127,7 +127,7 @@ async fn double_delete_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::ScheduleAlreadyDeleted, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::ScheduleAlreadyDeleted, .. })
     );
 
     Ok(())
@@ -143,7 +143,7 @@ async fn missing_schedule_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidScheduleId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidScheduleId, .. })
     );
 
     Ok(())

--- a/tests/e2e/schedule/info.rs
+++ b/tests/e2e/schedule/info.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction,
     Hbar,
     KeyList,
@@ -105,7 +105,7 @@ async fn missing_schedule_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryNoPaymentPreCheckStatus { status: Status::InvalidScheduleId })
+        Err(hiero_sdk::Error::QueryNoPaymentPreCheckStatus { status: Status::InvalidScheduleId })
     );
 
     Ok(())
@@ -207,7 +207,7 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 
     let (max_query_payment, query_cost) = assert_matches!(
         res,
-        Err(hedera::Error::MaxQueryPaymentExceeded {
+        Err(hiero_sdk::Error::MaxQueryPaymentExceeded {
             max_query_payment,
             query_cost
         }) => (max_query_payment, query_cost)
@@ -254,7 +254,7 @@ async fn query_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
+        Err(hiero_sdk::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     account.delete(&client).await?;

--- a/tests/e2e/token/airdrop.rs
+++ b/tests/e2e/token/airdrop.rs
@@ -2,7 +2,7 @@ use std::iter::repeat;
 
 use anyhow::anyhow;
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AccountAllowanceApproveTransaction,
     AccountBalanceQuery,
     AccountCreateTransaction,
@@ -502,7 +502,7 @@ async fn token_allowance_and_no_balance_ft_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::NotSupported, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::NotSupported, .. })
     );
 
     Ok(())
@@ -593,7 +593,7 @@ async fn token_allowance_and_no_balance_nft_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::NotSupported, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::NotSupported, .. })
     );
 
     Ok(())
@@ -613,7 +613,7 @@ async fn invalid_body_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
             status: Status::EmptyTokenTransferBody,
             ..
         })
@@ -632,7 +632,7 @@ async fn invalid_body_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
             status: Status::AirdropContainsMultipleSendersForAToken,
             ..
         })

--- a/tests/e2e/token/associate.rs
+++ b/tests/e2e/token/associate.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenAssociateTransaction,
@@ -73,7 +73,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     Ok(())
@@ -97,7 +97,7 @@ async fn missing_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     account.delete(&client).await?;

--- a/tests/e2e/token/burn.rs
+++ b/tests/e2e/token/burn.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenAssociateTransaction,
@@ -63,7 +63,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     Ok(())
@@ -122,7 +122,7 @@ async fn missing_supply_key_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     token.delete(&client).await?;
@@ -202,7 +202,7 @@ async fn unowned_nft_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TreasuryMustOwnBurnedNft, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TreasuryMustOwnBurnedNft, .. })
     );
 
     TransferTransaction::new()

--- a/tests/e2e/token/cancel_airdrop.rs
+++ b/tests/e2e/token/cancel_airdrop.rs
@@ -2,7 +2,7 @@ use std::iter::repeat;
 
 use anyhow::anyhow;
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery,
     PrivateKey,
     Status,
@@ -443,7 +443,7 @@ async fn cannot_cancel_nonexisting_airdrops_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -492,7 +492,7 @@ async fn cannot_cancel_canceled_airdrops_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidPendingAirdropId, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidPendingAirdropId, .. })
     );
 
     Ok(())
@@ -510,7 +510,7 @@ async fn cannot_cancel_empty_airdrop_list_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
             status: Status::EmptyPendingAirdropIdList,
             ..
         })
@@ -553,7 +553,7 @@ async fn cannot_cancel_duplicated_entries_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
             status: Status::PendingAirdropIdRepeated,
             ..
         })

--- a/tests/e2e/token/claim_airdrop.rs
+++ b/tests/e2e/token/claim_airdrop.rs
@@ -2,7 +2,7 @@ use std::iter::repeat;
 
 use anyhow::anyhow;
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery,
     PrivateKey,
     Status,
@@ -365,7 +365,7 @@ async fn cannot_claim_nonexisting_tokens_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -418,7 +418,7 @@ async fn cannot_claim_already_claimed_airdrop_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidPendingAirdropId, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidPendingAirdropId, .. })
     );
 
     Ok(())
@@ -436,7 +436,7 @@ async fn cannot_claim_empty_pending_airdrops_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
             status: Status::EmptyPendingAirdropIdList,
             ..
         })
@@ -479,7 +479,7 @@ async fn cannot_claim_duplicate_entries_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
             status: Status::PendingAirdropIdRepeated,
             ..
         })
@@ -531,7 +531,7 @@ async fn cannot_claim_deleted_tokens_fail() -> anyhow::Result<()> {
         .get_record(&client)
         .await;
 
-    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::TokenWasDeleted, .. }));
+    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenWasDeleted, .. }));
 
     Ok(())
 }
@@ -593,7 +593,7 @@ async fn cannot_claim_frozen_token_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::AccountFrozenForToken, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::AccountFrozenForToken, .. })
     );
 
     Ok(())

--- a/tests/e2e/token/claim_airdrop.rs
+++ b/tests/e2e/token/claim_airdrop.rs
@@ -531,7 +531,10 @@ async fn cannot_claim_deleted_tokens_fail() -> anyhow::Result<()> {
         .get_record(&client)
         .await;
 
-    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenWasDeleted, .. }));
+    assert_matches!(
+        res,
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenWasDeleted, .. })
+    );
 
     Ok(())
 }

--- a/tests/e2e/token/create.rs
+++ b/tests/e2e/token/create.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AccountId,
     AnyCustomFee,
     FixedFee,
@@ -46,7 +46,7 @@ fn fractional_fee(fee_collector: AccountId) -> AnyCustomFee {
             numerator: 1,
             minimum_amount: 1,
             maximum_amount: 20,
-            assessment_method: hedera::FeeAssessmentMethod::Exclusive,
+            assessment_method: hiero_sdk::FeeAssessmentMethod::Exclusive,
         },
         fee_collector_account_id: Some(fee_collector),
         all_collectors_are_exempt: false,
@@ -134,7 +134,7 @@ async fn missing_name_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::MissingTokenName, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::MissingTokenName, .. })
     );
 
     account.delete(&client).await?;
@@ -161,7 +161,7 @@ async fn missing_symbol_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::MissingTokenSymbol, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::MissingTokenSymbol, .. })
     );
 
     account.delete(&client).await?;
@@ -183,7 +183,7 @@ async fn missing_treasury_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
             status: Status::InvalidTreasuryAccountForToken,
             ..
         })
@@ -212,7 +212,7 @@ async fn missing_treasury_account_id_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     account.delete(&client).await?;
@@ -243,7 +243,7 @@ async fn missing_admin_key_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     account.delete(&client).await?;
@@ -306,7 +306,7 @@ async fn too_many_custom_fees_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::CustomFeesListTooLong, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::CustomFeesListTooLong, .. })
     );
 
     account.delete(&client).await?;
@@ -387,7 +387,7 @@ async fn fractional_fee_min_bigger_than_max_fails() -> anyhow::Result<()> {
             numerator: 1,
             minimum_amount: 3,
             maximum_amount: 2,
-            assessment_method: hedera::FeeAssessmentMethod::Exclusive,
+            assessment_method: hiero_sdk::FeeAssessmentMethod::Exclusive,
         },
         fee_collector_account_id: Some(account.id),
         all_collectors_are_exempt: false,
@@ -409,7 +409,7 @@ async fn fractional_fee_min_bigger_than_max_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
+        Err(hiero_sdk::Error::ReceiptStatus {
             status: Status::FractionalFeeMaxAmountLessThanMinAmount,
             ..
         })
@@ -449,7 +449,7 @@ async fn invalid_fee_collector_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidCustomFeeCollector, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidCustomFeeCollector, .. })
     );
 
     account.delete(&client).await?;
@@ -486,7 +486,7 @@ async fn negative_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::CustomFeeMustBePositive, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::CustomFeeMustBePositive, .. })
     );
 
     account.delete(&client).await?;
@@ -507,7 +507,7 @@ async fn zero_denominator_fails() -> anyhow::Result<()> {
             numerator: 1,
             minimum_amount: 1,
             maximum_amount: 10,
-            assessment_method: hedera::FeeAssessmentMethod::Exclusive,
+            assessment_method: hiero_sdk::FeeAssessmentMethod::Exclusive,
         },
         fee_collector_account_id: Some(account.id),
         all_collectors_are_exempt: false,
@@ -529,7 +529,7 @@ async fn zero_denominator_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::FractionDividesByZero, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::FractionDividesByZero, .. })
     );
 
     account.delete(&client).await?;
@@ -580,7 +580,7 @@ async fn royalty_fee() -> anyhow::Result<()> {
     let account = Account::create(Hbar::new(0), &client).await?;
 
     let fee = RoyaltyFee {
-        fee: hedera::RoyaltyFeeData {
+        fee: hiero_sdk::RoyaltyFeeData {
             denominator: 10,
             numerator: 1,
             fallback_fee: Some(FixedFeeData::from_hbar(Hbar::new(1))),

--- a/tests/e2e/token/delete.rs
+++ b/tests/e2e/token/delete.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenDeleteTransaction,
@@ -83,7 +83,7 @@ async fn missing_admin_key_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     token.delete(&client).await?;
@@ -116,7 +116,7 @@ async fn missing_admin_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, .. })
     );
 
     Ok(())
@@ -132,7 +132,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     Ok(())

--- a/tests/e2e/token/dissociate.rs
+++ b/tests/e2e/token/dissociate.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenAssociateTransaction,
@@ -82,7 +82,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     Ok(())
@@ -106,7 +106,7 @@ async fn missing_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     account.delete(&client).await?;
@@ -138,7 +138,7 @@ async fn unassociated_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/fee_schedule_update.rs
+++ b/tests/e2e/token/fee_schedule_update.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     FixedFee,
     FixedFeeData,
     FractionalFee,
@@ -52,7 +52,7 @@ async fn basic() -> anyhow::Result<()> {
                 numerator: 1,
                 minimum_amount: 1,
                 maximum_amount: 10,
-                assessment_method: hedera::FeeAssessmentMethod::Exclusive,
+                assessment_method: hiero_sdk::FeeAssessmentMethod::Exclusive,
             },
             fee_collector_account_id: Some(account.id),
             all_collectors_are_exempt: false,
@@ -105,7 +105,7 @@ async fn invalid_signature_fails() -> anyhow::Result<()> {
                 numerator: 1,
                 minimum_amount: 1,
                 maximum_amount: 10,
-                assessment_method: hedera::FeeAssessmentMethod::Exclusive,
+                assessment_method: hiero_sdk::FeeAssessmentMethod::Exclusive,
             },
             fee_collector_account_id: Some(account.id),
             all_collectors_are_exempt: false,
@@ -126,7 +126,7 @@ async fn invalid_signature_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())

--- a/tests/e2e/token/freeze.rs
+++ b/tests/e2e/token/freeze.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenAssociateTransaction,
@@ -76,7 +76,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     account.delete(&client).await?;
@@ -101,7 +101,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     token.delete(&client).await?;
@@ -134,7 +134,7 @@ async fn non_associated_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/grant_kyc.rs
+++ b/tests/e2e/token/grant_kyc.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenAssociateTransaction,
@@ -76,7 +76,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     account.delete(&client).await?;
@@ -106,7 +106,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     token.delete(&client).await?;
@@ -139,7 +139,7 @@ async fn non_associated_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/info.rs
+++ b/tests/e2e/token/info.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Key,
     PrivateKey,
@@ -254,7 +254,7 @@ async fn query_cost_small_max_fails() -> anyhow::Result<()> {
 
     let (max_query_payment, query_cost) = assert_matches!(
         res,
-        Err(hedera::Error::MaxQueryPaymentExceeded {
+        Err(hiero_sdk::Error::MaxQueryPaymentExceeded {
             max_query_payment,
             query_cost
         }) => (max_query_payment, query_cost)
@@ -289,7 +289,7 @@ async fn query_cost_insufficient_tx_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
+        Err(hiero_sdk::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/mint.rs
+++ b/tests/e2e/token/mint.rs
@@ -273,7 +273,10 @@ async fn nft_metadata_too_long_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::MetadataTooLong, .. }));
+    assert_matches!(
+        res,
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::MetadataTooLong, .. })
+    );
 
     token.delete(&client).await?;
     account.delete(&client).await?;

--- a/tests/e2e/token/mint.rs
+++ b/tests/e2e/token/mint.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenCreateTransaction,
@@ -71,7 +71,7 @@ async fn over_supply_limit_fails() -> anyhow::Result<()> {
     let token_id = TokenCreateTransaction::new()
         .name("ffff")
         .symbol("F")
-        .token_supply_type(hedera::TokenSupplyType::Finite)
+        .token_supply_type(hiero_sdk::TokenSupplyType::Finite)
         .max_supply(5)
         .treasury_account_id(account.id)
         .admin_key(account.key.public_key())
@@ -98,7 +98,7 @@ async fn over_supply_limit_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenMaxSupplyReached, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenMaxSupplyReached, .. })
     );
 
     token.delete(&client).await?;
@@ -117,7 +117,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     Ok(())
@@ -180,7 +180,7 @@ async fn missing_supply_key_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     token.delete(&client).await?;
@@ -273,7 +273,7 @@ async fn nft_metadata_too_long_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::MetadataTooLong, .. }));
+    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::MetadataTooLong, .. }));
 
     token.delete(&client).await?;
     account.delete(&client).await?;

--- a/tests/e2e/token/mod.rs
+++ b/tests/e2e/token/mod.rs
@@ -25,7 +25,7 @@ mod unpause;
 mod update;
 mod wipe;
 
-use hedera::{
+use hiero_sdk::{
     Client,
     PublicKey,
     TokenBurnTransaction,
@@ -113,7 +113,7 @@ impl FungibleToken {
         client: &Client,
         owner: &Account,
         params: CreateFungibleToken,
-    ) -> hedera::Result<Self> {
+    ) -> hiero_sdk::Result<Self> {
         let owner_public_key = owner.key.public_key();
 
         let token_id = {
@@ -202,7 +202,7 @@ impl FungibleToken {
             .initial_supply(1_000_000)
             .max_supply(1_000_000)
             .treasury_account_id(owner.id)
-            .token_supply_type(hedera::TokenSupplyType::Finite)
+            .token_supply_type(hiero_sdk::TokenSupplyType::Finite)
             .admin_key(owner.key.public_key())
             .freeze_key(owner.key.public_key())
             .wipe_key(owner.key.public_key())
@@ -219,8 +219,8 @@ impl FungibleToken {
         Ok(FungibleToken { id, owner: owner.clone() })
     }
 
-    async fn burn(&self, client: &Client, supply: u64) -> hedera::Result<()> {
-        hedera::TokenBurnTransaction::new()
+    async fn burn(&self, client: &Client, supply: u64) -> hiero_sdk::Result<()> {
+        hiero_sdk::TokenBurnTransaction::new()
             .token_id(self.id)
             .amount(supply)
             .sign(self.owner.key.clone())
@@ -232,7 +232,7 @@ impl FungibleToken {
         Ok(())
     }
 
-    async fn delete(self, client: &Client) -> hedera::Result<()> {
+    async fn delete(self, client: &Client) -> hiero_sdk::Result<()> {
         TokenDeleteTransaction::new()
             .token_id(self.id)
             .sign(self.owner.key)
@@ -251,12 +251,12 @@ pub(crate) struct Nft {
 }
 
 impl Nft {
-    pub(crate) async fn create(client: &Client, owner: &Account) -> hedera::Result<Self> {
+    pub(crate) async fn create(client: &Client, owner: &Account) -> hiero_sdk::Result<Self> {
         let owner_public_key = owner.key.public_key();
         let token_id = TokenCreateTransaction::new()
             .name("ffff")
             .symbol("F")
-            .token_type(hedera::TokenType::NonFungibleUnique)
+            .token_type(hiero_sdk::TokenType::NonFungibleUnique)
             .treasury_account_id(owner.id)
             .admin_key(owner_public_key)
             .freeze_key(owner_public_key)
@@ -282,7 +282,7 @@ impl Nft {
         &self,
         client: &Client,
         nfts_to_mint: u8,
-    ) -> hedera::Result<Vec<i64>> {
+    ) -> hiero_sdk::Result<Vec<i64>> {
         self.mint(client, (0..nfts_to_mint).map(|it| [it])).await
     }
 
@@ -290,12 +290,12 @@ impl Nft {
         &self,
         client: &Client,
         metadata: impl IntoIterator<Item = Bytes>,
-    ) -> hedera::Result<Vec<i64>> {
+    ) -> hiero_sdk::Result<Vec<i64>> {
         async fn inner(
             nft: &Nft,
             client: &Client,
             mut tx: TokenMintTransaction,
-        ) -> hedera::Result<Vec<i64>> {
+        ) -> hiero_sdk::Result<Vec<i64>> {
             let serials = tx
                 .token_id(nft.id)
                 .sign(nft.owner.key.clone())
@@ -319,13 +319,13 @@ impl Nft {
         &self,
         client: &Client,
         serials: impl IntoIterator<Item = i64>,
-    ) -> hedera::Result<()> {
+    ) -> hiero_sdk::Result<()> {
         // non generic inner function to save generic instantiations... Not that that's a huge concern here.
         async fn inner(
             nft: &Nft,
             client: &Client,
             mut tx: TokenBurnTransaction,
-        ) -> hedera::Result<()> {
+        ) -> hiero_sdk::Result<()> {
             tx.token_id(nft.id)
                 .sign(nft.owner.key.clone())
                 .execute(client)
@@ -342,7 +342,7 @@ impl Nft {
         inner(self, client, tx).await
     }
 
-    pub(crate) async fn delete(self, client: &Client) -> hedera::Result<()> {
+    pub(crate) async fn delete(self, client: &Client) -> hiero_sdk::Result<()> {
         TokenDeleteTransaction::new()
             .token_id(self.id)
             .sign(self.owner.key)
@@ -361,7 +361,7 @@ async fn mint_several_nfts_at_once() -> anyhow::Result<()> {
         let token_id = TokenCreateTransaction::new()
             .name("sdk::rust::e2e::mint_many")
             .symbol("µ")
-            .token_type(hedera::TokenType::NonFungibleUnique)
+            .token_type(hiero_sdk::TokenType::NonFungibleUnique)
             .treasury_account_id(op.account_id)
             .admin_key(op.private_key.clone().public_key())
             .supply_key(op.private_key.clone().public_key())
@@ -452,7 +452,7 @@ async fn create_nft(
     client: &Client,
     token_id: TokenId,
     nfts: usize,
-) -> hedera::Result<TransactionResponse> {
+) -> hiero_sdk::Result<TransactionResponse> {
     TokenMintTransaction::default()
         .token_id(token_id)
         .metadata(vec![Vec::from([0x12, 0x34]); nfts])

--- a/tests/e2e/token/nft_info.rs
+++ b/tests/e2e/token/nft_info.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     NftId,
     Status,
@@ -54,7 +54,7 @@ async fn invalid_nft_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryNoPaymentPreCheckStatus { status: Status::InvalidNftId })
+        Err(hiero_sdk::Error::QueryNoPaymentPreCheckStatus { status: Status::InvalidNftId })
     );
 
     Ok(())
@@ -73,7 +73,7 @@ async fn invalid_serial_number_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryNoPaymentPreCheckStatus {
+        Err(hiero_sdk::Error::QueryNoPaymentPreCheckStatus {
             status: Status::InvalidTokenNftSerialNumber
         })
     );

--- a/tests/e2e/token/nft_transfer.rs
+++ b/tests/e2e/token/nft_transfer.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenAssociateTransaction,
@@ -109,7 +109,7 @@ async fn unowned_nfts_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::SenderDoesNotOwnNftSerialNo, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::SenderDoesNotOwnNftSerialNo, .. })
     );
 
     token.burn(&client, serials).await?;

--- a/tests/e2e/token/nft_update.rs
+++ b/tests/e2e/token/nft_update.rs
@@ -6,7 +6,7 @@ use futures_util::stream::{
     TryStreamExt,
 };
 use futures_util::StreamExt;
-use hedera::{
+use hiero_sdk::{
     Client,
     NftId,
     PrivateKey,
@@ -148,7 +148,7 @@ async fn cannot_update_without_signed_metadata_key_error() -> anyhow::Result<()>
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -213,7 +213,7 @@ async fn cannot_update_without_set_metadata_key_error() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())

--- a/tests/e2e/token/pause.rs
+++ b/tests/e2e/token/pause.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenPauseTransaction,
@@ -55,7 +55,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     Ok(())
@@ -80,7 +80,7 @@ async fn missing_pause_key_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -105,7 +105,7 @@ async fn missing_pause_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenHasNoPauseKey, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenHasNoPauseKey, .. })
     );
 
     Ok(())

--- a/tests/e2e/token/reject.rs
+++ b/tests/e2e/token/reject.rs
@@ -373,7 +373,10 @@ async fn ft_and_nft_paused_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsPaused, .. }));
+    assert_matches!(
+        res,
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsPaused, .. })
+    );
 
     let nft_serials = TokenMintTransaction::new()
         .token_id(nft.id)
@@ -412,7 +415,10 @@ async fn ft_and_nft_paused_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsPaused, .. }));
+    assert_matches!(
+        res,
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsPaused, .. })
+    );
 
     Ok(())
 }

--- a/tests/e2e/token/reject.rs
+++ b/tests/e2e/token/reject.rs
@@ -4,7 +4,7 @@ use std::iter::repeat;
 
 use anyhow::anyhow;
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery,
     Client,
     Hbar,
@@ -284,7 +284,7 @@ async fn ft_and_nft_freeze_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::AccountFrozenForToken, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::AccountFrozenForToken, .. })
     );
 
     let nft_serials = TokenMintTransaction::new()
@@ -327,7 +327,7 @@ async fn ft_and_nft_freeze_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::AccountFrozenForToken, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::AccountFrozenForToken, .. })
     );
 
     nft.delete(&client).await?;
@@ -373,7 +373,7 @@ async fn ft_and_nft_paused_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::TokenIsPaused, .. }));
+    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsPaused, .. }));
 
     let nft_serials = TokenMintTransaction::new()
         .token_id(nft.id)
@@ -412,7 +412,7 @@ async fn ft_and_nft_paused_fails() -> anyhow::Result<()> {
         .get_receipt(&client)
         .await;
 
-    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::TokenIsPaused, .. }));
+    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsPaused, .. }));
 
     Ok(())
 }
@@ -462,7 +462,7 @@ async fn add_or_set_nft_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
+        Err(hiero_sdk::Error::ReceiptStatus {
             status: Status::AccountAmountTransfersOnlyAllowedForFungibleCommon,
             ..
         })
@@ -480,7 +480,7 @@ async fn add_or_set_nft_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
+        Err(hiero_sdk::Error::ReceiptStatus {
             status: Status::AccountAmountTransfersOnlyAllowedForFungibleCommon,
             ..
         })
@@ -511,7 +511,7 @@ async fn treasury_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::AccountIsTreasury, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::AccountIsTreasury, .. })
     );
 
     let nft_serials = TokenMintTransaction::new()
@@ -536,7 +536,7 @@ async fn treasury_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::AccountIsTreasury, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::AccountIsTreasury, .. })
     );
 
     Ok(())
@@ -574,7 +574,7 @@ async fn invalid_sig_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     ft.delete(&client).await?;
@@ -593,7 +593,7 @@ async fn missing_token_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus {
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
             status: Status::EmptyTokenReferenceList,
             ..
         })
@@ -668,7 +668,7 @@ async fn token_reference_list_size_exceeded_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
+        Err(hiero_sdk::Error::ReceiptStatus {
             status: Status::TokenReferenceListSizeLimitExceeded,
             ..
         })
@@ -693,7 +693,7 @@ async fn create_ft(
         .initial_supply(1_000_000)
         .max_supply(1_000_000)
         .treasury_account_id(owner.id)
-        .token_supply_type(hedera::TokenSupplyType::Finite)
+        .token_supply_type(hiero_sdk::TokenSupplyType::Finite)
         .admin_key(owner.key.public_key())
         .freeze_key(owner.key.public_key())
         .wipe_key(owner.key.public_key())
@@ -721,9 +721,9 @@ async fn test_operator_account(config: &Config) -> anyhow::Result<Account> {
 async fn create_receiver_account(
     max_automatic_token_associations: i32,
     account_key: &PrivateKey,
-    client: &hedera::Client,
-) -> hedera::Result<Account> {
-    let receipt = hedera::AccountCreateTransaction::new()
+    client: &hiero_sdk::Client,
+) -> hiero_sdk::Result<Account> {
+    let receipt = hiero_sdk::AccountCreateTransaction::new()
         .set_key_without_alias(account_key.public_key())
         .initial_balance(Hbar::new(10))
         .max_automatic_token_associations(max_automatic_token_associations)

--- a/tests/e2e/token/reject_flow.rs
+++ b/tests/e2e/token/reject_flow.rs
@@ -4,7 +4,7 @@ use std::iter::repeat;
 
 use anyhow::anyhow;
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery,
     Client,
     Hbar,
@@ -82,7 +82,7 @@ async fn basic_flow_fungible_token() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     ft.delete(&client).await?;
@@ -156,7 +156,7 @@ async fn basic_flow_nft() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     nft.delete(&client).await?;
@@ -177,7 +177,7 @@ async fn create_ft(
         .initial_supply(1_000_000)
         .max_supply(1_000_000)
         .treasury_account_id(owner.id)
-        .token_supply_type(hedera::TokenSupplyType::Finite)
+        .token_supply_type(hiero_sdk::TokenSupplyType::Finite)
         .admin_key(owner.key.public_key())
         .freeze_key(owner.key.public_key())
         .wipe_key(owner.key.public_key())
@@ -205,9 +205,9 @@ async fn test_operator_account(config: &Config) -> anyhow::Result<Account> {
 async fn create_receiver_account(
     max_automatic_token_associations: i32,
     account_key: &PrivateKey,
-    client: &hedera::Client,
-) -> hedera::Result<Account> {
-    let receipt = hedera::AccountCreateTransaction::new()
+    client: &hiero_sdk::Client,
+) -> hiero_sdk::Result<Account> {
+    let receipt = hiero_sdk::AccountCreateTransaction::new()
         .set_key_without_alias(account_key.public_key())
         .initial_balance(Hbar::new(1))
         .max_automatic_token_associations(max_automatic_token_associations)

--- a/tests/e2e/token/revoke_kyc.rs
+++ b/tests/e2e/token/revoke_kyc.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenAssociateTransaction,
@@ -76,7 +76,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     account.delete(&client).await?;
@@ -101,7 +101,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     token.delete(&client).await?;
@@ -134,7 +134,7 @@ async fn non_associated_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/transfer.rs
+++ b/tests/e2e/token/transfer.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction,
     FixedFee,
     FixedFeeData,
@@ -166,7 +166,7 @@ async fn insufficient_balance_for_fee_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus {
+        Err(hiero_sdk::Error::ReceiptStatus {
             status: Status::InsufficientSenderAccountBalanceForCustomFee,
             ..
         })
@@ -224,7 +224,7 @@ async fn unowned_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InsufficientTokenBalance, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InsufficientTokenBalance, .. })
     );
 
     token.burn(&client, 10).await?;
@@ -320,7 +320,7 @@ async fn incorrect_decimals_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::UnexpectedTokenDecimals, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::UnexpectedTokenDecimals, .. })
     );
 
     token.burn(&client, 10).await?;

--- a/tests/e2e/token/unfreeze.rs
+++ b/tests/e2e/token/unfreeze.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenAssociateTransaction,
@@ -76,7 +76,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     account.delete(&client).await?;
@@ -101,7 +101,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     token.delete(&client).await?;
@@ -134,7 +134,7 @@ async fn non_associated_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenNotAssociatedToAccount, .. })
     );
 
     token.delete(&client).await?;

--- a/tests/e2e/token/unpause.rs
+++ b/tests/e2e/token/unpause.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenUnpauseTransaction,
@@ -55,7 +55,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     Ok(())
@@ -80,7 +80,7 @@ async fn missing_pause_key_sig_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())
@@ -105,7 +105,7 @@ async fn missing_pause_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenHasNoPauseKey, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenHasNoPauseKey, .. })
     );
 
     Ok(())

--- a/tests/e2e/token/update.rs
+++ b/tests/e2e/token/update.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Client,
     Hbar,
     Key,
@@ -104,7 +104,7 @@ async fn immutable_token_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, .. })
     );
 
     // can't delete the account because the token still exists, can't delete the token because there's no admin key.
@@ -457,7 +457,7 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -471,7 +471,7 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -485,7 +485,7 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -499,7 +499,7 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -513,7 +513,7 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -527,7 +527,7 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -541,7 +541,7 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -555,7 +555,7 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -597,7 +597,7 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -611,7 +611,7 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -625,7 +625,7 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -639,7 +639,7 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -653,7 +653,7 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -667,7 +667,7 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -681,7 +681,7 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -695,7 +695,7 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -758,7 +758,7 @@ async fn update_admin_key_to_usuable_key_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -986,7 +986,7 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1002,7 +1002,7 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1018,7 +1018,7 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1034,7 +1034,7 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1050,7 +1050,7 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1066,7 +1066,7 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1082,7 +1082,7 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -1126,7 +1126,7 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1140,7 +1140,7 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1154,7 +1154,7 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1168,7 +1168,7 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1182,7 +1182,7 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1196,7 +1196,7 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1210,7 +1210,7 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -1256,7 +1256,7 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1272,7 +1272,7 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1288,7 +1288,7 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1304,7 +1304,7 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1320,7 +1320,7 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1336,7 +1336,7 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1352,7 +1352,7 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -1402,7 +1402,7 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1419,7 +1419,7 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1436,7 +1436,7 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1453,7 +1453,7 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1470,7 +1470,7 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1487,7 +1487,7 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1504,7 +1504,7 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -1547,7 +1547,7 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1563,7 +1563,7 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1579,7 +1579,7 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1595,7 +1595,7 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1611,7 +1611,7 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1627,7 +1627,7 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1643,7 +1643,7 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -1699,7 +1699,7 @@ async fn create_token_with_keys(client: &Client, keys: &Keys) -> anyhow::Result<
         tx.execute(&client).await?.get_receipt(&client).await?.token_id.unwrap()
     };
 
-    let token_info: hedera::TokenInfo =
+    let token_info: hiero_sdk::TokenInfo =
         TokenInfoQuery::new().token_id(token_id).execute(&client).await?;
 
     if let Some(admin_key) = &keys.admin_key {

--- a/tests/e2e/token/update.rs
+++ b/tests/e2e/token/update.rs
@@ -457,7 +457,10 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -471,7 +474,10 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -485,7 +491,10 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -499,7 +508,10 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -513,7 +525,10 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -527,7 +542,10 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -541,7 +559,10 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -555,7 +576,10 @@ async fn update_keys_empty_keylist_without_admin_sig_fails() -> anyhow::Result<(
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -597,7 +621,10 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -611,7 +638,10 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -625,7 +655,10 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -639,7 +672,10 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -653,7 +689,10 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -667,7 +706,10 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -681,7 +723,10 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -695,7 +740,10 @@ async fn update_keys_unusable_key_without_admin_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -758,7 +806,10 @@ async fn update_admin_key_to_usuable_key_fail() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -986,7 +1037,10 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::TokenIsImmutable,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1002,7 +1056,10 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::TokenIsImmutable,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1018,7 +1075,10 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::TokenIsImmutable,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1034,7 +1094,10 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::TokenIsImmutable,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1050,7 +1113,10 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::TokenIsImmutable,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1066,7 +1132,10 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::TokenIsImmutable,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1082,7 +1151,10 @@ async fn remove_empty_keylist_keys_lower_privilege_keys_sigs_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::TokenIsImmutable, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::TokenIsImmutable,
+            transaction_id: _
+        })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -1126,7 +1198,10 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1140,7 +1215,10 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1154,7 +1232,10 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1168,7 +1249,10 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1182,7 +1266,10 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1196,7 +1283,10 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1210,7 +1300,10 @@ async fn update_keys_unusable_key_different_key_sig_fails() -> anyhow::Result<()
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -1256,7 +1349,10 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1272,7 +1368,10 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1288,7 +1387,10 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1304,7 +1406,10 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1320,7 +1425,10 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1336,7 +1444,10 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1352,7 +1463,10 @@ async fn update_with_unusable_key_with_old_key_sig_fails() -> anyhow::Result<()>
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -1402,7 +1516,10 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1419,7 +1536,10 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1436,7 +1556,10 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1453,7 +1576,10 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1470,7 +1596,10 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1487,7 +1616,10 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1504,7 +1636,10 @@ async fn update_unusable_key_old_new_key_sig_full_validation_fails() -> anyhow::
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;
@@ -1547,7 +1682,10 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1563,7 +1701,10 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1579,7 +1720,10 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1595,7 +1739,10 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1611,7 +1758,10 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1627,7 +1777,10 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     let tx = TokenUpdateTransaction::new()
@@ -1643,7 +1796,10 @@ async fn update_keys_old_key_sig_full_validation_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         tx,
-        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, transaction_id: _ })
+        Err(hiero_sdk::Error::ReceiptStatus {
+            status: Status::InvalidSignature,
+            transaction_id: _
+        })
     );
 
     _ = TokenDeleteTransaction::new().token_id(token_id).execute(&client).await?;

--- a/tests/e2e/token/wipe.rs
+++ b/tests/e2e/token/wipe.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TokenAssociateTransaction,
@@ -172,7 +172,7 @@ async fn unowned_nft_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::AccountDoesNotOwnWipedNft, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::AccountDoesNotOwnWipedNft, .. })
     );
 
     token.burn(&client, serials).await?;
@@ -201,7 +201,7 @@ async fn missing_account_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidAccountId, .. })
     );
 
     token.delete(&client).await?;
@@ -222,7 +222,7 @@ async fn missing_token_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTokenId, .. })
     );
 
     account.delete(&client).await?;

--- a/tests/e2e/topic/create.rs
+++ b/tests/e2e/topic/create.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     AccountBalanceQuery,
     AccountCreateTransaction,
     Client,
@@ -217,8 +217,8 @@ async fn create_revenue_generating_topic_with_invalid_fee_exempt_key_fails() -> 
 
     assert!(matches!(
         result,
-        Err(hedera::Error::TransactionPreCheckStatus {
-            status: hedera::Status::FeeExemptKeyListContainsDuplicatedKeys,
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
+            status: hiero_sdk::Status::FeeExemptKeyListContainsDuplicatedKeys,
             ..
         })
     ));
@@ -237,8 +237,8 @@ async fn create_revenue_generating_topic_with_invalid_fee_exempt_key_fails() -> 
 
     assert!(matches!(
         result.unwrap_err(),
-        hedera::Error::ReceiptStatus {
-            status: hedera::Status::MaxEntriesForFeeExemptKeyListExceeded,
+        hiero_sdk::Error::ReceiptStatus {
+            status: hiero_sdk::Status::MaxEntriesForFeeExemptKeyListExceeded,
             ..
         }
     ));
@@ -278,7 +278,7 @@ async fn update_fee_schedule_key_without_permission_fails() -> anyhow::Result<()
 
     assert!(matches!(
         result.unwrap_err(),
-        hedera::Error::ReceiptStatus { status: hedera::Status::FeeScheduleKeyCannotBeUpdated, .. }
+        hiero_sdk::Error::ReceiptStatus { status: hiero_sdk::Status::FeeScheduleKeyCannotBeUpdated, .. }
     ));
 
     Ok(())
@@ -323,7 +323,7 @@ async fn update_custom_fees_without_fee_schedule_key_fails() -> anyhow::Result<(
 
     assert!(matches!(
         result.unwrap_err(),
-        hedera::Error::ReceiptStatus { status: hedera::Status::FeeScheduleKeyNotSet, .. }
+        hiero_sdk::Error::ReceiptStatus { status: hiero_sdk::Status::FeeScheduleKeyNotSet, .. }
     ));
 
     Ok(())

--- a/tests/e2e/topic/create.rs
+++ b/tests/e2e/topic/create.rs
@@ -278,7 +278,10 @@ async fn update_fee_schedule_key_without_permission_fails() -> anyhow::Result<()
 
     assert!(matches!(
         result.unwrap_err(),
-        hiero_sdk::Error::ReceiptStatus { status: hiero_sdk::Status::FeeScheduleKeyCannotBeUpdated, .. }
+        hiero_sdk::Error::ReceiptStatus {
+            status: hiero_sdk::Status::FeeScheduleKeyCannotBeUpdated,
+            ..
+        }
     ));
 
     Ok(())

--- a/tests/e2e/topic/delete.rs
+++ b/tests/e2e/topic/delete.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     PrivateKey,
     Status,
     TopicCreateTransaction,
@@ -50,7 +50,7 @@ async fn immutable_fails() -> anyhow::Result<()> {
         .await?
         .get_receipt(&client)
         .await;
-    assert_matches!(res, Err(hedera::Error::ReceiptStatus { status: Status::Unauthorized, .. }));
+    assert_matches!(res, Err(hiero_sdk::Error::ReceiptStatus { status: Status::Unauthorized, .. }));
 
     Ok(())
 }
@@ -82,7 +82,7 @@ async fn wrong_admin_key_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
+        Err(hiero_sdk::Error::ReceiptStatus { status: Status::InvalidSignature, .. })
     );
 
     Ok(())

--- a/tests/e2e/topic/info.rs
+++ b/tests/e2e/topic/info.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     Hbar,
     Status,
     TopicInfoQuery,
@@ -90,7 +90,7 @@ async fn query_cost_small_max() -> anyhow::Result<()> {
 
     let (max_query_payment, query_cost) = assert_matches!(
         res,
-        Err(hedera::Error::MaxQueryPaymentExceeded {
+        Err(hiero_sdk::Error::MaxQueryPaymentExceeded {
             max_query_payment,
             query_cost
         }) => (max_query_payment, query_cost)
@@ -123,7 +123,7 @@ async fn query_cost_insufficient_tx_fee() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
+        Err(hiero_sdk::Error::QueryPaymentPreCheckStatus { status: Status::InsufficientTxFee, .. })
     );
 
     topic.delete(&client).await?;

--- a/tests/e2e/topic/message.rs
+++ b/tests/e2e/topic/message.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     Key,
     TopicInfoQuery,
     TopicMessageQuery,
@@ -64,7 +64,7 @@ async fn basic() -> anyhow::Result<()> {
             tokio::time::sleep(std::time::Duration::from_millis(3000)).await;
 
             // topic not found -> try again
-            if let Err(hedera::Error::GrpcStatus(status)) = &res {
+            if let Err(hiero_sdk::Error::GrpcStatus(status)) = &res {
                 if status.code() == tonic::Code::NotFound {
                     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                     continue;
@@ -127,7 +127,7 @@ async fn large() -> anyhow::Result<()> {
                 .await;
 
             // topic not found -> try again
-            if let Err(hedera::Error::GrpcStatus(status)) = &res {
+            if let Err(hiero_sdk::Error::GrpcStatus(status)) = &res {
                 if status.code() == tonic::Code::NotFound {
                     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                     continue;

--- a/tests/e2e/topic/message_submit.rs
+++ b/tests/e2e/topic/message_submit.rs
@@ -100,7 +100,10 @@ async fn missing_message_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTopicMessage, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus {
+            status: Status::InvalidTopicMessage,
+            ..
+        })
     );
 
     topic.delete(&client).await?;

--- a/tests/e2e/topic/message_submit.rs
+++ b/tests/e2e/topic/message_submit.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use hedera::{
+use hiero_sdk::{
     AnyTransaction,
     Status,
     TopicInfoQuery,
@@ -82,7 +82,7 @@ async fn missing_topic_id_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTopicId, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTopicId, .. })
     );
 
     Ok(())
@@ -100,7 +100,7 @@ async fn missing_message_fails() -> anyhow::Result<()> {
 
     assert_matches!(
         res,
-        Err(hedera::Error::TransactionPreCheckStatus { status: Status::InvalidTopicMessage, .. })
+        Err(hiero_sdk::Error::TransactionPreCheckStatus { status: Status::InvalidTopicMessage, .. })
     );
 
     topic.delete(&client).await?;

--- a/tests/e2e/topic/mod.rs
+++ b/tests/e2e/topic/mod.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     Client,
     TopicCreateTransaction,
     TopicDeleteTransaction,

--- a/tests/e2e/topic/revenue_schedule.rs
+++ b/tests/e2e/topic/revenue_schedule.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     AccountInfoQuery,
     CustomFeeLimit,
     CustomFixedFee,

--- a/tests/e2e/topic/update.rs
+++ b/tests/e2e/topic/update.rs
@@ -1,4 +1,4 @@
-use hedera::{
+use hiero_sdk::{
     TopicInfoQuery,
     TopicUpdateTransaction,
 };

--- a/tests/e2e/transaction/mod.rs
+++ b/tests/e2e/transaction/mod.rs
@@ -18,7 +18,7 @@
  * ‍
  */
 
-use hedera::{
+use hiero_sdk::{
     AccountCreateTransaction,
     AccountId,
     AnyTransaction,


### PR DESCRIPTION
## Description

This pull request updates the SDK and proto package naming conventions throughout the codebase and CI workflow, switching from `hedera`/`hedera-proto` to `hiero-sdk`/`hiero-sdk-proto` (and vice versa in some workflow steps), and adjusts publishing logic and references accordingly. The changes affect the main SDK, proto subpackage, example usage, and the release workflow to ensure correct package names and publishing conditions.

**SDK and proto package renaming:**

* Changed the main SDK package name from `hedera` to `hiero-sdk` and the proto subpackage from `hedera-proto` to `hiero-sdk-proto` in `Cargo.toml` and all code references. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L8-R8) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L30-R30)
* Updated all example files to use `hiero_sdk` instead of `hedera` for imports and type references, ensuring consistency with the new naming convention. [[1]](diffhunk://#diff-41d9f2ea0def9b894b67d69f22f2d947400f7a3db0cc3b2e406e08b685d89447L4-R4) [[2]](diffhunk://#diff-90764eb4f652487083e1c683897758f97e7b787cec2c89690b6848235c559801L4-R4) [[3]](diffhunk://#diff-90764eb4f652487083e1c683897758f97e7b787cec2c89690b6848235c559801L27-R27) [[4]](diffhunk://#diff-90764eb4f652487083e1c683897758f97e7b787cec2c89690b6848235c559801L70-R70) [[5]](diffhunk://#diff-90764eb4f652487083e1c683897758f97e7b787cec2c89690b6848235c559801L240-R240) [[6]](diffhunk://#diff-f6bd078b1f13440fbd2ea6a822814a97134d3bf420cfeb4353d1e2151539b743L4-R4) [[7]](diffhunk://#diff-f6bd078b1f13440fbd2ea6a822814a97134d3bf420cfeb4353d1e2151539b743L120-R122) [[8]](diffhunk://#diff-f6bd078b1f13440fbd2ea6a822814a97134d3bf420cfeb4353d1e2151539b743L131-R137) [[9]](diffhunk://#diff-4d6801140ba02519798f11154ff7b1e964d716c95eb2d9592fe9ab92577e47a9L10-R10) [[10]](diffhunk://#diff-cdba4e23dd0bb84917b64a3a52588b74c7b9d0fca2c61272c334969f99924471L9-R9) [[11]](diffhunk://#diff-cdba4e23dd0bb84917b64a3a52588b74c7b9d0fca2c61272c334969f99924471L54-R54) [[12]](diffhunk://#diff-0bc19011e3f6e2bbfe1dc7532ba73b66575f122a798e9a13ab0c88a9fa00e95dL5-R5) [[13]](diffhunk://#diff-0bc19011e3f6e2bbfe1dc7532ba73b66575f122a798e9a13ab0c88a9fa00e95dL50-R50) [[14]](diffhunk://#diff-7e995088aaa0b416abfdd01717f46fd6b8bc68a47878b013891d9b5ed98c9d9cL3-R3) [[15]](diffhunk://#diff-7e995088aaa0b416abfdd01717f46fd6b8bc68a47878b013891d9b5ed98c9d9cL27-R27)

**Release workflow logic and publishing:**

* Modified the `.github/workflows/zxf-publish-release.yaml` workflow to update job steps, publishing logic, and summary outputs for the new package names, including switching publishing order and registry tokens for `hiero-sdk`/`hiero-sdk-proto` and `hedera`/`hedera-proto` depending on the dual publishing flag. [[1]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL101-L109) [[2]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL120-R118) [[3]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eR130-R147) [[4]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL357-R371) [[5]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL393-R420) [[6]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL429-R439) [[7]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL460-R470) [[8]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL480-R485)

**Automated code and dependency updates:**

* Updated scripts and commands in the workflow to rename packages in `Cargo.toml` files and adjust dependencies and imports in Rust source files to match new package names, including search-and-replace logic for both proto and SDK packages. [[1]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL393-R420) [[2]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL460-R470)

**Summary reporting and conditional publishing:**

* Adjusted the package version summary and conditional publishing checks in the workflow to correctly reflect the new package names and publishing requirements for both proto and SDK packages.

**Environment and registry token management:**

* Updated environment variable usage and registry token selection for publishing jobs to ensure the correct tokens are used for each package and publishing scenario. [[1]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL357-R371) [[2]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL429-R439) [[3]](diffhunk://#diff-67e420187ece21cf081d3ce81b80ad5ab90c5fd55425da4c23f15bf76789b59eL480-R485)

## Related Issue(s)

Resolves #1128 