### PR TITLE
fix: replace unwrap() with pb_getf! for creation_time in TokenNftInfo

### DIFF
--- a/src/token/token_nft_info.rs
+++ b/src/token/token_nft_info.rs
@@ -168,11 +168,17 @@ mod tests {
     #[test]
     fn from_protobuf_missing_creation_time() {
         use hiero_sdk_proto::services;
+
         use crate::FromProtobuf;
 
         let pb = services::TokenNftInfo {
             nft_id: Some(services::NftId {
-                token_id: Some(services::TokenId { shard_num: 1, realm_num: 2, token_num: 3, ..Default::default() }),
+                token_id: Some(services::TokenId {
+                    shard_num: 1,
+                    realm_num: 2,
+                    token_num: 3,
+                    ..Default::default()
+                }),
                 serial_number: 4,
             }),
             account_id: Some(services::AccountId {
@@ -190,5 +196,4 @@ mod tests {
         let result = TokenNftInfo::from_protobuf(pb);
         assert!(result.is_err());
     }
-
 }

--- a/src/token/token_nft_info.rs
+++ b/src/token/token_nft_info.rs
@@ -78,7 +78,7 @@ impl FromProtobuf<services::TokenNftInfo> for TokenNftInfo {
     {
         let nft_id = pb_getf!(pb, nft_id)?;
         let account_id = pb_getf!(pb, account_id)?;
-        let creation_time = pb.creation_time.unwrap();
+        let creation_time = pb_getf!(pb, creation_time)?;
         let metadata = pb.metadata;
         let spender_account_id = Option::from_protobuf(pb.spender_id)?;
 
@@ -164,4 +164,31 @@ mod tests {
         "#]]
         .assert_debug_eq(&TokenNftInfo::from_bytes(&info.to_bytes()));
     }
+
+    #[test]
+    fn from_protobuf_missing_creation_time() {
+        use hiero_sdk_proto::services;
+        use crate::FromProtobuf;
+
+        let pb = services::TokenNftInfo {
+            nft_id: Some(services::NftId {
+                token_id: Some(services::TokenId { shard_num: 1, realm_num: 2, token_num: 3, ..Default::default() }),
+                serial_number: 4,
+            }),
+            account_id: Some(services::AccountId {
+                shard_num: 5,
+                realm_num: 6,
+                account: Some(services::account_id::Account::AccountNum(7)),
+                ..Default::default()
+            }),
+            creation_time: None, // intentionally missing
+            metadata: vec![],
+            ledger_id: vec![],
+            spender_id: None,
+        };
+
+        let result = TokenNftInfo::from_protobuf(pb);
+        assert!(result.is_err());
+    }
+
 }


### PR DESCRIPTION
**Description**:
Fix runtime panic in `TokenNftInfo::from_protobuf` when `creation_time` is missing from protobuf payload. Replace `unwrap()` with `pb_getf!` macro to return `Error::FromProtobuf` instead of panicking.

* Replace `pb.creation_time.unwrap()` with `pb_getf!(pb, creation_time)?` in `token_nft_info.rs`
* Add unit test to verify missing `creation_time` returns an error instead of panicking

**Related issue(s)**:
Fixes #

**Notes for reviewer**:
Added a test `from_protobuf_missing_creation_time` that reproduces the panic before the fix and passes cleanly after.

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)