### PR TITLE
ci: scope workflow token permissions to the jobs that need them

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -23,12 +23,14 @@ defaults:
     shell: bash
 
 permissions:
-  statuses: write
+  contents: read
 
 jobs:
   title-check:
     name: Title Check
     runs-on: hiero-client-sdk-linux-medium
+    permissions:
+      statuses: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2

--- a/.github/workflows/zxf-publish-release.yaml
+++ b/.github/workflows/zxf-publish-release.yaml
@@ -20,7 +20,7 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CONSENSUS_NODE_VERSION: "v0.73.0"
@@ -273,6 +273,8 @@ jobs:
       - validate-release
       - run-safety-checks
     runs-on: hiero-client-sdk-linux-medium
+    permissions:
+      contents: write
     env:
       DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled || 'false' }}
     steps:


### PR DESCRIPTION
**Description**:

Harden the GitHub Actions token permissions so that every workflow declares a read-only top-level `permissions` block and write scopes are granted only to the individual jobs that use them. This is the remaining item that keeps the repository's OpenSSF Scorecard `Token-Permissions` check at 0 (any top-level `contents: write` zeroes the check for the whole repo, and top-level `statuses: write` is penalised as well).

The effective permissions of the jobs that perform a write are unchanged; the remaining jobs in those workflows now run with a read-only token.

**Changes**

Token-Permissions

* `flow-pull-request-formatting.yaml`: replace the top-level `statuses: write` with `contents: read` and move `statuses: write` onto the `title-check` job (the only job that reports a commit status). The `assignee-check` job only reads the event payload and needs no API access.
* `zxf-publish-release.yaml`: replace the top-level `contents: write` with `contents: read` and move `contents: write` onto the `publish` job (the only job that creates a GitHub release). `validate-release` and `run-safety-checks` only check out code and run `cargo`, so read access is sufficient for them.

| Check | Before | After (local `scorecard --local`) |
| --- | --- | --- |
| Token-Permissions | 0 | 10 |
| Dangerous-Workflow | 10 | 10 |
| Pinned-Dependencies | 7 | 7 |
| Binary-Artifacts | 10 | 10 |

**Intentionally not changed**

* The `curl … https://sh.rustup.rs | sh` steps in `flow-rust-ci.yaml` and `zxf-publish-release.yaml` are what Scorecard reports under Pinned-Dependencies (`downloadThenRun`). There is no checksum-verified form of the rustup installer, and the jobs that also use `dtolnay/rust-toolchain` would need a behaviour change to drop those steps, so they are left as-is for a separate discussion.
* No CodeQL workflow is added: this repository already runs CodeQL through GitHub's default setup (`dynamic/github-code-scanning/codeql` on every push and PR), and an advanced-setup workflow cannot upload results while default setup is enabled.
* `.github/dependabot.yml` already covers `github-actions` and `cargo`, so it is unchanged.

**Related issue(s)**:

N/A

**Notes for reviewer**:

Verification performed locally:

* `actionlint` on both modified workflows reports only the findings that already exist on `main` (unknown self-hosted runner label, shellcheck style notes, and the existing `needs.validate-release.outputs.prerelease` reference); nothing new is introduced.
* `scorecard --local . --checks Token-Permissions,Pinned-Dependencies,Binary-Artifacts,Dangerous-Workflow` before and after, results in the table above.
* Because `flow-pull-request-formatting.yaml` runs on `pull_request_target`, the version on `main` (not this branch) is what runs against this PR; the job-level `statuses: write` will take effect once merged. The `zxf-publish-release.yaml` change can be exercised with a `workflow_dispatch` dry run after merge.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
