### PR TITLE
fix: use crate Channel type alias in RegisteredNode transactions

### DIFF
--- a/src/address_book/registered_node_create_transaction.rs
+++ b/src/address_book/registered_node_create_transaction.rs
@@ -2,7 +2,6 @@
 
 use hiero_sdk_proto::services;
 use hiero_sdk_proto::services::address_book_service_client::AddressBookServiceClient;
-use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
@@ -17,6 +16,7 @@ use crate::transaction::{
 };
 use crate::{
     BoxGrpcFuture,
+    Channel,
     Error,
     Key,
     ToProtobuf,

--- a/src/address_book/registered_node_delete_transaction.rs
+++ b/src/address_book/registered_node_delete_transaction.rs
@@ -2,7 +2,6 @@
 
 use hiero_sdk_proto::services;
 use hiero_sdk_proto::services::address_book_service_client::AddressBookServiceClient;
-use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
@@ -16,6 +15,7 @@ use crate::transaction::{
 };
 use crate::{
     BoxGrpcFuture,
+    Channel,
     Error,
     ToProtobuf,
     Transaction,

--- a/src/address_book/registered_node_update_transaction.rs
+++ b/src/address_book/registered_node_update_transaction.rs
@@ -2,7 +2,6 @@
 
 use hiero_sdk_proto::services;
 use hiero_sdk_proto::services::address_book_service_client::AddressBookServiceClient;
-use tonic::transport::Channel;
 
 use crate::ledger_id::RefLedgerId;
 use crate::protobuf::FromProtobuf;
@@ -17,6 +16,7 @@ use crate::transaction::{
 };
 use crate::{
     BoxGrpcFuture,
+    Channel,
     Error,
     Key,
     ToProtobuf,


### PR DESCRIPTION
**Description**:
Fix compilation errors in `RegisteredNode` transactions introduced by #1295, where
`tonic::transport::Channel` was used directly instead of the crate's `Channel` type
alias (`InterceptedService<tonic::transport::Channel, SdkInterceptor>`), causing a
trait signature mismatch with `TransactionExecute`.

* Fix `registered_node_create_transaction.rs` to use crate `Channel` type alias
* Fix `registered_node_delete_transaction.rs` to use crate `Channel` type alias
* Fix `registered_node_update_transaction.rs` to use crate `Channel` type alias

**Related issue(s)**:
Fixes #1295 (broken `main` since May 19 — also unblocks #1307 and #1309)

**Notes for reviewer**:
`main` has been failing to compile since #1295 was merged. This is a minimal fix —
only the import is changed, no logic touched.

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)