### PR TITLE
feat: Added ability to change max nodes per request

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -400,7 +400,7 @@ impl Client {
     }
 
     /// Sets the max number of nodes to attempt for a request/transaction before failing.
-    /// 
+    ///
     /// If set to `None`, then the client will attempt to use all healthy nodes.
     pub fn set_max_nodes_per_request(&self, max_nodes: Option<u32>) {
         self.net().0.load().set_max_nodes_per_request(max_nodes)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -394,6 +394,18 @@ impl Client {
         self.net().0.load().set_min_backoff(min_node_backoff)
     }
 
+    /// Returns the max number of nodes to attempt for a request/transaction before failing.
+    pub fn max_nodes_per_request(&self) -> Option<u32> {
+        self.net().0.load().max_nodes_per_request()
+    }
+
+    /// Sets the max number of nodes to attempt for a request/transaction before failing.
+    /// 
+    /// If set to `None`, then the client will attempt to use all healthy nodes.
+    pub fn set_max_nodes_per_request(&self, max_nodes: Option<u32>) {
+        self.net().0.load().set_max_nodes_per_request(max_nodes)
+    }
+
     /// Construct a hedera client pre-configured for access to the given network.
     ///
     /// Currently supported network names are `"mainnet"`, `"testnet"`, and `"previewnet"`.

--- a/src/client/network/mod.rs
+++ b/src/client/network/mod.rs
@@ -160,6 +160,7 @@ pub(crate) struct NetworkData {
     // Health stuff has to be in an Arc because it needs to stick around even if the map changes.
     health: Box<[Arc<parking_lot::RwLock<NodeHealth>>]>,
     connections: Box<[NodeConnection]>,
+    max_nodes_per_request: RwLock<Option<u32>>,
 }
 
 impl NetworkData {
@@ -188,6 +189,7 @@ impl NetworkData {
             health: health.into_boxed_slice(),
             connections: connections.into_boxed_slice(),
             backoff: NodeBackoff::default().into(),
+            max_nodes_per_request: None.into(),
         }
     }
 
@@ -247,6 +249,7 @@ impl NetworkData {
             health: health.into_boxed_slice(),
             connections: connections.into_boxed_slice(),
             backoff: NodeBackoff::default().into(),
+            max_nodes_per_request: None.into(),
         }
     }
 
@@ -287,6 +290,7 @@ impl NetworkData {
             health: health.into_boxed_slice(),
             connections: connections.into_boxed_slice(),
             backoff: NodeBackoff::default().into(),
+            max_nodes_per_request: None.into(),
         })
     }
 
@@ -367,6 +371,15 @@ impl NetworkData {
     pub(crate) fn healthy_node_ids(&self) -> impl Iterator<Item = AccountId> + '_ {
         self.healthy_node_indexes(Instant::now()).map(|it| self.node_ids[it])
     }
+
+    pub(crate) fn set_max_nodes_per_request(&self, max_nodes: Option<u32>) {
+        *self.max_nodes_per_request.write() = max_nodes;
+    }
+
+    pub(crate) fn max_nodes_per_request(&self) -> Option<u32> {
+        *self.max_nodes_per_request.read()
+    }
+
     pub(crate) fn random_node_ids(&self) -> Vec<AccountId> {
         let mut node_ids: Vec<_> = self.healthy_node_ids().collect();
         // self.remove_dead_nodes();
@@ -377,7 +390,11 @@ impl NetworkData {
             node_ids = self.node_ids.to_vec();
         }
 
-        let node_sample_amount = node_ids.len();
+        // Use all healthy nodes unless a max is specified
+        let node_sample_amount = self.max_nodes_per_request().map_or(
+            node_ids.len(), 
+            |it| (it as usize).min(node_ids.len())
+        );
 
         let node_id_indecies =
             rand::seq::index::sample(&mut thread_rng(), node_ids.len(), node_sample_amount);

--- a/src/client/network/mod.rs
+++ b/src/client/network/mod.rs
@@ -391,10 +391,9 @@ impl NetworkData {
         }
 
         // Use all healthy nodes unless a max is specified
-        let node_sample_amount = self.max_nodes_per_request().map_or(
-            node_ids.len(), 
-            |it| (it as usize).min(node_ids.len())
-        );
+        let node_sample_amount = self
+            .max_nodes_per_request()
+            .map_or(node_ids.len(), |it| (it as usize).min(node_ids.len()));
 
         let node_id_indecies =
             rand::seq::index::sample(&mut thread_rng(), node_ids.len(), node_sample_amount);
@@ -590,7 +589,7 @@ mod tests {
         let num_healthy_nodes = network.healthy_node_ids().count();
         let num_random_nodes = network.random_node_ids().len();
         assert!(num_random_nodes == num_healthy_nodes, "Default should get all healthy nodes");
-        
+
         // Check getter and setters
         network.set_max_nodes_per_request(Some(2));
         assert_eq!(network.max_nodes_per_request(), Some(2));

--- a/src/client/network/mod.rs
+++ b/src/client/network/mod.rs
@@ -583,6 +583,25 @@ mod tests {
     };
 
     #[test]
+    fn test_network_set_max_nodes_per_request() {
+        let network = NetworkData::from_static(TESTNET);
+
+        // Check default
+        let num_healthy_nodes = network.healthy_node_ids().count();
+        let num_random_nodes = network.random_node_ids().len();
+        assert!(num_random_nodes == num_healthy_nodes, "Default should get all healthy nodes");
+        
+        // Check getter and setters
+        network.set_max_nodes_per_request(Some(2));
+        assert_eq!(network.max_nodes_per_request(), Some(2));
+
+        // Check that setter works properly
+        let num_random_nodes = network.random_node_ids().len();
+        println!("Number of random nodes: {}", num_random_nodes);
+        assert!(num_random_nodes == 2, "Should only get 2 random nodes");
+    }
+
+    #[test]
     fn test_network_with_string_endpoints() {
         let node_address = NodeAddress {
             node_id: 1,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

Adds support to change the max number of nodes attempted per each request/transaction before failure. This is feature already supported by the java sdk.

**Related issue(s)**:

#845
#1222

Fixes #

#1222

Fixes it since people can set the max nodes to 1 for 1 random node.

**Notes for reviewer**:
See provided test for working behavior.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
