### PR TITLE
feat: expose get_transaction_body_bytes for external signers

### DIFF
--- a/src/address_book/registered_node_create_transaction.rs
+++ b/src/address_book/registered_node_create_transaction.rs
@@ -2,8 +2,8 @@
 
 use hiero_sdk_proto::services;
 use hiero_sdk_proto::services::address_book_service_client::AddressBookServiceClient;
-use tonic::transport::Channel;
 
+use crate::channel::Channel;
 use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
 use crate::registered_service_endpoint::RegisteredServiceEndpoint;

--- a/src/address_book/registered_node_delete_transaction.rs
+++ b/src/address_book/registered_node_delete_transaction.rs
@@ -2,8 +2,8 @@
 
 use hiero_sdk_proto::services;
 use hiero_sdk_proto::services::address_book_service_client::AddressBookServiceClient;
-use tonic::transport::Channel;
 
+use crate::channel::Channel;
 use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
 use crate::transaction::{

--- a/src/address_book/registered_node_update_transaction.rs
+++ b/src/address_book/registered_node_update_transaction.rs
@@ -2,8 +2,8 @@
 
 use hiero_sdk_proto::services;
 use hiero_sdk_proto::services::address_book_service_client::AddressBookServiceClient;
-use tonic::transport::Channel;
 
+use crate::channel::Channel;
 use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
 use crate::registered_service_endpoint::RegisteredServiceEndpoint;

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -765,6 +765,23 @@ impl<D: TransactionExecute> Transaction<D> {
 
         self
     }
+    /// Returns the bytes of the transaction body for use with external signers.
+    ///
+    /// This is useful when signing with an async or remote signer (e.g. a vault or HSM)
+    /// that cannot be used with the synchronous [`Self::sign_with`] closure.
+    /// The returned bytes can be signed externally and passed to [`Self::add_signature`].
+    ///
+    /// # Errors
+    /// Returns an error if the transaction has not been frozen or has no transactions.
+    pub fn get_transaction_body_bytes(&self) -> crate::Result<Vec<u8>> {
+        let sources = self.make_sources()?;
+        Ok(sources
+            .signed_transactions()
+            .first()
+            .ok_or_else(|| crate::Error::basic_parse("no transactions"))?
+            .body_bytes
+            .clone())
+    }
 
     /// # Panics
     /// panics if the transaction is not schedulable, a transaction can be non-schedulable due to:

--- a/src/transaction/tests.rs
+++ b/src/transaction/tests.rs
@@ -338,3 +338,36 @@ fn test_offline_transaction_signing_with_chunks() -> crate::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn get_transaction_body_bytes_returns_non_empty_bytes() -> crate::Result<()> {
+    let mut tx = TransferTransaction::new();
+    tx.node_account_ids(TEST_NODE_ACCOUNT_IDS)
+        .transaction_id(TEST_TX_ID)
+        .max_transaction_fee(Hbar::new(2))
+        .freeze()?;
+
+    let bytes = tx.get_transaction_body_bytes()?;
+    assert!(!bytes.is_empty());
+
+    Ok(())
+}
+
+
+
+#[test]
+fn get_transaction_body_bytes_are_signable() -> crate::Result<()> {
+    let mut tx = TransferTransaction::new();
+    tx.node_account_ids(TEST_NODE_ACCOUNT_IDS)
+        .transaction_id(TEST_TX_ID)
+        .max_transaction_fee(Hbar::new(2))
+        .freeze()?;
+
+    let bytes = tx.get_transaction_body_bytes()?;
+    let key = unused_private_key();
+    let sig = key.sign(&bytes);
+
+    assert_eq!(sig.len(), 64);
+
+    Ok(())
+}

--- a/src/transaction/tests.rs
+++ b/src/transaction/tests.rs
@@ -353,8 +353,6 @@ fn get_transaction_body_bytes_returns_non_empty_bytes() -> crate::Result<()> {
     Ok(())
 }
 
-
-
 #[test]
 fn get_transaction_body_bytes_are_signable() -> crate::Result<()> {
     let mut tx = TransferTransaction::new();


### PR DESCRIPTION
**Description**:
Add `get_transaction_body_bytes()` to enable external and async signers

* Add `Transaction::get_transaction_body_bytes()` public method to `src/transaction/mod.rs` that exposes the protobuf-encoded transaction body bytes
* Fix incorrect `tonic::transport::Channel` import in `registered_node_create_transaction.rs`, `registered_node_delete_transaction.rs`, `registered_node_update_transaction.rs` — should be `crate::channel::Channel` (pre-existing compile errors on `main`)

**Related issue(s)**:

N/A

**Notes for reviewer**:

`get_transaction_body_bytes()` is needed by external signers (e.g. vault, HSM, AWS KMS) that cannot use the synchronous `sign_with` closure. The existing `add_signature` API was unusable for this purpose because `body_bytes` on the inner `SignedTransaction` was private. This is the minimal non-breaking fix — the `Signer` trait stays sync, async happens outside the SDK.

The 3 registered node file fixes are, confirmed pre-existing on `main` before this branch via `git stash && cargo check`.

**Checklist**

- [x] Documented (code doc comment on the new method explaining usage and errors)
- [x] Tested (`cargo test --workspace` — 1393 passed, 0 failed; `cargo +nightly fmt --check` — clean)